### PR TITLE
Add `ghcup` step

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -93,6 +93,7 @@ pub enum Step {
     Fossil,
     Gcloud,
     Gem,
+    Ghcup,
     GithubCliExtensions,
     GitRepos,
     Go,

--- a/src/main.rs
+++ b/src/main.rs
@@ -323,6 +323,7 @@ fn run() -> Result<()> {
     runner.execute(Step::Pipx, "pipx", || generic::run_pipx_update(run_type))?;
     runner.execute(Step::Conda, "conda", || generic::run_conda_update(&ctx))?;
     runner.execute(Step::Pip3, "pip3", || generic::run_pip3_update(run_type))?;
+    runner.execute(Step::Ghcup, "ghcup", || generic::run_ghcup_update(run_type))?;
     runner.execute(Step::Stack, "stack", || generic::run_stack_update(run_type))?;
     runner.execute(Step::Tlmgr, "tlmgr", || generic::run_tlmgr_update(&ctx))?;
     runner.execute(Step::Myrepos, "myrepos", || {

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -289,6 +289,13 @@ pub fn run_pip3_update(run_type: RunType) -> Result<()> {
 }
 
 pub fn run_stack_update(run_type: RunType) -> Result<()> {
+    if let Ok(_) = utils::require("ghcup") {
+        // `ghcup` is present and probably(?) being used to install `stack`.
+        // Don't upgrade `stack`, let `ghcup` handle it. Per `ghcup install stack`:
+        // !!! Additionally, you should upgrade stack only through ghcup and not use 'stack upgrade' !!!
+        return Ok(());
+    }
+
     let stack = utils::require("stack")?;
     print_separator("stack");
 

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -295,6 +295,13 @@ pub fn run_stack_update(run_type: RunType) -> Result<()> {
     run_type.execute(&stack).arg("upgrade").check_run()
 }
 
+pub fn run_ghcup_update(run_type: RunType) -> Result<()> {
+    let ghcup = utils::require("ghcup")?;
+    print_separator("ghcup");
+
+    run_type.execute(&ghcup).arg("upgrade").check_run()
+}
+
 pub fn run_tlmgr_update(ctx: &ExecutionContext) -> Result<()> {
     cfg_if::cfg_if! {
         if #[cfg(any(target_os = "linux", target_os = "android"))] {


### PR DESCRIPTION
This upgrades `ghcup`: https://www.haskell.org/ghcup/

Potential work: if `stack` is installed through `ghcup`, you're not supposed to run `stack upgrade`, so I could potentially patch this to ignore the `stack` step when `ghcup` is present. (And/or detect if `stack` is a `ghcup`-installed `stack`.)

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
  - Yes but it ran zero tests? Also I didn't write any
- [x] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed