### PR TITLE
Add garuda-update

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -223,6 +223,7 @@ pub struct Brew {
 #[derive(Debug, Deserialize, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum ArchPackageManager {
+    GarudaUpdate,
     Autodetect,
     Trizen,
     Paru,

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -202,7 +202,6 @@ pub fn run_juliaup(base_dirs: &BaseDirs, run_type: RunType) -> Result<()> {
     }
 
     run_type.execute(&juliaup).arg("update").status_checked()
-
 }
 
 pub fn run_choosenim(ctx: &ExecutionContext) -> Result<()> {

--- a/src/steps/os/archlinux.rs
+++ b/src/steps/os/archlinux.rs
@@ -70,6 +70,27 @@ impl YayParu {
     }
 }
 
+pub struct GarudaUpdate {
+    executable: PathBuf,
+}
+
+impl ArchPackageManager for GarudaUpdate {
+    fn upgrade(&self, ctx: &ExecutionContext) -> Result<()> {
+        let mut command = ctx.run_type().execute(&self.executable);
+        command.env("PATH", get_execution_path());
+        command.status_checked()?;
+        Ok(())
+    }
+}
+
+impl GarudaUpdate {
+    fn get() -> Option<Self> {
+        Some(Self {
+            executable: which("garuda-update")?,
+        })
+    }
+}
+
 pub struct Trizen {
     executable: PathBuf,
 }
@@ -282,14 +303,16 @@ pub fn get_arch_package_manager(ctx: &ExecutionContext) -> Option<Box<dyn ArchPa
     let pacman = which("powerpill").unwrap_or_else(|| PathBuf::from("pacman"));
 
     match ctx.config().arch_package_manager() {
-        config::ArchPackageManager::Autodetect => YayParu::get("paru", &pacman)
+        config::ArchPackageManager::Autodetect => GarudaUpdate::get()
             .map(box_package_manager)
+            .or_else(|| YayParu::get("paru", &pacman).map(box_package_manager))
             .or_else(|| YayParu::get("yay", &pacman).map(box_package_manager))
             .or_else(|| Trizen::get().map(box_package_manager))
             .or_else(|| Pikaur::get().map(box_package_manager))
             .or_else(|| Pamac::get().map(box_package_manager))
             .or_else(|| Pacman::get(ctx).map(box_package_manager))
             .or_else(|| Aura::get(ctx).map(box_package_manager)),
+        config::ArchPackageManager::GarudaUpdate => GarudaUpdate::get().map(box_package_manager),
         config::ArchPackageManager::Trizen => Trizen::get().map(box_package_manager),
         config::ArchPackageManager::Paru => YayParu::get("paru", &pacman).map(box_package_manager),
         config::ArchPackageManager::Yay => YayParu::get("yay", &pacman).map(box_package_manager),


### PR DESCRIPTION
if garuda-update is in our path use that instead of directly calling pacman/paru/powerpill. There's more stuff the update script does that you're just asking for problems if you upgrade partially.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

I created a feature request here:
https://github.com/topgrade-rs/topgrade/issues/226