### PR TITLE
Fix missing separator for Pkgin (pkgsrc)

### DIFF
--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -152,6 +152,8 @@ pub fn run_oh_my_fish(ctx: &ExecutionContext) -> Result<()> {
 pub fn run_pkgin(ctx: &ExecutionContext) -> Result<()> {
     let pkgin = require("pkgin")?;
 
+    print_separator("Pkgin");
+    
     let mut command = ctx.run_type().execute(ctx.sudo().as_ref().unwrap());
     command.arg(&pkgin).arg("update");
     if ctx.config().yes(Step::Pkgin) {

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -153,7 +153,7 @@ pub fn run_pkgin(ctx: &ExecutionContext) -> Result<()> {
     let pkgin = require("pkgin")?;
 
     print_separator("Pkgin");
-    
+
     let mut command = ctx.run_type().execute(ctx.sudo().as_ref().unwrap());
     command.arg(&pkgin).arg("update");
     if ctx.config().yes(Step::Pkgin) {


### PR DESCRIPTION
## Standards checklist:

- [*] The PR title is descriptive.
- [*] The code compiles (`cargo build`)
- [*] The code passes rustfmt (`cargo fmt`)
- [*] The code passes clippy (`cargo clippy`)
- [*] The code passes tests (`cargo test`)
- [*] *Optional:* I have tested the code myself
    - [*] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
