### PR TITLE
adds fish_update_completions to fish step

### DIFF
--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -102,6 +102,12 @@ pub fn run_fisher(run_type: RunType) -> Result<()> {
         .and_then(|output| Path::new(&output.stdout.trim()).require().map(|_| ()))
         .map_err(|err| SkipStep(format!("`fish_plugins` path doesn't exist: {err}")))?;
 
+    Command::new(&fish)
+        .args(["-c", "fish_update_completions"])
+        .output_checked_utf8()
+        .map(|_| ())
+        .map_err(|_| SkipStep("`fish_update_completions` is not available".to_owned()))?;
+
     print_separator("Fisher");
 
     let version_str = run_type


### PR DESCRIPTION
Closes #261 

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
@bagel897 please test
