### PR TITLE
bugfix Closing #150 (#151)

### DIFF
--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -607,10 +607,12 @@ pub fn run_protonup_update(ctx: &ExecutionContext) -> Result<()> {
 }
 
 pub fn run_distrobox_update(ctx: &ExecutionContext) -> Result<()> {
+    let distrobox = require("distrobox")?;
+
     print_separator("Distrobox");
     match (
         match (
-            ctx.run_type().execute("distrobox").arg("upgrade"),
+            ctx.run_type().execute(distrobox).arg("upgrade"),
             ctx.config().distrobox_containers(),
         ) {
             (r, Some(c)) => {


### PR DESCRIPTION
* Check if distrobox exists before running step

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
