### PR TITLE
style(self_update): Run cargo fmt

### DIFF
--- a/src/self_update.rs
+++ b/src/self_update.rs
@@ -18,7 +18,11 @@ pub fn self_update() -> Result<()> {
         .repo_owner("topgrade-rs")
         .repo_name("topgrade")
         .target(target)
-        .bin_name(if cfg!(windows) { "topgrade-rs.exe" } else { "topgrade-rs" })
+        .bin_name(if cfg!(windows) {
+            "topgrade-rs.exe"
+        } else {
+            "topgrade-rs"
+        })
         .show_output(false)
         .show_download_progress(true)
         .current_version(self_update_crate::cargo_crate_version!())


### PR DESCRIPTION
The commit 9105a8aac is not formatted, which breaks the CI check.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
