### PR TITLE
Print errors when steps fail

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2,6 +2,7 @@ use crate::ctrlc;
 use crate::error::{DryRun, SkipStep};
 use crate::execution_context::ExecutionContext;
 use crate::report::{Report, StepResult};
+use crate::terminal::print_error;
 use crate::{config::Step, terminal::should_retry};
 use anyhow::Result;
 use log::debug;
@@ -55,7 +56,12 @@ impl<'a> Runner<'a> {
 
                     let ignore_failure = self.ctx.config().ignore_failure(step);
                     let should_ask = interrupted || !(self.ctx.config().no_retry() || ignore_failure);
-                    let should_retry = should_ask && should_retry(interrupted, key.as_ref())?;
+                    let should_retry = if should_ask {
+                        print_error(&key, format!("{e:?}"));
+                        should_retry(interrupted, key.as_ref())?
+                    } else {
+                        false
+                    };
 
                     if !should_retry {
                         self.report.push_result(Some((

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -163,6 +163,19 @@ impl Terminal {
     }
 
     #[allow(dead_code)]
+    fn print_error<P: AsRef<str>, Q: AsRef<str>>(&mut self, key: Q, message: P) {
+        let key = key.as_ref();
+        let message = message.as_ref();
+        self.term
+            .write_fmt(format_args!(
+                "{} {}",
+                style(format!("{} failed:", key)).red().bold(),
+                message
+            ))
+            .ok();
+    }
+
+    #[allow(dead_code)]
     fn print_warning<P: AsRef<str>>(&mut self, message: P) {
         let message = message.as_ref();
         self.term
@@ -275,6 +288,11 @@ pub fn should_retry(interrupted: bool, step_name: &str) -> anyhow::Result<bool> 
 
 pub fn print_separator<P: AsRef<str>>(message: P) {
     TERMINAL.lock().unwrap().print_separator(message)
+}
+
+#[allow(dead_code)]
+pub fn print_error<P: AsRef<str>, Q: AsRef<str>>(key: Q, message: P) {
+    TERMINAL.lock().unwrap().print_error(key, message)
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
Here's what the error encountered in #167 looks like with this change:

```
pnpm failed: Command failed: `/usr/local/bin/pnpm root -g`

Stdout:
ERROR  Unable to find the global bin directory
Run "pnpm setup" to create it automatically, or set the global-bin-dir setting, or the PNPM_HOME env variable. The global bin directory should be in the PATH.

Caused by:
    `/usr/local/bin/pnpm` failed: exit status: 1
Retry? (y)es/(N)o/(s)hell/(q)uit
```

Note that:
- It tells you what step failed (`pnpm`)
- It tells you what command was run and which arguments were passed to it
- It shows you the output (stdout and stderr) of the program called (unless the output was already displayed to the user)
- It shows the exit status of the command