### PR TITLE
Make garuda-update update AUR packages by default

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -82,6 +82,7 @@
 #dnf_arguments = "--refresh"
 #aura_aur_arguments = "-kx"
 #aura_pacman_arguments = ""
+#garuda_update_arguments = ""
 #show_arch_news = true
 #trizen_arguments = "--devel"
 #pikaur_arguments = ""

--- a/config.example.toml
+++ b/config.example.toml
@@ -74,7 +74,7 @@
 #autoremove = true
 
 [linux]
-# Arch Package Manager to use. Allowed values: autodetect, trizen, aura, paru, yay, pikaur, pacman, pamac.
+# Arch Package Manager to use. Allowed values: autodetect, aura, garuda_update, pacman, pamac, paru, pikaur, trizen, yay.
 #arch_package_manager = "pacman"
 # Arguments to pass yay (or paru) when updating packages
 #yay_arguments = "--nodevel"

--- a/src/config.rs
+++ b/src/config.rs
@@ -231,15 +231,15 @@ pub struct Brew {
 #[derive(Debug, Deserialize, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum ArchPackageManager {
-    GarudaUpdate,
     Autodetect,
-    Trizen,
-    Paru,
-    Yay,
-    Pacman,
-    Pikaur,
-    Pamac,
     Aura,
+    GarudaUpdate,
+    Pacman,
+    Pamac,
+    Paru,
+    Pikaur,
+    Trizen,
+    Yay,
 }
 
 #[derive(Deserialize, Default, Debug)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -250,6 +250,7 @@ pub struct Linux {
     aura_pacman_arguments: Option<String>,
     arch_package_manager: Option<ArchPackageManager>,
     show_arch_news: Option<bool>,
+    garuda_update_arguments: Option<String>,
     trizen_arguments: Option<String>,
     pikaur_arguments: Option<String>,
     pamac_arguments: Option<String>,
@@ -779,6 +780,15 @@ impl Config {
     /// Whether to send a desktop notification at the beginning of every step
     pub fn notify_each_step(&self) -> bool {
         self.config_file.notify_each_step.unwrap_or(false)
+    }
+
+    /// Extra garuda-update arguments
+    pub fn garuda_update_arguments(&self) -> &str {
+        self.config_file
+            .linux
+            .as_ref()
+            .and_then(|s| s.garuda_update_arguments.as_deref())
+            .unwrap_or("")
     }
 
     /// Extra trizen arguments

--- a/src/steps/os/archlinux.rs
+++ b/src/steps/os/archlinux.rs
@@ -89,6 +89,7 @@ impl ArchPackageManager for GarudaUpdate {
         if ctx.config().yes(Step::System) {
             command.env("PACMAN_NOCONFIRM", "1");
         }
+        command.args(ctx.config().garuda_update_arguments().split_whitespace());
         command.status_checked()?;
 
         Ok(())

--- a/src/steps/os/archlinux.rs
+++ b/src/steps/os/archlinux.rs
@@ -86,6 +86,9 @@ impl ArchPackageManager for GarudaUpdate {
             .env("UPDATE_AUR", "1")
             .env("SKIP_MIRRORLIST", "1");
 
+        if ctx.config().yes(Step::System) {
+            command.env("PACMAN_NOCONFIRM", "1");
+        }
         command.status_checked()?;
 
         Ok(())

--- a/src/steps/os/archlinux.rs
+++ b/src/steps/os/archlinux.rs
@@ -80,8 +80,14 @@ pub struct GarudaUpdate {
 impl ArchPackageManager for GarudaUpdate {
     fn upgrade(&self, ctx: &ExecutionContext) -> Result<()> {
         let mut command = ctx.run_type().execute(&self.executable);
-        command.env("PATH", get_execution_path());
+
+        command
+            .env("PATH", get_execution_path())
+            .env("UPDATE_AUR", "1")
+            .env("SKIP_MIRRORLIST", "1");
+
         command.status_checked()?;
+
         Ok(())
     }
 }


### PR DESCRIPTION
By default, `garuda-update` only updates system packages, which in my opinion is not a good default behavior for us.

Additionally, it also updates the repositories' mirror list every time, slowing things down considerably, so I decided to disable this behavior. 

According to their [wiki page](https://wiki.garudalinux.org/en/garuda-update), and based on a cursory reading I did of their [update script](https://gitlab.com/garuda-linux/packages/stable-pkgbuilds/garuda-update/-/blob/59fd4b1e4f4887d23fcb1ac9603b497e4b2f89d7/main-update), this behavior can be changed in the following order of preference:

1. Environment variables.
2. `/etc/garuda/garuda-update/config`.
3. Command-line arguments passed to `garuda-update` directly.

I decided to go with the first option, so that topgrade users can easily change this new default behavior, if they wish.

A new option to forward arguments to `garuda-update` was also added, and documented in `config.example.toml`.

Fixes #284

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
