### PR TITLE
Fixes some references to the original topgrade repo

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,11 +12,11 @@
             "cargo": {
                 "args": [
                     "build",
-                    "--bin=topgrade",
-                    "--package=topgrade"
+                    "--bin=topgrade-rs",
+                    "--package=topgrade-rs"
                 ],
                 "filter": {
-                    "name": "topgrade",
+                    "name": "topgrade-rs",
                     "kind": "bin"
                 }
             },

--- a/src/self_update.rs
+++ b/src/self_update.rs
@@ -15,7 +15,7 @@ pub fn self_update() -> Result<()> {
 
     let target = self_update_crate::get_target();
     let result = Update::configure()
-        .repo_owner("r-darwish")
+        .repo_owner("topgrade-rs")
         .repo_name("topgrade")
         .target(target)
         .bin_name(if cfg!(windows) { "topgrade.exe" } else { "topgrade" })

--- a/src/self_update.rs
+++ b/src/self_update.rs
@@ -18,7 +18,7 @@ pub fn self_update() -> Result<()> {
         .repo_owner("topgrade-rs")
         .repo_name("topgrade")
         .target(target)
-        .bin_name(if cfg!(windows) { "topgrade.exe" } else { "topgrade" })
+        .bin_name(if cfg!(windows) { "topgrade-rs.exe" } else { "topgrade-rs" })
         .show_output(false)
         .show_download_progress(true)
         .current_version(self_update_crate::cargo_crate_version!())


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`) <-- there are no tests defined
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
