### PR TITLE
Fix broken fisher update command

### DIFF
--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -88,7 +88,7 @@ pub fn run_fisher(base_dirs: &BaseDirs, run_type: RunType) -> Result<()> {
 
     print_separator("Fisher");
 
-    run_type.execute(&fish).args(&["-c", "fisher update"]).check_run()
+    run_type.execute(&fish).args(&["-c", "fisher"]).check_run()
 }
 
 pub fn run_bashit(ctx: &ExecutionContext) -> Result<()> {


### PR DESCRIPTION
It's just `fisher` (no `update`)
```
fisher: unknown flag or command "update"
usage: fisher add <package...>     Add packages
       fisher rm  <package...>     Remove packages
       fisher                      Update all packages
       fisher ls  [<regex>]        List installed packages matching <regex>
       fisher --help               Show this help
       fisher --version            Show the current version
       fisher self-update          Update to the latest version
       fisher self-uninstall       Uninstall from your system
```

## Standards checklist:

- [x] The PR title is descriptive.
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed
