### PR TITLE
Fix neovim upgrade

### DIFF
--- a/src/steps/upgrade.vim
+++ b/src/steps/upgrade.vim
@@ -18,11 +18,6 @@ if exists(":PlugUpgrade")
     endif
 endif
 
-if exists(":PackerUpdate")
-    echo "Packer"
-    PackerSync
-endif
-
 if exists("*dein#update()")
     echo "dein#update()"
     call dein#update()
@@ -43,4 +38,10 @@ if exists(":CocUpdateSync")
     CocUpdateSync
 endif
 
-quitall
+if exists(':PackerSync')
+  echo "Packer"
+  autocmd User PackerComplete quitall
+  PackerSync
+else
+  quitall
+endif

--- a/src/steps/vim.rs
+++ b/src/steps/vim.rs
@@ -1,7 +1,7 @@
 use crate::error::{SkipStep, TopgradeError};
 use anyhow::Result;
 
-use crate::executor::{CommandExt, ExecutorOutput, RunType};
+use crate::executor::{CommandExt, Executor, ExecutorOutput, RunType};
 use crate::terminal::print_separator;
 use crate::{
     execution_context::ExecutionContext,
@@ -9,7 +9,7 @@ use crate::{
 };
 use directories::BaseDirs;
 use log::debug;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::{
     io::{self, Write},
     process::Command,
@@ -40,19 +40,14 @@ fn nvimrc(base_dirs: &BaseDirs) -> Result<PathBuf> {
         .or_else(|_| base_dir.join("nvim/init.lua").require())
 }
 
-fn upgrade(vim: &Path, vimrc: &Path, ctx: &ExecutionContext) -> Result<()> {
+fn upgrade_script() -> Result<tempfile::NamedTempFile> {
     let mut tempfile = tempfile::NamedTempFile::new()?;
     tempfile.write_all(UPGRADE_VIM.replace('\r', "").as_bytes())?;
     debug!("Wrote vim script to {:?}", tempfile.path());
+    Ok(tempfile)
+}
 
-    let mut command = ctx.run_type().execute(vim);
-
-    command
-        .args(["-u"])
-        .arg(vimrc)
-        .args(["-U", "NONE", "-V1", "-nNesS"])
-        .arg(tempfile.path());
-
+fn upgrade(command: &mut Executor, ctx: &ExecutionContext) -> Result<()> {
     if ctx.config().force_vim_plug_update() {
         command.env("TOPGRADE_FORCE_PLUGUPDATE", "true");
     }
@@ -114,13 +109,21 @@ pub fn upgrade_vim(base_dirs: &BaseDirs, ctx: &ExecutionContext) -> Result<()> {
 
     let output = Command::new(&vim).arg("--version").check_output()?;
     if !output.starts_with("VIM") {
-        return Err(SkipStep(String::from("vim binary might by actually nvim")).into());
+        return Err(SkipStep(String::from("vim binary might be actually nvim")).into());
     }
 
     let vimrc = vimrc(base_dirs)?;
 
     print_separator("Vim");
-    upgrade(&vim, &vimrc, ctx)
+    upgrade(
+        ctx.run_type()
+            .execute(&vim)
+            .args(&["-u"])
+            .arg(vimrc)
+            .args(&["-U", "NONE", "-V1", "-nNesS"])
+            .arg(upgrade_script()?.path()),
+        ctx,
+    )
 }
 
 pub fn upgrade_neovim(base_dirs: &BaseDirs, ctx: &ExecutionContext) -> Result<()> {
@@ -128,7 +131,15 @@ pub fn upgrade_neovim(base_dirs: &BaseDirs, ctx: &ExecutionContext) -> Result<()
     let nvimrc = nvimrc(base_dirs)?;
 
     print_separator("Neovim");
-    upgrade(&nvim, &nvimrc, ctx)
+    upgrade(
+        ctx.run_type()
+            .execute(&nvim)
+            .args(&["-u"])
+            .arg(nvimrc)
+            .args(&["--headless", "-V1", "-nS"])
+            .arg(upgrade_script()?.path()),
+        ctx,
+    )
 }
 
 pub fn run_voom(_base_dirs: &BaseDirs, run_type: RunType) -> Result<()> {


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

Fix neovim upgrade (command line arguments are different from the vim's one) and fix the upgrade script when using Packer.

https://asciinema.org/a/vxfsGPHxp0BteRssN4OrpuvvR
