### PR TITLE
Fix misleading log message when detecting rbenv

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -93,8 +93,10 @@ pub fn run_rubygems(base_dirs: &BaseDirs, run_type: RunType) -> Result<()> {
     command.args(["update", "--system"]);
 
     if env::var_os("RBENV_SHELL").is_none() {
-        debug!("Detected rbenv. Avoiding --user-install");
+        debug!("Did not detect rbenv. Adding --user-install");
         command.arg("--user-install");
+    } else {
+        debug!("Detected rbenv. Avoiding --user-install");
     }
 
     command.status_checked()


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

This is a follow-up to a review comment added in https://github.com/topgrade-rs/topgrade/pull/248#discussion_r1039102177

cc @mouse07410 @DottoDev
