### PR TITLE
Get windows to finish clippy without errors

### DIFF
--- a/.github/workflows/check-and-lint.yaml
+++ b/.github/workflows/check-and-lint.yaml
@@ -10,8 +10,8 @@ name: Check and Lint
 jobs:
   check:
     name: Check
-      matrix:
-        platform: [ ubuntu-latest, macos-latest, windows-latest ]
+    matrix:
+      platform: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v2
@@ -26,8 +26,8 @@ jobs:
 
   fmt:
     name: Rustfmt
-      matrix:
-        platform: [ ubuntu-latest, macos-latest, windows-latest ]
+    matrix:
+      platform: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v2
@@ -44,8 +44,8 @@ jobs:
 
   clippy:
     name: Clippy
-      matrix:
-        platform: [ ubuntu-latest, macos-latest, windows-latest ]
+    matrix:
+      platform: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v2

--- a/src/steps/os/windows.rs
+++ b/src/steps/os/windows.rs
@@ -94,7 +94,7 @@ fn upgrade_wsl_distribution(wsl: &Path, dist: &str, ctx: &ExecutionContext) -> R
 
 pub fn run_wsl_topgrade(ctx: &ExecutionContext) -> Result<()> {
     let wsl = require("wsl")?;
-    let wsl_distributions = get_wsl_distributions(wsl)?;
+    let wsl_distributions = get_wsl_distributions(&wsl)?;
     let mut ran = false;
 
     debug!("WSL distributions: {:?}", wsl_distributions);

--- a/src/steps/os/windows.rs
+++ b/src/steps/os/windows.rs
@@ -66,7 +66,7 @@ pub fn run_scoop(cleanup: bool, run_type: RunType) -> Result<()> {
 }
 
 fn get_wsl_distributions(wsl: &Path) -> Result<Vec<String>> {
-    let output = Command::new(wsl).args(["--list", "-q"]).check_output()?;
+    let output = Command::new(&wsl).args(["--list", "-q"]).check_output()?;
     Ok(output
         .lines()
         .filter(|s| !s.is_empty())

--- a/src/steps/os/windows.rs
+++ b/src/steps/os/windows.rs
@@ -65,7 +65,7 @@ pub fn run_scoop(cleanup: bool, run_type: RunType) -> Result<()> {
     Ok(())
 }
 
-fn get_wsl_distributions(wsl: Path) -> Result<Vec<String>> {
+fn get_wsl_distributions(wsl: &Path) -> Result<Vec<String>> {
     let output = Command::new(wsl).args(["--list", "-q"]).check_output()?;
     Ok(output
         .lines()


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
