### PR TITLE
Revert clap version bump

### DIFF
--- a/.github/workflows/release-cross.yml
+++ b/.github/workflows/release-cross.yml
@@ -22,11 +22,23 @@ jobs:
           target: ${{ matrix.target }}
           components: rustfmt, clippy
       - uses: actions-rs/cargo@v1.0.1
+        name: Check format
+        with:
+          use-cross: true
+          command: fmt
+          args: --all -- --check
+      - uses: actions-rs/cargo@v1.0.1
+        name: Run clippy
+        with:
+          command: clippy
+          use-cross: true
+          args: --all-targets --locked --target ${{matrix.target}} -- -D warnings
+      - uses: actions-rs/cargo@v1.0.1
         name: Run clippy (All features)
         with:
           command: clippy
           use-cross: true
-          args:  --locked --all-features --target ${{matrix.target}}
+          args:  --locked --all-features --target ${{matrix.target}} -- -D warnings
       - uses: actions-rs/cargo@v1.0.1
         name: Run tests
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,20 @@ jobs:
           override: true
           components: rustfmt, clippy
       - uses: actions-rs/cargo@v1.0.1
+        name: Check format
+        with:
+          command: fmt
+          args: --all -- --check
+      - uses: actions-rs/cargo@v1.0.1
+        name: Run clippy
+        with:
+          command: clippy
+          args: --all-targets --locked -- -D warnings
+      - uses: actions-rs/cargo@v1.0.1
         name: Run clippy (All features)
         with:
           command: clippy
-          args: --all-targets --locked --all-features
+          args: --all-targets --locked --all-features -- -D warnings
       - uses: actions-rs/cargo@v1.0.1
         name: Run tests
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,24 +224,26 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.18"
+version = "3.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335867764ed2de42325fafe6d18b8af74ba97ee0c590fa016f157535b42ab04b"
+checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
+ "indexmap",
  "once_cell",
  "strsim",
  "termcolor",
+ "textwrap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.0.18"
+version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16a1b0f6422af32d5da0c58e2703320f379216ee70198241c84173a8c5ac28f3"
+checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -252,9 +254,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.3.0"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
@@ -1782,6 +1784,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1.0", features = ["derive"] }
 toml = "0.5"
 which_crate = { version = "4.1", package = "which" }
 shellexpand = "2.1"
-clap = { version = "4.0.18", features = ["cargo", "derive"] }
+clap = { version = "4.0.17", features = ["cargo", "derive"] }
 log = "0.4"
 walkdir = "2.3"
 console = "0.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1.0", features = ["derive"] }
 toml = "0.5"
 which_crate = { version = "4.1", package = "which" }
 shellexpand = "2.1"
-clap = { version = "4.0.17", features = ["cargo", "derive"] }
+clap = { version = "3.1", features = ["cargo", "derive"] }
 log = "0.4"
 walkdir = "2.3"
 console = "0.15"

--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ For tools please open an Issue describing the tool, which platforms it supports 
 
 Just fork the repository and start coding.
 
+### Contribution Guidelines
+
+- Check if your code passes `cargo fmt` and `cargo clippy`.
+- Check if your code is self explanatory, if not it should be documented by comments.
+- Make a Pull Request to the dev branch for new features or to the bug-fixes branch for bug fixes.
+
 ## Remote execution
 
 You can specify a key called `remote_topgrades` in the configuration file.

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 use std::{env, fs};
 
 use anyhow::Result;
-use clap::{Parser, ValueEnum};
+use clap::{ArgEnum, Parser};
 use directories::BaseDirs;
 use log::debug;
 use regex::Regex;
