### PR TITLE
Use `tracing`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,22 +63,22 @@ version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e14485364214912d3b19cc3435dde4df66065127f05fa0d75c712f36f12c2f28"
 dependencies = [
- "concurrent-queue",
+ "concurrent-queue 1.2.4",
  "event-listener",
  "futures-core",
 ]
 
 [[package]]
 name = "async-executor"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "871f9bb5e0a22eeb7e8cf16641feb87c9dc67032ccf8ff49e772eb9941d3a965"
+checksum = "17adb73da160dfb475c183343c8cccd80721ea5a605d3eb57125f0a7b7a92d0b"
 dependencies = [
+ "async-lock",
  "async-task",
- "concurrent-queue",
+ "concurrent-queue 2.0.0",
  "fastrand",
  "futures-lite",
- "once_cell",
  "slab",
 ]
 
@@ -90,7 +90,7 @@ checksum = "e8121296a9f05be7f34aa4196b1747243b3b62e048bb7906f644f3fbfc490cf7"
 dependencies = [
  "async-lock",
  "autocfg",
- "concurrent-queue",
+ "concurrent-queue 1.2.4",
  "futures-lite",
  "libc",
  "log",
@@ -216,9 +216,9 @@ checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
 
 [[package]]
 name = "cc"
-version = "1.0.74"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581f5dba903aac52ea3feb5ec4810848460ee833876f1f9b0fdeab1f19091574"
+checksum = "76a284da2e6fe2092f2353e51713435363112dfd60030e22add80be333fb928f"
 
 [[package]]
 name = "cfg-if"
@@ -327,6 +327,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd7bef69dc86e3c610e4e7aed41035e2a7ed12e72dd7530f61327a6579a4390b"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "console"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,9 +375,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b7d4e43b25d3c994662706a1d4fcfc32aaa6afd287502c111b237093bb23f3a"
+checksum = "97abf9f0eca9e52b7f81b945524e76710e6cb2366aead23b7d4fbf72e281f888"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -378,9 +387,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84f8829ddc213e2c1368e51a2564c552b65a8cb6a28f31e576270ac81d5e5827"
+checksum = "7cc32cc5fea1d894b77d269ddb9f192110069a8a9c1f1d441195fba90553dea3"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -393,15 +402,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72537424b474af1460806647c41d4b6d35d09ef7fe031c5c2fa5766047cc56a"
+checksum = "8ca220e4794c934dc6b1207c3b42856ad4c302f2df1712e9f8d2eec5afaacf1f"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "309e4fb93eed90e1e14bea0da16b209f81813ba9fc7830c20ed151dd7bc0a4d7"
+checksum = "b846f081361125bfc8dc9d3940c84e1fd83ba54bbca7b17cd29483c828be0704"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -515,19 +524,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
 ]
 
 [[package]]
@@ -821,19 +817,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
-name = "humantime"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-dependencies = [
- "quick-error",
-]
-
-[[package]]
 name = "hyper"
-version = "0.14.22"
+version = "0.14.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abfba89e19b959ca163c7752ba59d737c1ceea53a5d31a149c805446fc958064"
+checksum = "034711faac9d2166cb1baf1a2fb0b60b1f277f8492fd72176c17f3515e1abd3c"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -939,9 +926,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.5.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
+checksum = "f88c5561171189e69df9d98bcf18fd5f9558300f7ea7b801eb8a0fd748bd8745"
 
 [[package]]
 name = "itoa"
@@ -1008,7 +995,7 @@ dependencies = [
  "dirs-next",
  "objc-foundation",
  "objc_id",
- "time 0.3.16",
+ "time 0.3.17",
 ]
 
 [[package]]
@@ -1018,6 +1005,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -1121,6 +1117,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1141,20 +1147,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
 dependencies = [
  "hermit-abi",
- "libc",
-]
-
-[[package]]
-name = "num_threads"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
-dependencies = [
  "libc",
 ]
 
@@ -1230,9 +1227,15 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.3.1"
+version = "6.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3baf96e39c5359d2eb0dd6ccb42c62b91d9678aa68160d261b9e0ccbf9e9dea9"
+checksum = "7b5bf27447411e9ee3ff51186bf7a08e16c341efdde93f4d823e8844429bed7e"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owo-colors"
@@ -1316,19 +1319,9 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
-
-[[package]]
-name = "pretty_env_logger"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
-dependencies = [
- "env_logger",
- "log",
-]
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro-crate"
@@ -1373,12 +1366,6 @@ checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
  "unicode-ident",
 ]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
