### PR TITLE
Add Treesitter support to Vim upgrade

### DIFF
--- a/src/steps/os/freebsd.rs
+++ b/src/steps/os/freebsd.rs
@@ -1,12 +1,12 @@
 use crate::command::CommandExt;
+use crate::config::Step;
+use crate::execution_context::ExecutionContext;
 use crate::executor::RunType;
 use crate::terminal::print_separator;
 use crate::utils::require_option;
 use color_eyre::eyre::Result;
 use std::path::PathBuf;
 use std::process::Command;
-use crate::config::{Step};
-use crate::execution_context::ExecutionContext;
 
 pub fn upgrade_freebsd(sudo: Option<&PathBuf>, run_type: RunType) -> Result<()> {
     let sudo = require_option(sudo, String::from("No sudo detected"))?;

--- a/src/steps/upgrade.vim
+++ b/src/steps/upgrade.vim
@@ -38,6 +38,14 @@ if exists(":CocUpdateSync")
     CocUpdateSync
 endif
 
+" TODO: Should this be after `PackerSync`?
+" Not sure how to sequence this after Packer without doing something weird
+" with that `PackerComplete` autocommand.
+if exists(":TSUpdate")
+    echo "TreeSitter Update"
+    TSUpdate
+endif
+
 if exists(':PackerSync')
   echo "Packer"
   autocmd User PackerComplete quitall


### PR DESCRIPTION
This adds `:TSUpdate` (haha `TS`) to the Vim upgrade script. Fixes #183.

In the future, I'd like the Vim upgrade to display its output. Right now if I show the output, it's kinda messy due to weirdness with some of the plugins I use:

```
―― 14:27:05 - Neovim ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――
Error detected while processing BufWinEnter Autocommands for "*":
E495: no autocommand file name to substitute for "<afile>"
Error detected while processing BufEnter Autocommands for "*"..function <SNR>42_detect_indent:
line   10:
E495: no autocommand file name to substitute for "<afile>"
TreeSitter Update
All parsers are up-to-date!
PackerPlugins upgraded
```

This is due to the way we run Vim (headless).