### PR TITLE
Add `pre_sudo` option

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -13,6 +13,10 @@
 # Do not ask to retry failed steps (default: false)
 #no_retry = true
 
+# Run `sudo -v` to cache credentials at the start of the run; this avoids a
+# blocking password prompt in the middle of a possibly-unattended run.
+#pre_sudo = false
+
 # Run inside tmux
 #run_in_tmux = true
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -269,6 +269,7 @@ pub struct Vim {
 #[serde(deny_unknown_fields)]
 /// Configuration file
 pub struct ConfigFile {
+    pre_sudo: Option<bool>,
     pre_commands: Option<Commands>,
     post_commands: Option<Commands>,
     commands: Option<Commands>,
@@ -945,6 +946,12 @@ impl Config {
             .as_ref()
             .and_then(|windows| windows.open_remotes_in_new_terminal)
             .unwrap_or(false)
+    }
+
+    /// If `true`, `sudo` should be called after `pre_commands` in order to elevate at the
+    /// start of the session (and not in the middle).
+    pub fn pre_sudo(&self) -> bool {
+        self.config_file.pre_sudo.unwrap_or(false)
     }
 
     #[cfg(target_os = "linux")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ mod self_renamer;
 #[cfg(feature = "self-update")]
 mod self_update;
 mod steps;
+mod sudo;
 mod terminal;
 mod utils;
 
@@ -82,7 +83,7 @@ fn run() -> Result<()> {
     let git = git::Git::new();
     let mut git_repos = git::Repositories::new(&git);
 
-    let sudo = utils::sudo();
+    let sudo = sudo::path();
     let run_type = executor::RunType::new(config.dry_run());
 
     let ctx = execution_context::ExecutionContext::new(run_type, &sudo, &git, &config, &base_dirs);
@@ -117,6 +118,10 @@ fn run() -> Result<()> {
         for (name, command) in commands {
             generic::run_custom_command(name, command, &ctx)?;
         }
+    }
+
+    if config.pre_sudo() {
+        sudo::elevate(&ctx, sudo.as_ref())?;
     }
 
     let powershell = powershell::Powershell::new();

--- a/src/steps/node.rs
+++ b/src/steps/node.rs
@@ -4,6 +4,7 @@ use std::os::unix::fs::MetadataExt;
 use std::path::PathBuf;
 use std::process::Command;
 
+use crate::sudo;
 use crate::utils::require_option;
 use color_eyre::eyre::Result;
 #[cfg(target_os = "linux")]
@@ -14,7 +15,6 @@ use tracing::debug;
 use crate::command::CommandExt;
 use crate::executor::RunType;
 use crate::terminal::print_separator;
-use crate::utils::sudo;
 use crate::utils::{require, PathExt};
 use crate::{error::SkipStep, execution_context::ExecutionContext};
 
@@ -93,7 +93,7 @@ impl NPM {
     fn upgrade(&self, run_type: RunType, use_sudo: bool) -> Result<()> {
         let args = ["update", self.global_location_arg()];
         if use_sudo {
-            let sudo_option = sudo();
+            let sudo_option = sudo::path();
             let sudo = require_option(sudo_option, String::from("sudo is not installed"))?;
             run_type.execute(sudo).arg(&self.command).args(args).status_checked()?;
         } else {

--- a/src/sudo.rs
+++ b/src/sudo.rs
@@ -1,0 +1,34 @@
+use std::path::PathBuf;
+
+use color_eyre::eyre::Context;
+use color_eyre::eyre::Result;
+
+use crate::command::CommandExt;
+use crate::execution_context::ExecutionContext;
+use crate::terminal::print_separator;
+use crate::utils::which;
+
+/// Get the path of the `sudo` utility.
+///
+/// Detects `doas`, `sudo`, `gsudo`, or `pkexec`.
+pub fn path() -> Option<PathBuf> {
+    which("doas")
+        .or_else(|| which("sudo"))
+        .or_else(|| which("gsudo"))
+        .or_else(|| which("pkexec"))
+}
+
+/// Elevate permissions with `sudo`.
+pub fn elevate(ctx: &ExecutionContext, sudo: Option<&PathBuf>) -> Result<()> {
+    if let Some(sudo) = sudo {
+        print_separator("Sudo");
+        ctx.run_type()
+            .execute(sudo)
+            // TODO: Does this work with `doas`, `pkexec`, `gsudo`, GNU `sudo`...?
+            .arg("-v")
+            .status_checked()
+            .wrap_err("Failed to elevate permissions")?;
+    }
+
+    Ok(())
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -67,13 +67,6 @@ pub fn which<T: AsRef<OsStr> + Debug>(binary_name: T) -> Option<PathBuf> {
     }
 }
 
-pub fn sudo() -> Option<PathBuf> {
-    which("doas")
-        .or_else(|| which("sudo"))
-        .or_else(|| which("gsudo"))
-        .or_else(|| which("pkexec"))
-}
-
 pub fn editor() -> Vec<String> {
     env::var("EDITOR")
         .unwrap_or_else(|_| String::from(if cfg!(windows) { "notepad" } else { "vi" }))


### PR DESCRIPTION
Closes #205 by adding a `pre_sudo` option (defaults to `false`) which calls `sudo -v` after any `pre_commands` in order to update the current session's cached credentials. 