### PR TITLE
Fix compilation on FreeBSD

### DIFF
--- a/src/steps/os/freebsd.rs
+++ b/src/steps/os/freebsd.rs
@@ -1,3 +1,4 @@
+use crate::command::CommandExt;
 use crate::executor::RunType;
 use crate::terminal::print_separator;
 use crate::utils::require_option;
@@ -10,7 +11,7 @@ pub fn upgrade_freebsd(sudo: Option<&PathBuf>, run_type: RunType) -> Result<()> 
     print_separator("FreeBSD Update");
     run_type
         .execute(sudo)
-        .args(&["/usr/sbin/freebsd-update", "fetch", "install"])
+        .args(["/usr/sbin/freebsd-update", "fetch", "install"])
         .status_checked()
 }
 
@@ -19,7 +20,7 @@ pub fn upgrade_packages(sudo: Option<&PathBuf>, run_type: RunType) -> Result<()>
     print_separator("FreeBSD Packages");
     run_type
         .execute(sudo)
-        .args(&["/usr/sbin/pkg", "upgrade"])
+        .args(["/usr/sbin/pkg", "upgrade"])
         .status_checked()
 }
 
@@ -27,8 +28,8 @@ pub fn audit_packages(sudo: &Option<PathBuf>) -> Result<()> {
     if let Some(sudo) = sudo {
         println!();
         Command::new(sudo)
-            .args(&["/usr/sbin/pkg", "audit", "-Fr"])
-            .status_checked();
+            .args(["/usr/sbin/pkg", "audit", "-Fr"])
+            .status_checked()?;
     }
     Ok(())
 }


### PR DESCRIPTION
I also fixed a couple of clippy warnings, but not all, as those also target other platforms, so it makes sense to address them in a new PR.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [ ] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
