### PR TITLE
Fix for gcloud snap issue

### DIFF
--- a/.github/workflows/check-and-lint.yaml
+++ b/.github/workflows/check-and-lint.yaml
@@ -10,7 +10,10 @@ name: Check and Lint
 jobs:
   check:
     name: Check
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [ ubuntu-latest, macos-latest, windows-latest ]
+    runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -24,7 +27,10 @@ jobs:
 
   fmt:
     name: Rustfmt
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [ ubuntu-latest, macos-latest, windows-latest ]
+    runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -40,7 +46,10 @@ jobs:
 
   clippy:
     name: Clippy
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [ ubuntu-latest, macos-latest, windows-latest ]
+    runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -51,5 +60,10 @@ jobs:
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features
+          args: --all-targets --locked -- -D warnings
           name: Clippy Output
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-targets --locked --all-features -- -D warnings
+          name: Clippy (All features) Output

--- a/.github/workflows/check-and-lint.yaml
+++ b/.github/workflows/check-and-lint.yaml
@@ -57,13 +57,13 @@ jobs:
           toolchain: stable
           components: clippy
           override: true
-      - uses: actions-rs/clippy-check@v1
+      - uses: actions-rs/cargo@v1.0.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          command: clippy
           args: --all-targets --locked -- -D warnings
           name: Clippy Output
-      - uses: actions-rs/clippy-check@v1
+      - uses: actions-rs/cargo@v1.0.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          command: clippy
           args: --all-targets --locked --all-features -- -D warnings
           name: Clippy (All features) Output

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -196,12 +196,16 @@ pub fn run_krew_upgrade(run_type: RunType) -> Result<()> {
 pub fn run_gcloud_components_update(run_type: RunType) -> Result<()> {
     let gcloud = utils::require("gcloud")?;
 
-    print_separator("gcloud");
+    if gcloud.starts_with("/snap") {
+        Ok(())
+    } else {
+        print_separator("gcloud");
 
-    run_type
-        .execute(gcloud)
-        .args(["components", "update", "--quiet"])
-        .check_run()
+        run_type
+            .execute(gcloud)
+            .args(["components", "update", "--quiet"])
+            .check_run()
+    }
 }
 
 pub fn run_jetpack(run_type: RunType) -> Result<()> {


### PR DESCRIPTION
Closes #138 

Since snapd handles updates for us, and it doesn't work anyways, skip if the install uses snap.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
