### PR TITLE
Don't panic on git repository with no remote

### DIFF
--- a/src/steps/git.rs
+++ b/src/steps/git.rs
@@ -231,8 +231,7 @@ impl Git {
         let results = basic_rt.block_on(async { stream_of_futures.collect::<Vec<Result<()>>>().await });
 
         let error = results.into_iter().find(|r| r.is_err());
-        error.unwrap()?;
-        Ok(())
+        error.unwrap_or(Ok(()))
     }
 }
 


### PR DESCRIPTION
Current code panics when update of git repositories is run on repository with no remotes. This is a regression I noticed after recent update form crates.io.
Looking around I found that the issue was introduced in #60, simply reverting the offending line fixed the issue for me. I don't get any clippy warnings for this line after changing it back (maybe there was a false positive?).

## Standards checklist:

- [X] The PR title is descriptive.
- [X] The code compiles (`cargo build`)
- [X] The code passes rustfmt (`cargo fmt`)
- [X] The code passes clippy (`cargo clippy`)
- [X] The code passes tests (`cargo test`)
- [X] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
