### PR TITLE
OpenBSD support

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -209,6 +209,11 @@ fn run() -> Result<()> {
         freebsd::upgrade_packages(sudo.as_ref(), run_type)
     })?;
 
+    #[cfg(target_os = "openbsd")]
+    runner.execute(Step::Pkg, "OpenBSD Packages", || {
+        openbsd::upgrade_packages(sudo.as_ref(), run_type)
+    })?;
+
     #[cfg(target_os = "android")]
     runner.execute(Step::Pkg, "Termux Packages", || android::upgrade_packages(&ctx))?;
 
@@ -409,6 +414,11 @@ fn run() -> Result<()> {
     #[cfg(target_os = "freebsd")]
     runner.execute(Step::System, "FreeBSD Upgrade", || {
         freebsd::upgrade_freebsd(sudo.as_ref(), run_type)
+    })?;
+
+    #[cfg(target_os = "openbsd")]
+    runner.execute(Step::System, "OpenBSD Upgrade", || {
+        openbsd::upgrade_openbsd(sudo.as_ref(), run_type)
     })?;
 
     #[cfg(windows)]

--- a/src/steps/os/mod.rs
+++ b/src/steps/os/mod.rs
@@ -6,12 +6,12 @@ mod archlinux;
 pub mod dragonfly;
 #[cfg(target_os = "freebsd")]
 pub mod freebsd;
-#[cfg(target_os = "openbsd")]
-pub mod openbsd;
 #[cfg(target_os = "linux")]
 pub mod linux;
 #[cfg(target_os = "macos")]
 pub mod macos;
+#[cfg(target_os = "openbsd")]
+pub mod openbsd;
 #[cfg(unix)]
 pub mod unix;
 #[cfg(target_os = "windows")]

--- a/src/steps/os/mod.rs
+++ b/src/steps/os/mod.rs
@@ -6,6 +6,8 @@ mod archlinux;
 pub mod dragonfly;
 #[cfg(target_os = "freebsd")]
 pub mod freebsd;
+#[cfg(target_os = "openbsd")]
+pub mod openbsd;
 #[cfg(target_os = "linux")]
 pub mod linux;
 #[cfg(target_os = "macos")]

--- a/src/steps/os/openbsd.rs
+++ b/src/steps/os/openbsd.rs
@@ -7,18 +7,11 @@ use std::path::PathBuf;
 pub fn upgrade_openbsd(sudo: Option<&PathBuf>, run_type: RunType) -> Result<()> {
     let sudo = require_option(sudo, String::from("No sudo detected"))?;
     print_separator("OpenBSD Update");
-    run_type
-        .execute(sudo)
-        .args(&["/usr/sbin/sysupgrade", "-n"])
-        .check_run()
+    run_type.execute(sudo).args(&["/usr/sbin/sysupgrade", "-n"]).check_run()
 }
 
 pub fn upgrade_packages(sudo: Option<&PathBuf>, run_type: RunType) -> Result<()> {
     let sudo = require_option(sudo, String::from("No sudo detected"))?;
     print_separator("OpenBSD Packages");
-    run_type
-        .execute(sudo)
-        .args(&["/usr/sbin/pkg_add", "-u"])
-        .check_run()
+    run_type.execute(sudo).args(&["/usr/sbin/pkg_add", "-u"]).check_run()
 }
-

--- a/src/steps/os/openbsd.rs
+++ b/src/steps/os/openbsd.rs
@@ -1,0 +1,24 @@
+use crate::executor::RunType;
+use crate::terminal::print_separator;
+use crate::utils::require_option;
+use anyhow::Result;
+use std::path::PathBuf;
+
+pub fn upgrade_openbsd(sudo: Option<&PathBuf>, run_type: RunType) -> Result<()> {
+    let sudo = require_option(sudo, String::from("No sudo detected"))?;
+    print_separator("OpenBSD Update");
+    run_type
+        .execute(sudo)
+        .args(&["/usr/sbin/sysupgrade", "-n"])
+        .check_run()
+}
+
+pub fn upgrade_packages(sudo: Option<&PathBuf>, run_type: RunType) -> Result<()> {
+    let sudo = require_option(sudo, String::from("No sudo detected"))?;
+    print_separator("OpenBSD Packages");
+    run_type
+        .execute(sudo)
+        .args(&["/usr/sbin/pkg_add", "-u"])
+        .check_run()
+}
+


### PR DESCRIPTION
This PR adds support for OpenBSD (ports & system upgrade).

## Standards checklist:
- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

Signed-off-by: Benjamin Stuerz <benni@stuerz.xyz>