### PR TITLE
Fixes deb-get upgrade process

### DIFF
--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -329,6 +329,7 @@ pub fn run_deb_get(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("deb-get");
 
+    ctx.execute_elevated(&deb_get, false)?.arg("update").check_run()?;
     ctx.execute_elevated(&deb_get, false)?.arg("upgrade").check_run()?;
 
     if ctx.config().cleanup() {


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed
