### PR TITLE
CI: Install only necessary components

### DIFF
--- a/.github/workflows/check-and-lint.yaml
+++ b/.github/workflows/check-and-lint.yaml
@@ -23,8 +23,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: '${{ env.RUST_VER }}'
-          targets: ${{ matrix.target }}
-          components: clippy, rustfmt
+          components: rustfmt
 
       - name: Run cargo fmt
         run: |
@@ -72,8 +71,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: '${{ env.RUST_VER }}'
-          targets: ${{ matrix.target }}
-          components: clippy, rustfmt
+          components: clippy
 
       - name: Setup Rust Cache
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
This PR prevents `clippy` from being installed in the Rustfmt job (and vice-versa). It also prevents the (unnecessary) installation of the target toolchain on the host.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
