### PR TITLE
Backwards compatibility with fisher v3

### DIFF
--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -88,7 +88,19 @@ pub fn run_fisher(base_dirs: &BaseDirs, run_type: RunType) -> Result<()> {
 
     print_separator("Fisher");
 
-    run_type.execute(&fish).args(&["-c", "fisher update"]).check_run()
+    let version_str = run_type
+        .execute(&fish)
+        .args(&["-c", "fisher --version"])
+        .check_output()?;
+    debug!("Fisher version: {}", version_str);
+
+    if version_str.starts_with("fisher version 3.") {
+        // v3 - see https://github.com/topgrade-rs/topgrade/pull/37#issuecomment-1283844506
+        run_type.execute(&fish).args(&["-c", "fisher"]).check_run()
+    } else {
+        // v4
+        run_type.execute(&fish).args(&["-c", "fisher update"]).check_run()
+    }
 }
 
 pub fn run_bashit(ctx: &ExecutionContext) -> Result<()> {


### PR DESCRIPTION
Follow-up of https://github.com/topgrade-rs/topgrade/pull/37#issuecomment-1283844506

Tested for both v3 and v4 :)

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [ ] The code passes clippy (`cargo clippy`) - _a lot of warnings, but not from me I think_
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed
