### PR TITLE
Bump clap version to 4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,26 +224,24 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.22"
+version = "4.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
+checksum = "335867764ed2de42325fafe6d18b8af74ba97ee0c590fa016f157535b42ab04b"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
- "indexmap",
  "once_cell",
  "strsim",
  "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.18"
+version = "4.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+checksum = "16a1b0f6422af32d5da0c58e2703320f379216ee70198241c84173a8c5ac28f3"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -254,9 +252,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -1784,12 +1782,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1.0", features = ["derive"] }
 toml = "0.5"
 which_crate = { version = "4.1", package = "which" }
 shellexpand = "2.1"
-clap = { version = "3.1", features = ["cargo", "derive"] }
+clap = { version = "4.0", features = ["cargo", "derive"] }
 log = "0.4"
 walkdir = "2.3"
 console = "0.15"

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 use std::{env, fs};
 
 use anyhow::Result;
-use clap::{ArgEnum, Parser};
+use clap::{Parser, ValueEnum};
 use directories::BaseDirs;
 use log::debug;
 use regex::Regex;
@@ -62,7 +62,7 @@ macro_rules! get_deprecated {
 
 type Commands = BTreeMap<String, String>;
 
-#[derive(ArgEnum, EnumString, EnumVariantNames, Debug, Clone, PartialEq, Eq, Deserialize, EnumIter, Copy)]
+#[derive(ValueEnum, EnumString, EnumVariantNames, Debug, Clone, PartialEq, Eq, Deserialize, EnumIter, Copy)]
 #[clap(rename_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
@@ -386,78 +386,78 @@ impl ConfigFile {
 
 // Command line arguments
 #[derive(Parser, Debug)]
-#[clap(name = "Topgrade", version)]
+#[command(name = "Topgrade", version)]
 pub struct CommandLineArgs {
     /// Edit the configuration file
-    #[clap(long = "edit-config")]
+    #[arg(long = "edit-config")]
     edit_config: bool,
 
     /// Show config reference
-    #[clap(long = "config-reference")]
+    #[arg(long = "config-reference")]
     show_config_reference: bool,
 
     /// Run inside tmux
-    #[clap(short = 't', long = "tmux")]
+    #[arg(short = 't', long = "tmux")]
     run_in_tmux: bool,
 
     /// Cleanup temporary or old files
-    #[clap(short = 'c', long = "cleanup")]
+    #[arg(short = 'c', long = "cleanup")]
     cleanup: bool,
 
     /// Print what would be done
-    #[clap(short = 'n', long = "dry-run")]
+    #[arg(short = 'n', long = "dry-run")]
     dry_run: bool,
 
     /// Do not ask to retry failed steps
-    #[clap(long = "no-retry")]
+    #[arg(long = "no-retry")]
     no_retry: bool,
 
     /// Do not perform upgrades for the given steps
-    #[clap(long = "disable", arg_enum, multiple_values = true)]
+    #[arg(long = "disable", value_name = "STEP", value_enum, num_args = 1..)]
     disable: Vec<Step>,
 
     /// Perform only the specified steps (experimental)
-    #[clap(long = "only", arg_enum, multiple_values = true)]
+    #[arg(long = "only", value_name = "STEP", value_enum, num_args = 1..)]
     only: Vec<Step>,
 
     /// Run only specific custom commands
-    #[clap(long = "custom-commands")]
+    #[arg(long = "custom-commands", value_name = "NAME", num_args = 1..)]
     custom_commands: Vec<String>,
 
     /// Set environment variables
-    #[clap(long = "env", multiple_values = true)]
+    #[arg(long = "env", value_name = "NAME=VALUE", num_args = 1..)]
     env: Vec<String>,
 
     /// Output logs
-    #[clap(short = 'v', long = "verbose")]
+    #[arg(short = 'v', long = "verbose")]
     pub verbose: bool,
 
     /// Prompt for a key before exiting
-    #[clap(short = 'k', long = "keep")]
+    #[arg(short = 'k', long = "keep")]
     keep_at_end: bool,
 
     /// Skip sending a notification at the end of a run
-    #[clap(long = "skip-notify")]
+    #[arg(long = "skip-notify")]
     skip_notify: bool,
 
     /// Say yes to package manager's prompt
-    #[clap(short = 'y', long = "yes", arg_enum, multiple_values = true, min_values = 0)]
+    #[arg(short = 'y', long = "yes", value_name = "STEP", value_enum, num_args = 0..)]
     yes: Option<Vec<Step>>,
 
     /// Don't pull the predefined git repos
-    #[clap(long = "disable-predefined-git-repos")]
+    #[arg(long = "disable-predefined-git-repos")]
     disable_predefined_git_repos: bool,
 
     /// Alternative configuration file
-    #[clap(long = "config")]
+    #[arg(long = "config", value_name = "PATH")]
     config: Option<PathBuf>,
 
     /// A regular expression for restricting remote host execution
-    #[clap(long = "remote-host-limit")]
+    #[arg(long = "remote-host-limit", value_name = "REGEX")]
     remote_host_limit: Option<Regex>,
 
     /// Show the reason for skipped steps
-    #[clap(long = "show-skipped")]
+    #[arg(long = "show-skipped")]
     show_skipped: bool,
 }
 


### PR DESCRIPTION
Clap 4 no longer depends on `textwrap` or `indexmap` - slightly better build time/size. Additionally, we had textwrap in a yanked version in Cargo.lock.

Notably, clap no longer colors help printouts in this version, only basic text decorations like underscores.

I also added some `value_name` fields to better describe the flags that have values. I also added `num_args` to the `--custom-commands` so we can accept multiple custom command names.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
