### PR TITLE
 Fix unattended package upgrades on FreeBSD

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -206,7 +206,7 @@ fn run() -> Result<()> {
 
     #[cfg(target_os = "freebsd")]
     runner.execute(Step::Pkg, "FreeBSD Packages", || {
-        freebsd::upgrade_packages(sudo.as_ref(), run_type)
+        freebsd::upgrade_packages(&ctx, sudo.as_ref(), run_type)
     })?;
 
     #[cfg(target_os = "openbsd")]

--- a/src/steps/os/freebsd.rs
+++ b/src/steps/os/freebsd.rs
@@ -4,6 +4,8 @@ use crate::utils::require_option;
 use anyhow::Result;
 use std::path::PathBuf;
 use std::process::Command;
+use crate::config::{Step};
+use crate::execution_context::ExecutionContext;
 
 pub fn upgrade_freebsd(sudo: Option<&PathBuf>, run_type: RunType) -> Result<()> {
     let sudo = require_option(sudo, String::from("No sudo detected"))?;
@@ -14,10 +16,18 @@ pub fn upgrade_freebsd(sudo: Option<&PathBuf>, run_type: RunType) -> Result<()> 
         .check_run()
 }
 
-pub fn upgrade_packages(sudo: Option<&PathBuf>, run_type: RunType) -> Result<()> {
+pub fn upgrade_packages(ctx: &ExecutionContext, sudo: Option<&PathBuf>, run_type: RunType) -> Result<()> {
     let sudo = require_option(sudo, String::from("No sudo detected"))?;
     print_separator("FreeBSD Packages");
-    run_type.execute(sudo).args(&["/usr/sbin/pkg", "upgrade"]).check_run()
+    let mut command = run_type.execute(sudo);
+
+    command.args(&["/usr/sbin/pkg", "upgrade"]);
+
+    if ctx.config().yes(Step::System) {
+        command.arg("-y");
+    }
+
+    command.check_run()
 }
 
 pub fn audit_packages(sudo: &Option<PathBuf>) -> Result<()> {


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

```
$ cargo clippy
warning: constant `INTEL_BREW` is never used
  --> src/steps/os/unix.rs:20:1
   |
20 | const INTEL_BREW: &str = "/usr/local/bin/brew";
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: constant `ARM_BREW` is never used
  --> src/steps/os/unix.rs:21:1
   |
21 | const ARM_BREW: &str = "/opt/homebrew/bin/brew";
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: associated function `binary_name` is never used
  --> src/steps/os/unix.rs:32:8
   |
32 |     fn binary_name(self) -> &'static str {
   |        ^^^^^^^^^^^

warning: associated function `both_both_exist` is never used
  --> src/steps/os/unix.rs:45:8
   |
45 |     fn both_both_exist() -> bool {
   |        ^^^^^^^^^^^^^^^

warning: associated function `step_title` is never used
  --> src/steps/os/unix.rs:49:12
   |
49 |     pub fn step_title(self) -> &'static str {
   |            ^^^^^^^^^^

warning: associated function `execute` is never used
  --> src/steps/os/unix.rs:58:8
   |
58 |     fn execute(self, run_type: RunType) -> Executor {
   |        ^^^^^^^

warning: function `run_brew_formula` is never used
   --> src/steps/os/unix.rs:219:8
    |
219 | pub fn run_brew_formula(ctx: &ExecutionContext, variant: BrewVariant) -> Result<()> {
    |        ^^^^^^^^^^^^^^^^

warning: `topgrade` (bin "topgrade") generated 7 warnings
    Finished dev [unoptimized + debuginfo] target(s) in 0.28s
```

@ercan1104