### PR TITLE
Revert fix for older fisher version

### DIFF
--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -88,7 +88,7 @@ pub fn run_fisher(base_dirs: &BaseDirs, run_type: RunType) -> Result<()> {
 
     print_separator("Fisher");
 
-    run_type.execute(&fish).args(&["-c", "fisher"]).check_run()
+    run_type.execute(&fish).args(&["-c", "fisher update"]).check_run()
 }
 
 pub fn run_bashit(ctx: &ExecutionContext) -> Result<()> {


### PR DESCRIPTION
Reverts topgrade-rs/topgrade#33

Terribly sorry. I just had an old fisher version myself (v3.2.10) :face_with_spiral_eyes: 