### PR TITLE
Ignore return code `1` from `paru` when checking for news

### DIFF
--- a/src/steps/os/archlinux.rs
+++ b/src/steps/os/archlinux.rs
@@ -1,7 +1,6 @@
 use std::env::var_os;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 use color_eyre::eyre;
 use color_eyre::eyre::Result;
@@ -32,7 +31,11 @@ pub struct YayParu {
 impl ArchPackageManager for YayParu {
     fn upgrade(&self, ctx: &ExecutionContext) -> Result<()> {
         if ctx.config().show_arch_news() {
-            Command::new(&self.executable).arg("-Pw").status_checked()?;
+            let mut command = ctx.run_type().execute(&self.executable);
+            command
+                .arg("-Pw")
+                .env("PATH", get_execution_path())
+                .status_checked_with_codes(&[0, 1])?;
         }
 
         let mut command = ctx.run_type().execute(&self.executable);


### PR DESCRIPTION
Running `paru -Pw` can return `1` if there are no new Arch Linux news.

Let's just ignore it.

Fixes #234

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
