### PR TITLE
Run `fisher` if `fish -c 'type -t fisher'` is OK

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -299,7 +299,7 @@ fn run() -> Result<()> {
         runner.execute(Step::Shell, "zi", || zsh::run_zi(&base_dirs, run_type))?;
         runner.execute(Step::Shell, "zim", || zsh::run_zim(&base_dirs, run_type))?;
         runner.execute(Step::Shell, "oh-my-zsh", || zsh::run_oh_my_zsh(&ctx))?;
-        runner.execute(Step::Shell, "fisher", || unix::run_fisher(&base_dirs, run_type))?;
+        runner.execute(Step::Shell, "fisher", || unix::run_fisher(run_type))?;
         runner.execute(Step::Shell, "bash-it", || unix::run_bashit(&ctx))?;
         runner.execute(Step::Shell, "oh-my-fish", || unix::run_oh_my_fish(&ctx))?;
         runner.execute(Step::Shell, "fish-plug", || unix::run_fish_plug(&ctx))?;


### PR DESCRIPTION
Fixes https://github.com/topgrade-rs/topgrade/issues/9

It definitely works, although if you just install `fisher` (e.g. with `brew install fisher`) and don't do anything else, it's not too happy:

```
―― 22:07:34 - Fisher ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――
fisher: "/Users/wiggles/.config/fish/fish_plugins" file not found: "update"

Retry? (y)es/(N)o/(s)hell/(q)uit
```

I think `~/.config/fish/fish_plugins` is where `fisher` expects to find a list of plugins. I don't use `fisher` currently, though.