@@ -1469,10 +1456,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex-syntax"
-version = "0.6.27"
+name = "regex-automata"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "remove_dir_all"
@@ -1910,9 +1906,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
+checksum = "b7b3e525a49ec206798b40326a44121291b530c963cfb01018f63e135bac543d"
 
 [[package]]
 name = "thiserror"
@@ -1956,13 +1952,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fab5c8b9980850e06d92ddbe3ab839c062c801f3927c0fb8abd6fc8e918fbca"
+checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
 dependencies = [
  "itoa",
- "libc",
- "num_threads",
  "serde",
  "time-core",
  "time-macros",
@@ -1976,9 +1970,9 @@ checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "time-macros"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bb801831d812c562ae7d2bfb531f26e66e4e1f6b17307ba4149c5064710e5b"
+checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
 dependencies = [
  "time-core",
 ]
@@ -2064,11 +2058,9 @@ dependencies = [
  "glob",
  "home",
  "lazy_static",
- "log",
  "nix 0.24.2",
  "notify-rust",
  "parselnk",
- "pretty_env_logger",
  "regex",
  "rust-ini",
  "self_update",
@@ -2082,6 +2074,8 @@ dependencies = [
  "thiserror",
  "tokio",
  "toml",
+ "tracing",
+ "tracing-subscriber",
  "walkdir",
  "which",
  "winapi",
@@ -2100,6 +2094,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -2137,14 +2132,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-log"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
 dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
+ "smallvec",
  "thread_local",
+ "time 0.3.17",
+ "tracing",
  "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -2607,7 +2621,7 @@ dependencies = [
  "crc32fast",
  "crossbeam-utils",
  "flate2",
- "time 0.3.16",
+ "time 0.3.17",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,12 +27,10 @@ toml = "0.5"
 which_crate = { version = "~4.1", package = "which" }
 shellexpand = "~2.1"
 clap = { version = "~3.1", features = ["cargo", "derive"] }
-log = "~0.4"
 walkdir = "~2.3"
 console = "~0.15"
 lazy_static = "~1.4"
 chrono = "~0.4"
-pretty_env_logger = "~0.4"
 glob = "~0.3"
 strum = { version = "~0.24", features = ["derive"] }
 thiserror = "~1.0"
@@ -45,6 +43,8 @@ sys-info = "~0.9"
 semver = "~1.0"
 shell-words = "~1.1"
 color-eyre = "0.6.2"
+tracing = { version = "0.1.37", features = ["attributes", "log"] }
+tracing-subscriber = { version = "0.3.16", features = ["env-filter", "time"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 notify-rust = "~4.5"

--- a/src/command.rs
+++ b/src/command.rs
@@ -183,7 +183,7 @@ impl CommandExt for Command {
             let err = TopgradeError::ProcessFailedWithOutput(program, output.status, stderr.into_owned());
 
             let ret = Err(err).with_context(|| message);
-            log::debug!("Command failed: {ret:?}");
+            tracing::debug!("Command failed: {ret:?}");
             ret
         }
     }
@@ -203,7 +203,7 @@ impl CommandExt for Command {
             let (program, _) = get_program_and_args(self);
             let err = TopgradeError::ProcessFailed(program, status);
             let ret = Err(err).with_context(|| format!("Command failed: `{command}`"));
-            log::debug!("Command failed: {ret:?}");
+            tracing::debug!("Command failed: {ret:?}");
             ret
         }
     }
@@ -239,6 +239,6 @@ fn format_program_and_args(cmd: &Command) -> String {
 
 fn log(cmd: &Command) -> String {
     let command = format_program_and_args(cmd);
-    log::debug!("Executing command `{command}`");
+    tracing::debug!("Executing command `{command}`");
     command
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -442,7 +442,7 @@ pub struct CommandLineArgs {
     #[clap(long = "env", value_name = "NAME=VALUE", multiple_values = true)]
     env: Vec<String>,
 
-    /// Output debug logs. Alias for `--trace debug`.
+    /// Output debug logs. Alias for `--log-filter debug`.
     #[clap(short = 'v', long = "verbose")]
     pub verbose: bool,
 
@@ -485,7 +485,7 @@ pub struct CommandLineArgs {
     ///
     /// See: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/struct.EnvFilter.html
     #[clap(long, default_value = "info")]
-    pub trace: String,
+    pub log_filter: String,
 }
 
 impl CommandLineArgs {
@@ -505,7 +505,7 @@ impl CommandLineArgs {
         if self.verbose {
             "debug".into()
         } else {
-            self.trace.clone()
+            self.log_filter.clone()
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,11 +10,11 @@ use color_eyre::eyre;
 use color_eyre::eyre::Context;
 use color_eyre::eyre::Result;
 use directories::BaseDirs;
-use log::debug;
 use regex::Regex;
 use serde::Deserialize;
 use strum::{EnumIter, EnumString, EnumVariantNames, IntoEnumIterator};
 use sys_info::hostname;
+use tracing::debug;
 use which_crate::which;
 
 use crate::command::CommandExt;
@@ -352,12 +352,12 @@ impl ConfigFile {
         };
 
         let contents = fs::read_to_string(&config_path).map_err(|e| {
-            log::error!("Unable to read {}", config_path.display());
+            tracing::error!("Unable to read {}", config_path.display());
             e
         })?;
 
         let mut result: Self = toml::from_str(&contents).map_err(|e| {
-            log::error!("Failed to deserialize {}", config_path.display());
+            tracing::error!("Failed to deserialize {}", config_path.display());
             e
         })?;
 
@@ -442,7 +442,7 @@ pub struct CommandLineArgs {
     #[clap(long = "env", value_name = "NAME=VALUE", multiple_values = true)]
     env: Vec<String>,
 
-    /// Output logs
+    /// Output debug logs. Alias for `--trace debug`.
     #[clap(short = 'v', long = "verbose")]
     pub verbose: bool,
 
@@ -480,6 +480,12 @@ pub struct CommandLineArgs {
     /// Show the reason for skipped steps
     #[clap(long = "show-skipped")]
     show_skipped: bool,
+
+    /// Tracing filter directives.
+    ///
+    /// See: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/struct.EnvFilter.html
+    #[clap(long, default_value = "info")]
+    pub trace: String,
 }
 
 impl CommandLineArgs {
@@ -493,6 +499,14 @@ impl CommandLineArgs {
 
     pub fn env_variables(&self) -> &Vec<String> {
         &self.env
+    }
+
+    pub fn tracing_filter_directives(&self) -> String {
+        if self.verbose {
+            "debug".into()
+        } else {
+            self.trace.clone()
+        }
     }
 }
 
@@ -517,11 +531,11 @@ impl Config {
             ConfigFile::read(base_dirs, opt.config.clone()).unwrap_or_else(|e| {
                 // Inform the user about errors when loading the configuration,
                 // but fallback to the default config to at least attempt to do something
-                log::error!("failed to load configuration: {}", e);
+                tracing::error!("failed to load configuration: {}", e);
                 ConfigFile::default()
             })
         } else {
-            log::debug!("Configuration directory {} does not exist", config_directory.display());
+            tracing::debug!("Configuration directory {} does not exist", config_directory.display());
             ConfigFile::default()
         };
 

--- a/src/ctrlc/windows.rs
+++ b/src/ctrlc/windows.rs
@@ -16,6 +16,6 @@ extern "system" fn handler(ctrl_type: DWORD) -> BOOL {
 
 pub fn set_handler() {
     if 0 == unsafe { SetConsoleCtrlHandler(Some(handler), TRUE) } {
-        log::error!("Cannot set a control C handler")
+        tracing::error!("Cannot set a control C handler")
     }
 }

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -5,7 +5,7 @@ use std::process::{Child, Command, ExitStatus, Output};
 
 use color_eyre::eyre;
 use color_eyre::eyre::Result;
-use log::debug;
+use tracing::debug;
 
 use crate::command::CommandExt;
 use crate::error::DryRun;

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,9 +8,7 @@ use clap::{crate_version, Parser};
 use color_eyre::eyre::Context;
 use color_eyre::eyre::{eyre, Result};
 use console::Key;
-use log::debug;
-use log::LevelFilter;
-use pretty_env_logger::formatted_timed_builder;
+use tracing::debug;
 
 use self::config::{CommandLineArgs, Config, Step};
 use self::error::StepFailed;
@@ -43,20 +41,14 @@ fn run() -> Result<()> {
 
     let opt = CommandLineArgs::parse();
 
+    install_tracing(&opt.tracing_filter_directives())?;
+
     for env in opt.env_variables() {
         let mut splitted = env.split('=');
         let var = splitted.next().unwrap();
         let value = splitted.next().unwrap();
         env::set_var(var, value);
     }
-
-    let mut builder = formatted_timed_builder();
-
-    if opt.verbose {
-        builder.filter(Some("topgrade"), LevelFilter::Trace);
-    }
-
-    builder.init();
 
     if opt.edit_config() {
         Config::edit(&base_dirs)?;
@@ -535,4 +527,27 @@ fn main() {
             exit(1);
         }
     }
+}
+
+pub fn install_tracing(filter_directives: &str) -> Result<()> {
+    use tracing_subscriber::fmt;
+    use tracing_subscriber::fmt::format::FmtSpan;
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::util::SubscriberInitExt;
+    use tracing_subscriber::EnvFilter;
+
+    let env_filter = EnvFilter::try_new(filter_directives)
+        .or_else(|_| EnvFilter::try_from_default_env())
+        .or_else(|_| EnvFilter::try_new("info"))?;
+
+    let fmt_layer = fmt::layer()
+        .with_target(false)
+        .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
+        .without_time();
+
+    let registry = tracing_subscriber::registry();
+
+    registry.with(env_filter).with(fmt_layer).init();
+
+    Ok(())
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -5,9 +5,9 @@ use crate::report::{Report, StepResult};
 use crate::terminal::print_error;
 use crate::{config::Step, terminal::should_retry};
 use color_eyre::eyre::Result;
-use log::debug;
 use std::borrow::Cow;
 use std::fmt::Debug;
+use tracing::debug;
 
 pub struct Runner<'a> {
     ctx: &'a ExecutionContext<'a>,

--- a/src/self_renamer.rs
+++ b/src/self_renamer.rs
@@ -1,8 +1,8 @@
 #![cfg(windows)]
 
 use color_eyre::eyre::Result;
-use log::{debug, error};
 use std::{env::current_exe, fs, path::PathBuf};
+use tracing::{debug, error};
 
 pub struct SelfRenamer {
     exe_path: PathBuf,

--- a/src/steps/containers.rs
+++ b/src/steps/containers.rs
@@ -1,14 +1,15 @@
+use std::path::Path;
+use std::process::Command;
+
 use color_eyre::eyre::eyre;
 use color_eyre::eyre::Context;
 use color_eyre::eyre::Result;
+use tracing::{debug, error, warn};
 
 use crate::command::CommandExt;
 use crate::error::{self, TopgradeError};
 use crate::terminal::print_separator;
 use crate::{execution_context::ExecutionContext, utils::require};
-use log::{debug, error, warn};
-use std::path::Path;
-use std::process::Command;
 
 // A string found in the output of docker for containers that weren't found in
 // the docker registry. We use this to gracefully handle and skip containers

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -9,8 +9,8 @@ use color_eyre::eyre::eyre;
 use color_eyre::eyre::Context;
 use color_eyre::eyre::Result;
 use directories::BaseDirs;
-use log::debug;
 use tempfile::tempfile_in;
+use tracing::debug;
 
 use crate::command::{CommandExt, Utf8Output};
 use crate::execution_context::ExecutionContext;

--- a/src/steps/git.rs
+++ b/src/steps/git.rs
@@ -8,9 +8,9 @@ use console::style;
 use futures::stream::{iter, FuturesUnordered};
 use futures::StreamExt;
 use glob::{glob_with, MatchOptions};
-use log::{debug, error};
 use tokio::process::Command as AsyncCommand;
 use tokio::runtime;
+use tracing::{debug, error};
 
 use crate::command::CommandExt;
 use crate::execution_context::ExecutionContext;

--- a/src/steps/node.rs
+++ b/src/steps/node.rs
@@ -5,10 +5,10 @@ use std::path::PathBuf;
 use std::process::Command;
 
 use color_eyre::eyre::Result;
-use log::debug;
 #[cfg(target_os = "linux")]
 use nix::unistd::Uid;
 use semver::Version;
+use tracing::debug;
 
 use crate::command::CommandExt;
 use crate::executor::RunType;

--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -3,7 +3,7 @@ use std::process::Command;
 
 use color_eyre::eyre::Result;
 use ini::Ini;
-use log::{debug, warn};
+use tracing::{debug, warn};
 
 use crate::command::CommandExt;
 use crate::error::{SkipStep, TopgradeError};

--- a/src/steps/os/macos.rs
+++ b/src/steps/os/macos.rs
@@ -4,9 +4,9 @@ use crate::executor::RunType;
 use crate::terminal::{print_separator, prompt_yesno};
 use crate::{utils::require, Step};
 use color_eyre::eyre::Result;
-use log::debug;
 use std::fs;
 use std::process::Command;
+use tracing::debug;
 
 pub fn run_macports(ctx: &ExecutionContext) -> Result<()> {
     require("port")?;

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -10,7 +10,7 @@ use color_eyre::eyre::Result;
 use directories::BaseDirs;
 use home;
 use ini::Ini;
-use log::debug;
+use tracing::debug;
 
 use crate::error::SkipStep;
 use crate::execution_context::ExecutionContext;

--- a/src/steps/os/windows.rs
+++ b/src/steps/os/windows.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use std::{ffi::OsStr, process::Command};
 
 use color_eyre::eyre::Result;
-use log::debug;
+use tracing::debug;
 
 use crate::command::CommandExt;
 use crate::execution_context::ExecutionContext;

--- a/src/steps/remote/vagrant.rs
+++ b/src/steps/remote/vagrant.rs
@@ -3,9 +3,9 @@ use std::process::Command;
 use std::{fmt::Display, rc::Rc, str::FromStr};
 
 use color_eyre::eyre::Result;
-use log::{debug, error};
 use regex::Regex;
 use strum::EnumString;
+use tracing::{debug, error};
 
 use crate::command::CommandExt;
 use crate::execution_context::ExecutionContext;

--- a/src/steps/toolbx.rs
+++ b/src/steps/toolbx.rs
@@ -4,9 +4,9 @@ use crate::command::CommandExt;
 use crate::config::Step;
 use crate::terminal::print_separator;
 use crate::{execution_context::ExecutionContext, utils::require};
-use log::debug;
 use std::path::Path;
 use std::{path::PathBuf, process::Command};
+use tracing::debug;
 
 fn list_toolboxes(toolbx: &Path) -> Result<Vec<String>> {
     let output = Command::new(toolbx)

--- a/src/steps/vim.rs
+++ b/src/steps/vim.rs
@@ -9,12 +9,12 @@ use crate::{
     utils::{require, PathExt},
 };
 use directories::BaseDirs;
-use log::debug;
 use std::path::PathBuf;
 use std::{
     io::{self, Write},
     process::Command,
 };
+use tracing::debug;
 
 const UPGRADE_VIM: &str = include_str!("upgrade.vim");
 

--- a/src/steps/zsh.rs
+++ b/src/steps/zsh.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 
 use color_eyre::eyre::Result;
 use directories::BaseDirs;
-use log::debug;
+use tracing::debug;
 use walkdir::WalkDir;
 
 use crate::command::CommandExt;

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -12,9 +12,9 @@ use color_eyre::eyre;
 use color_eyre::eyre::Context;
 use console::{style, Key, Term};
 use lazy_static::lazy_static;
-use log::{debug, error};
 #[cfg(target_os = "macos")]
 use notify_rust::{Notification, Timeout};
+use tracing::{debug, error};
 #[cfg(windows)]
 use which_crate::which;
 
@@ -105,7 +105,7 @@ impl Terminal {
                     command.args(["-a", "Topgrade", "Topgrade"]);
                     command.arg(message.as_ref());
                     if let Err(err) = command.output_checked() {
-                        log::error!("{err:?}");
+                        tracing::error!("{err:?}");
                     }
                 }
             }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,11 +1,11 @@
 use crate::error::SkipStep;
 use color_eyre::eyre::Result;
 
-use log::{debug, error};
 use std::env;
 use std::ffi::OsStr;
 use std::fmt::Debug;
 use std::path::{Path, PathBuf};
+use tracing::{debug, error};
 
 pub trait PathExt
 where


### PR DESCRIPTION
`tracing` is the standard logging library, used by rustc. Let's use it. In a future PR we can start leaning on `tracing`'s tools, annotating functions, and so on.

Might tweak the output format a bit more.