### PR TITLE
Fix clippy warning for DragonFly BSD

### DIFF
--- a/src/steps/os/dragonfly.rs
+++ b/src/steps/os/dragonfly.rs
@@ -4,7 +4,6 @@ use crate::sudo::Sudo;
 use crate::terminal::print_separator;
 use crate::utils::require_option;
 use color_eyre::eyre::Result;
-use std::path::PathBuf;
 use std::process::Command;
 
 pub fn upgrade_packages(sudo: Option<&Sudo>, run_type: RunType) -> Result<()> {


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
