### PR TITLE
Don't show desktop notification on error (if `skip_notify = true`)

### DIFF
--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -237,7 +237,9 @@ impl Terminal {
             self.term.set_title("Topgrade - Awaiting user");
         }
 
-        self.notify_desktop(format!("{} failed", step_name), None);
+        if self.desktop_notification {
+            self.notify_desktop(format!("{} failed", step_name), None);
+        }
 
         let prompt_inner = style(format!("{}Retry? (y)es/(N)o/(s)hell/(q)uit", self.prefix))
             .yellow()


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
