### PR TITLE
CI: Add NetBSD target 

### DIFF
--- a/.github/workflows/check-and-lint.yaml
+++ b/.github/workflows/check-and-lint.yaml
@@ -56,6 +56,11 @@ jobs:
             target_name: macOS
             os: macos-11
 
+          - target: x86_64-unknown-netbsd
+            target_name: NetBSD
+            use_cross: true
+            os: ubuntu-20.04
+
           - target: x86_64-pc-windows-msvc
             target_name: Windows
             os: windows-2019

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1840,16 +1840,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sys-info"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "tar"
 version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2058,6 +2048,7 @@ dependencies = [
  "glob",
  "home",
  "lazy_static",
+ "libc",
  "nix 0.24.2",
  "notify-rust",
  "parselnk",
@@ -2069,7 +2060,6 @@ dependencies = [
  "shell-words",
  "shellexpand",
  "strum 0.24.1",
- "sys-info",
  "tempfile",
  "thiserror",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ cfg-if = "~1.0"
 tokio = { version = "~1.5", features = ["process", "rt-multi-thread"] }
 futures = "~0.3"
 regex = "~1.5"
-sys-info = "~0.9"
 semver = "~1.0"
 shell-words = "~1.1"
 color-eyre = "0.6.2"
@@ -60,6 +59,7 @@ git = "*"
 depends = "$auto,git"
 
 [target.'cfg(unix)'.dependencies]
+libc = "~0.2"
 nix = "~0.24"
 rust-ini = "~0.18"
 self_update_crate = { version = "~0.30", default-features = false, optional = true, package = "self_update", features = ["archive-tar", "compression-flate2", "rustls"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,13 +13,12 @@ use directories::BaseDirs;
 use regex::Regex;
 use serde::Deserialize;
 use strum::{EnumIter, EnumString, EnumVariantNames, IntoEnumIterator};
-use sys_info::hostname;
 use tracing::debug;
 use which_crate::which;
 
 use crate::command::CommandExt;
 
-use super::utils::editor;
+use super::utils::{editor, hostname};
 
 pub static EXAMPLE_CONFIG: &str = include_str!("../config.example.toml");
 

--- a/src/steps/os/freebsd.rs
+++ b/src/steps/os/freebsd.rs
@@ -1,6 +1,4 @@
 use crate::command::CommandExt;
-use crate::config::Step;
-use crate::execution_context::ExecutionContext;
 use crate::executor::RunType;
 use crate::terminal::print_separator;
 use crate::utils::require_option;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -107,3 +107,55 @@ pub fn require_option<T>(option: Option<T>, cause: String) -> Result<T> {
         Err(SkipStep(cause).into())
     }
 }
+
+/* sys-info-rs
+ *
+ * Copyright (c) 2015 Siyu Wang
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#[cfg(target_family = "unix")]
+pub fn hostname() -> Result<String> {
+    use std::ffi;
+    extern crate libc;
+
+    unsafe {
+        let buf_size = libc::sysconf(libc::_SC_HOST_NAME_MAX) as usize;
+        let mut buf = Vec::<u8>::with_capacity(buf_size + 1);
+
+        if libc::gethostname(buf.as_mut_ptr() as *mut libc::c_char, buf_size) < 0 {
+            return Err(SkipStep(format!("Failed to get hostname: {}", std::io::Error::last_os_error())).into());
+        }
+        let hostname_len = libc::strnlen(buf.as_ptr() as *const libc::c_char, buf_size);
+        buf.set_len(hostname_len);
+
+        Ok(ffi::CString::new(buf).unwrap().into_string().unwrap())
+    }
+}
+
+#[cfg(target_family = "windows")]
+pub fn hostname() -> Result<String> {
+    use crate::command::CommandExt;
+    use std::process::Command;
+
+    Command::new("hostname")
+        .output_checked_utf8()
+        .map_err(|err| SkipStep(format!("Failed to get hostname: {}", err)).into())
+        .map(|output| output.stdout.trim().to_owned())
+}


### PR DESCRIPTION
This also removes the `sys-info` crate, because it offers much more features than we currently use.

Additionally, `sys-info` was preventing me to cross-compile for NetBSD.

Since we were just using the `hostname()` function from the crate, I went ahead and stole it.