### PR TITLE
Add(CI): For automatically publishing on new versions

### DIFF
--- a/.github/workflows/crates-publish.yml
+++ b/.github/workflows/crates-publish.yml
@@ -1,3 +1,7 @@
+on:
+  push:
+    branches:
+      - main
 steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1

--- a/.github/workflows/crates-publish.yml
+++ b/.github/workflows/crates-publish.yml
@@ -1,21 +1,34 @@
 on:
-  push:
-    branches:
-      - main
+  release:
+    types: [published, edited]
 
 name: Publish on release
 
 jobs:
+  prepare:
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly-2022-08-03
+          override: true
+
+  semver:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --git https://github.com/rust-lang/rust-semverver
+      - run: eval "current_version=$(grep -e '^version = .*$' Cargo.toml | cut -d ' ' -f 3)"
+      - run: cargo semver | tee semver_out
+      - run: (head -n 1 semver_out | grep "\-> $current_version") || (echo "versioning mismatch" && return 1)
+
   publish:
     steps:
-        - uses: actions/checkout@v2
-        - uses: actions-rs/toolchain@v1
-          with:
-              toolchain: stable
-              override: true
-        - uses: katyo/publish-crates@v1
-          with:
-              dry-run: true
-              check-repo: ${{ github.event_name == 'push' }}
-              registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-              ignore-unpublished-changes: true
+      - uses: katyo/publish-crates@v1
+        with:
+          dry-run: true
+          check-repo: ${{ github.event_name == 'push' }}
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          ignore-unpublished-changes: true

--- a/.github/workflows/crates-publish.yml
+++ b/.github/workflows/crates-publish.yml
@@ -2,7 +2,7 @@ on:
   release:
     types: [published, edited]
 
-name: Publish on release
+name: Check SemVer compliance and publish on release
 
 jobs:
   prepare:

--- a/.github/workflows/crates-publish.yml
+++ b/.github/workflows/crates-publish.yml
@@ -1,0 +1,12 @@
+steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+          toolchain: stable
+          override: true
+    - uses: katyo/publish-crates@v1
+      with:
+          dry-run: true
+          check-repo: ${{ github.event_name == 'push' }}
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          ignore-unpublished-changes: true

--- a/.github/workflows/crates-publish.yml
+++ b/.github/workflows/crates-publish.yml
@@ -2,15 +2,20 @@ on:
   push:
     branches:
       - main
-steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-          toolchain: stable
-          override: true
-    - uses: katyo/publish-crates@v1
-      with:
-          dry-run: true
-          check-repo: ${{ github.event_name == 'push' }}
-          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-          ignore-unpublished-changes: true
+
+name: Publish on release
+
+jobs:
+  publish:
+    steps:
+        - uses: actions/checkout@v2
+        - uses: actions-rs/toolchain@v1
+          with:
+              toolchain: stable
+              override: true
+        - uses: katyo/publish-crates@v1
+          with:
+              dry-run: true
+              check-repo: ${{ github.event_name == 'push' }}
+              registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+              ignore-unpublished-changes: true


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

# Reason

In `Cargo.toml` the version is 10.0.0 but the version on `crates.io` is only 9. There is no reason
to manage publishes ourselves. No more need to think when a publish is necessary.
