### PR TITLE
Further clippy fixes

### DIFF
--- a/src/steps/os/android.rs
+++ b/src/steps/os/android.rs
@@ -1,3 +1,4 @@
+use crate::command::CommandExt;
 use crate::execution_context::ExecutionContext;
 use crate::terminal::print_separator;
 use crate::utils::require;
@@ -21,18 +22,16 @@ pub fn upgrade_packages(ctx: &ExecutionContext) -> Result<()> {
     }
     command.status_checked()?;
 
-    if !is_nala {
-        if ctx.config().cleanup() {
-            ctx.run_type().execute(&pkg).arg("clean").status_checked()?;
+    if !is_nala && ctx.config().cleanup() {
+        ctx.run_type().execute(&pkg).arg("clean").status_checked()?;
 
-            let apt = require("apt")?;
-            let mut command = ctx.run_type().execute(&apt);
-            command.arg("autoremove");
-            if ctx.config().yes(Step::System) {
-                command.arg("-y");
-            }
-            command.status_checked()?;
+        let apt = require("apt")?;
+        let mut command = ctx.run_type().execute(&apt);
+        command.arg("autoremove");
+        if ctx.config().yes(Step::System) {
+            command.arg("-y");
         }
+        command.status_checked()?;
     }
 
     Ok(())

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -14,23 +14,30 @@ use log::debug;
 
 use crate::error::SkipStep;
 use crate::execution_context::ExecutionContext;
-use crate::executor::{Executor, RunType};
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+use crate::executor::Executor;
+use crate::executor::RunType;
 use crate::terminal::print_separator;
 #[cfg(not(target_os = "macos"))]
 use crate::utils::require_option;
 use crate::utils::{require, PathExt};
 
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 const INTEL_BREW: &str = "/usr/local/bin/brew";
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 const ARM_BREW: &str = "/opt/homebrew/bin/brew";
 
 #[derive(Copy, Clone, Debug)]
 #[allow(dead_code)]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 pub enum BrewVariant {
     Path,
     MacIntel,
     MacArm,
 }
 
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 impl BrewVariant {
     fn binary_name(self) -> &'static str {
         match self {
@@ -223,6 +230,7 @@ pub fn upgrade_gnome_extensions(ctx: &ExecutionContext) -> Result<()> {
         .status_checked()
 }
 
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 pub fn run_brew_formula(ctx: &ExecutionContext, variant: BrewVariant) -> Result<()> {
     #[allow(unused_variables)]
     let binary_name = require(variant.binary_name())?;

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -18,7 +18,7 @@ use crate::execution_context::ExecutionContext;
 use crate::executor::Executor;
 use crate::executor::RunType;
 use crate::terminal::print_separator;
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "android", target_os = "macos")))]
 use crate::utils::require_option;
 use crate::utils::{require, PathExt};
 


### PR DESCRIPTION
- Restrict Homebrew-related code to Linux and macOS 
- Don't import `require_option` on OSes with no GNOME support 
- Clippy fixes for Android

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
