### PR TITLE
Changed binary name to be backwards compatible, version bump to 10.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,10 @@ edition = "2018"
 
 readme = "README.md"
 
+[[bin]]
+name = "topgrade"
+path = "src/main.rs"
+
 [dependencies]
 directories = "4.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/build-all.sh
+++ b/build-all.sh
@@ -13,12 +13,12 @@ build_function() {
 }
 
 package_function() {
-    tar -czvf build/topgrade-${ans}-x86_64-linux-gnu.tar.gz target/x86_64-unknown-linux-gnu/release/topgrade-rs
-    tar -czvf build/topgrade-${ans}-x86_64-linux-musl.tar.gz target/x86_64-unknown-linux-musl/release/topgrade-rs
-    tar -czvf build/topgrade-${ans}-x86_64-freebsd.tar.gz target/x86_64-unknown-freebsd/release/topgrade-rs
-    tar -czvf build/topgrade-${ans}-aarch64-linux-gnu.tar.gz target/aarch64-unknown-linux-gnu/release/topgrade-rs
-    tar -czvf build/topgrade-${ans}-aarch64-linux-musl.tar.gz target/aarch64-unknown-linux-musl/release/topgrade-rs
-    tar -czvf build/topgrade-${ans}-x86_64-windows.tar.gz target/x86_64-pc-windows-gnu/release/topgrade-rs.exe
+    tar -czvf build/topgrade-${ans}-x86_64-linux-gnu.tar.gz target/x86_64-unknown-linux-gnu/release/topgrade
+    tar -czvf build/topgrade-${ans}-x86_64-linux-musl.tar.gz target/x86_64-unknown-linux-musl/release/topgrade
+    tar -czvf build/topgrade-${ans}-x86_64-freebsd.tar.gz target/x86_64-unknown-freebsd/release/topgrade
+    tar -czvf build/topgrade-${ans}-aarch64-linux-gnu.tar.gz target/aarch64-unknown-linux-gnu/release/topgrade
+    tar -czvf build/topgrade-${ans}-aarch64-linux-musl.tar.gz target/aarch64-unknown-linux-musl/release/topgrade
+    tar -czvf build/topgrade-${ans}-x86_64-windows.tar.gz target/x86_64-pc-windows-gnu/release/topgrade.exe
 
 }
 


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
