### PR TITLE
Change dnf ostree default value

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -798,7 +798,7 @@ impl Config {
             .linux
             .as_ref()
             .and_then(|linux| linux.rpm_ostree)
-            .unwrap_or(true)
+            .unwrap_or(false)
     }
 
     /// Should we ignore failures for this step


### PR DESCRIPTION
Default value for using ostree on dnf systems was true, which produced errors when run on non ostree systems. Because most users run non-ostree system this setting got changed to false.