### PR TITLE
Fix compilation on DragonFly BSD

### DIFF
--- a/src/steps/os/dragonfly.rs
+++ b/src/steps/os/dragonfly.rs
@@ -8,7 +8,7 @@ use std::process::Command;
 
 pub fn upgrade_packages(sudo: Option<&PathBuf>, run_type: RunType) -> Result<()> {
     let sudo = require_option(sudo, String::from("No sudo detected"))?;
-    print_separator("DrgaonFly BSD Packages");
+    print_separator("DragonFly BSD Packages");
     run_type
         .execute(sudo)
         .args(["/usr/local/sbin/pkg", "upgrade"])

--- a/src/steps/os/dragonfly.rs
+++ b/src/steps/os/dragonfly.rs
@@ -1,3 +1,4 @@
+use crate::command::CommandExt;
 use crate::executor::RunType;
 use crate::terminal::print_separator;
 use crate::utils::require_option;
@@ -10,7 +11,7 @@ pub fn upgrade_packages(sudo: Option<&PathBuf>, run_type: RunType) -> Result<()>
     print_separator("DrgaonFly BSD Packages");
     run_type
         .execute(sudo)
-        .args(&["/usr/local/sbin/pkg", "upgrade"])
+        .args(["/usr/local/sbin/pkg", "upgrade"])
         .status_checked()
 }
 
@@ -18,7 +19,7 @@ pub fn audit_packages(sudo: &Option<PathBuf>) -> Result<()> {
     if let Some(sudo) = sudo {
         println!();
         Command::new(sudo)
-            .args(&["/usr/local/sbin/pkg", "audit", "-Fr"])
+            .args(["/usr/local/sbin/pkg", "audit", "-Fr"])
             .status_checked()?;
     }
     Ok(())


### PR DESCRIPTION
CI for DragonFly BSD will have to wait for the next stable release of cross due to [this bug](https://github.com/cross-rs/cross/issues/1141), but I tested the changes locally and they worked.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
