### PR TITLE
Add `rcm` step

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -121,6 +121,7 @@ pub enum Step {
     Powershell,
     Protonup,
     Raco,
+    Rcm,
     Remotes,
     Restarts,
     Rtcl,

--- a/src/main.rs
+++ b/src/main.rs
@@ -231,6 +231,10 @@ fn run() -> Result<()> {
         git_repos.insert_if_repo(base_dirs.home_dir().join(".ideavimrc"));
         git_repos.insert_if_repo(base_dirs.home_dir().join(".intellimacs"));
 
+        if config.should_run(Step::Rcm) {
+            git_repos.insert_if_repo(base_dirs.home_dir().join(".dotfiles"));
+        }
+
         #[cfg(unix)]
         {
             git_repos.insert_if_repo(zsh::zshrc(&base_dirs));
@@ -301,6 +305,7 @@ fn run() -> Result<()> {
         runner.execute(Step::Sdkman, "SDKMAN!", || {
             unix::run_sdkman(&base_dirs, config.cleanup(), run_type)
         })?;
+        runner.execute(Step::Rcm, "rcm", || unix::run_rcm(&ctx))?;
     }
 
     #[cfg(not(any(

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -464,7 +464,7 @@ pub fn run_rcm(ctx: &ExecutionContext) -> Result<()> {
     let rcup = require("rcup")?;
 
     print_separator("rcm");
-    ctx.run_type().execute(&rcup).arg("-v").check_run()
+    ctx.run_type().execute(rcup).arg("-v").check_run()
 }
 
 pub fn reboot() {

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -457,6 +457,16 @@ pub fn run_bun(ctx: &ExecutionContext) -> Result<()> {
     ctx.run_type().execute(&bun).arg("upgrade").check_run()
 }
 
+/// Update dotfiles with `rcm(7)`.
+///
+/// See: <https://github.com/thoughtbot/rcm>
+pub fn run_rcm(ctx: &ExecutionContext) -> Result<()> {
+    let rcup = require("rcup")?;
+
+    print_separator("rcm");
+    ctx.run_type().execute(&rcup).arg("-v").check_run()
+}
+
 pub fn reboot() {
     print!("Rebooting...");
     Command::new("sudo").arg("reboot").spawn().unwrap().wait().unwrap();


### PR DESCRIPTION
https://github.com/thoughtbot/rcm

Tested on my machine with `cargo run -- --only rcm`.

Should I add an `#[serde(alias = "rcup")]` on the `Step` item? (The tool suite is called `rcm`, and `rcup` is the one that actually updates the dotfiles.)