### PR TITLE
CI improvements + Android and FreeBSD targets

### DIFF
--- a/.github/workflows/check-and-lint.yaml
+++ b/.github/workflows/check-and-lint.yaml
@@ -4,67 +4,69 @@ on:
     branches:
       - main
 
+name: CI
 
-name: Check and Lint
+env:
+  RUST_VER: '1.60.0'
+  CROSS_VER: '0.2.4'
+  CARGO_NET_RETRY: 3
 
 jobs:
-  check:
-    name: Check
-    strategy:
-      matrix:
-        platform: [ ubuntu-latest, macos-latest, windows-latest ]
-    runs-on: ${{ matrix.platform }}
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --color always
-
   fmt:
     name: Rustfmt
-    strategy:
-      matrix:
-        platform: [ ubuntu-latest, macos-latest, windows-latest ]
-    runs-on: ${{ matrix.platform }}
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - run: rustup component add rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check --color always
+      - name: Checkout code
+        uses: actions/checkout@v3
 
-  clippy:
-    name: Clippy
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: '${{ env.RUST_VER }}'
+          targets: ${{ matrix.target }}
+          components: clippy, rustfmt
+
+      - name: Run cargo fmt
+        run: |
+          cargo fmt --all -- --check
+
+  main:
+    needs: fmt
+    name: ${{ matrix.target_name }} (check, clippy)
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        platform: [ ubuntu-latest, macos-latest, windows-latest ]
-    runs-on: ${{ matrix.platform }}
+        include:
+          - target: x86_64-unknown-linux-gnu
+            target_name: Linux
+            os: ubuntu-20.04
+
+          - target: x86_64-apple-darwin
+            target_name: macOS
+            os: macos-11
+
+          - target: x86_64-pc-windows-msvc
+            target_name: Windows
+            os: windows-2019
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
-          components: clippy
-          override: true
-      - uses: actions-rs/cargo@v1.0.1
+          toolchain: '${{ env.RUST_VER }}'
+          targets: ${{ matrix.target }}
+          components: clippy, rustfmt
+
+      - name: Setup Rust Cache
+        uses: Swatinem/rust-cache@v2
         with:
-          command: clippy
-          args: --color always --all-targets --locked -- -D warnings
-          name: Clippy Output
-      - uses: actions-rs/cargo@v1.0.1
-        with:
-          command: clippy
-          args: --color always --all-targets --locked --all-features -- -D warnings
-          name: Clippy (All features) Output
+          prefix-key: ${{ matrix.target }}
+
+      - name: Run cargo check
+        run: ${{ matrix.use_cross == true && 'cross' || 'cargo' }} check --locked --target ${{ matrix.target }}
+
+      - name: Run cargo clippy
+        run: ${{ matrix.use_cross == true && 'cross' || 'cargo' }} clippy --locked --target ${{ matrix.target }} --all-features -- -D warnings

--- a/.github/workflows/check-and-lint.yaml
+++ b/.github/workflows/check-and-lint.yaml
@@ -38,6 +38,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - target: x86_64-linux-android
+            target_name: Android
+            use_cross: true
+            os: ubuntu-20.04
+
           - target: x86_64-unknown-linux-gnu
             target_name: Linux
             os: ubuntu-20.04
@@ -64,6 +69,10 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           prefix-key: ${{ matrix.target }}
+
+      - name: Setup cross
+        if: matrix.use_cross == true
+        run: curl -fL --retry 3 https://github.com/cross-rs/cross/releases/download/v${{ env.CROSS_VER }}/cross-x86_64-unknown-linux-musl.tar.gz | tar vxz -C /usr/local/bin
 
       - name: Run cargo check
         run: ${{ matrix.use_cross == true && 'cross' || 'cargo' }} check --locked --target ${{ matrix.target }}

--- a/.github/workflows/check-and-lint.yaml
+++ b/.github/workflows/check-and-lint.yaml
@@ -43,6 +43,11 @@ jobs:
             use_cross: true
             os: ubuntu-20.04
 
+          - target: x86_64-unknown-freebsd
+            target_name: FreeBSD
+            use_cross: true
+            os: ubuntu-20.04
+
           - target: x86_64-unknown-linux-gnu
             target_name: Linux
             os: ubuntu-20.04

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,4 @@
+# Workaround for: https://github.com/cross-rs/cross/issues/1100
+# TODO: Remove this file altogether once a new version of cross (after v0.2.4) is released.
+[target.x86_64-unknown-freebsd.env]
+passthrough = ["AR_x86_64_unknown_freebsd=x86_64-unknown-freebsd12-ar"]

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To remedy this, **Topgrade** detects which tools you use and runs the appropriat
 Other systems users can either use `cargo install` or use the compiled binaries from the release page.
 The compiled binaries contain a self-upgrading feature.
 
-Topgrade requires Rust 1.51 or above.
+Topgrade requires Rust 1.60 or above.
 
 ## Documentation
 


### PR DESCRIPTION
This PR is pretty much ready (reviews aside), but it currently depends on the following PRs to be merged first (in order for the CI to run successfully):

- [x] #175 
- [x] #176

---

Changes:

- Bump minimum Rust version to 1.60 (required by the `time` crate).
- Bump [actions/checkout](https://github.com/actions/checkout) to `v3`, fixing a bunch of warnings.
- Replace unmaintained [actions-rs/cargo](https://github.com/actions-rs/cargo) by [dtolnay/rust-toolchain](https://github.com/dtolnay/rust-toolchain).
- Run Rustfmt only once.
- Add support for cached dependencies (via [Swatinem/rust-cache](https://github.com/Swatinem/rust-cache)).
- Add Android target (cross-compiled using [cross](https://github.com/cross-rs/cross)).
- Add FreeBSD target (cross-compiled using [cross](https://github.com/cross-rs/cross)).