### PR TITLE
Fix compilation on Android

### DIFF
--- a/src/steps/os/android.rs
+++ b/src/steps/os/android.rs
@@ -1,6 +1,7 @@
 use crate::execution_context::ExecutionContext;
 use crate::terminal::print_separator;
 use crate::utils::require;
+use crate::utils::which;
 use crate::Step;
 use anyhow::Result;
 
@@ -10,7 +11,7 @@ pub fn upgrade_packages(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("Termux Packages");
 
-    let is_nala = pkg.end_with("nala");
+    let is_nala = pkg.ends_with("nala");
 
     let mut command = ctx.run_type().execute(&pkg);
     command.arg("upgrade");


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed
