### PR TITLE
Add `gup`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -323,7 +323,8 @@ fn run() -> Result<()> {
     runner.execute(Step::Choosenim, "choosenim", || generic::run_choosenim(&ctx))?;
     runner.execute(Step::Cargo, "cargo", || generic::run_cargo_update(&ctx))?;
     runner.execute(Step::Flutter, "Flutter", || generic::run_flutter_upgrade(run_type))?;
-    runner.execute(Step::Go, "Go", || generic::run_go(run_type))?;
+    runner.execute(Step::Go, "go-global-update", || go::run_go_global_update(run_type))?;
+    runner.execute(Step::Go, "gup", || go::run_go_gup(run_type))?;
     runner.execute(Step::Emacs, "Emacs", || emacs.upgrade(&ctx))?;
     runner.execute(Step::Opam, "opam", || generic::run_opam_update(&ctx))?;
     runner.execute(Step::Vcpkg, "vcpkg", || generic::run_vcpkg_update(run_type))?;

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -66,20 +66,6 @@ pub fn run_flutter_upgrade(run_type: RunType) -> Result<()> {
     run_type.execute(flutter).arg("upgrade").status_checked()
 }
 
-pub fn run_go(run_type: RunType) -> Result<()> {
-    let go = utils::require("go")?;
-    let go_output = run_type.execute(go).args(["env", "GOPATH"]).output_checked_utf8()?;
-    let gopath = go_output.stdout.trim();
-
-    let go_global_update = utils::require("go-global-update")
-        .unwrap_or_else(|_| PathBuf::from(gopath).join("bin/go-global-update"))
-        .require()?;
-
-    print_separator("Go");
-
-    run_type.execute(go_global_update).status_checked()
-}
-
 pub fn run_gem(base_dirs: &BaseDirs, run_type: RunType) -> Result<()> {
     let gem = utils::require("gem")?;
     base_dirs.home_dir().join(".gem").require()?;

--- a/src/steps/go.rs
+++ b/src/steps/go.rs
@@ -1,0 +1,39 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+use color_eyre::eyre::Result;
+
+use crate::command::CommandExt;
+use crate::executor::RunType;
+use crate::terminal::print_separator;
+use crate::utils;
+use crate::utils::PathExt;
+
+/// <https://github.com/Gelio/go-global-update>
+pub fn run_go_global_update(run_type: RunType) -> Result<()> {
+    let go_global_update = require_go_bin("go-global-update")?;
+
+    print_separator("go-global-update");
+
+    run_type.execute(go_global_update).status_checked()
+}
+
+/// <https://github.com/nao1215/gup>
+pub fn run_go_gup(run_type: RunType) -> Result<()> {
+    let gup = require_go_bin("gup")?;
+
+    print_separator("gup");
+
+    run_type.execute(gup).arg("update").status_checked()
+}
+
+/// Get the path of a Go binary.
+fn require_go_bin(name: &str) -> Result<PathBuf> {
+    let go = utils::require("go")?;
+    let gopath_output = Command::new(go).args(["env", "GOPATH"]).output_checked_utf8()?;
+    let gopath = gopath_output.stdout.trim();
+
+    utils::require(name)
+        .unwrap_or_else(|_| PathBuf::from(gopath).join("bin").join(name))
+        .require()
+}

--- a/src/steps/mod.rs
+++ b/src/steps/mod.rs
@@ -2,6 +2,7 @@ pub mod containers;
 pub mod emacs;
 pub mod generic;
 pub mod git;
+pub mod go;
 pub mod kakoune;
 pub mod node;
 pub mod os;


### PR DESCRIPTION
Fixes #195

I also want to keep splitting stuff out of the `generic` and `unix` modules into shorter, more specific modules (as I've done here with the `go` module).