@@ -62,7 +62,7 @@ macro_rules! get_deprecated {
 
 type Commands = BTreeMap<String, String>;
 
-#[derive(ValueEnum, EnumString, EnumVariantNames, Debug, Clone, PartialEq, Eq, Deserialize, EnumIter, Copy)]
+#[derive(ArgEnum, EnumString, EnumVariantNames, Debug, Clone, PartialEq, Eq, Deserialize, EnumIter, Copy)]
 #[clap(rename_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
@@ -397,78 +397,78 @@ impl ConfigFile {
 
 // Command line arguments
 #[derive(Parser, Debug)]
-#[command(name = "Topgrade", version)]
+#[clap(name = "Topgrade", version)]
 pub struct CommandLineArgs {
     /// Edit the configuration file
-    #[arg(long = "edit-config")]
+    #[clap(long = "edit-config")]
     edit_config: bool,
 
     /// Show config reference
-    #[arg(long = "config-reference")]
+    #[clap(long = "config-reference")]
     show_config_reference: bool,
 
     /// Run inside tmux
-    #[arg(short = 't', long = "tmux")]
+    #[clap(short = 't', long = "tmux")]
     run_in_tmux: bool,
 
     /// Cleanup temporary or old files
-    #[arg(short = 'c', long = "cleanup")]
+    #[clap(short = 'c', long = "cleanup")]
     cleanup: bool,
 
     /// Print what would be done
-    #[arg(short = 'n', long = "dry-run")]
+    #[clap(short = 'n', long = "dry-run")]
     dry_run: bool,
 
     /// Do not ask to retry failed steps
-    #[arg(long = "no-retry")]
+    #[clap(long = "no-retry")]
     no_retry: bool,
 
     /// Do not perform upgrades for the given steps
-    #[arg(long = "disable", value_name = "STEP", value_enum, num_args = 1..)]
+    #[clap(long = "disable", arg_enum, multiple_values = true)]
     disable: Vec<Step>,
 
     /// Perform only the specified steps (experimental)
-    #[arg(long = "only", value_name = "STEP", value_enum, num_args = 1..)]
+    #[clap(long = "only", arg_enum, multiple_values = true)]
     only: Vec<Step>,
 
     /// Run only specific custom commands
-    #[arg(long = "custom-commands", value_name = "NAME", num_args = 1..)]
+    #[clap(long = "custom-commands")]
     custom_commands: Vec<String>,
 
     /// Set environment variables
-    #[arg(long = "env", value_name = "NAME=VALUE", num_args = 1..)]
+    #[clap(long = "env", multiple_values = true)]
     env: Vec<String>,
 
     /// Output logs
-    #[arg(short = 'v', long = "verbose")]
+    #[clap(short = 'v', long = "verbose")]
     pub verbose: bool,
 
     /// Prompt for a key before exiting
-    #[arg(short = 'k', long = "keep")]
+    #[clap(short = 'k', long = "keep")]
     keep_at_end: bool,
 
     /// Skip sending a notification at the end of a run
-    #[arg(long = "skip-notify")]
+    #[clap(long = "skip-notify")]
     skip_notify: bool,
 
     /// Say yes to package manager's prompt
-    #[arg(short = 'y', long = "yes", value_name = "STEP", value_enum, num_args = 0..)]
+    #[clap(short = 'y', long = "yes", arg_enum, multiple_values = true, min_values = 0)]
     yes: Option<Vec<Step>>,
 
     /// Don't pull the predefined git repos
-    #[arg(long = "disable-predefined-git-repos")]
+    #[clap(long = "disable-predefined-git-repos")]
     disable_predefined_git_repos: bool,
 
     /// Alternative configuration file
-    #[arg(long = "config", value_name = "PATH")]
+    #[clap(long = "config")]
     config: Option<PathBuf>,
 
     /// A regular expression for restricting remote host execution
-    #[arg(long = "remote-host-limit", value_name = "REGEX")]
+    #[clap(long = "remote-host-limit")]
     remote_host_limit: Option<Regex>,
 
     /// Show the reason for skipped steps
-    #[arg(long = "show-skipped")]
+    #[clap(long = "show-skipped")]
     show_skipped: bool,
 }
 

--- a/src/self_update.rs
+++ b/src/self_update.rs
@@ -18,7 +18,11 @@ pub fn self_update() -> Result<()> {
         .repo_owner("topgrade-rs")
         .repo_name("topgrade")
         .target(target)
-        .bin_name(if cfg!(windows) { "topgrade-rs.exe" } else { "topgrade-rs" })
+        .bin_name(if cfg!(windows) {
+            "topgrade-rs.exe"
+        } else {
+            "topgrade-rs"
+        })
         .show_output(false)
         .show_download_progress(true)
         .current_version(self_update_crate::cargo_crate_version!())


### PR DESCRIPTION
This PR reverts the clap version bump introduced in #81 because clap in v4.x keeps failing the CD pipeline.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
