### PR TITLE
Don't run yum when rpm-ostree is available

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -942,7 +942,7 @@ impl Config {
             .linux
             .as_ref()
             .and_then(|linux| linux.rpm_ostree)
-            .unwrap_or(false)
+            .unwrap_or(true)
     }
 
     /// Should we ignore failures for this step

--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -175,7 +175,9 @@ fn upgrade_redhat(ctx: &ExecutionContext) -> Result<()> {
             command.arg("upgrade");
             return command.status_checked();
         }
-    } else if let Some(sudo) = &ctx.sudo() {
+    };
+
+    if let Some(sudo) = &ctx.sudo() {
         let mut command = ctx.run_type().execute(sudo);
         command
             .arg(which("dnf").unwrap_or_else(|| Path::new("yum").to_path_buf()))

--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -172,31 +172,30 @@ fn upgrade_redhat(ctx: &ExecutionContext) -> Result<()> {
             command.arg("upgrade");
             return command.status_checked();
         }
-    };
-
-    if let Some(sudo) = &ctx.sudo() {
-        let mut command = ctx.run_type().execute(sudo);
-        command
-            .arg(which("dnf").unwrap_or_else(|| Path::new("yum").to_path_buf()))
-            .arg(if ctx.config().redhat_distro_sync() {
-                "distro-sync"
-            } else {
-                "upgrade"
-            });
-
-        if let Some(args) = ctx.config().dnf_arguments() {
-            command.args(args.split_whitespace());
-        }
-
-        if ctx.config().yes(Step::System) {
-            command.arg("-y");
-        }
-
-        command.status_checked()?;
     } else {
-        print_warning("No sudo detected. Skipping system upgrade");
-    }
+        if let Some(sudo) = &ctx.sudo() {
+            let mut command = ctx.run_type().execute(sudo);
+            command
+                .arg(which("dnf").unwrap_or_else(|| Path::new("yum").to_path_buf()))
+                .arg(if ctx.config().redhat_distro_sync() {
+                    "distro-sync"
+                } else {
+                    "upgrade"
+                });
 
+            if let Some(args) = ctx.config().dnf_arguments() {
+                command.args(args.split_whitespace());
+            }
+
+            if ctx.config().yes(Step::System) {
+                command.arg("-y");
+            }
+
+            command.status_checked()?;
+        } else {
+            print_warning("No sudo detected. Skipping system upgrade");
+        }
+    }
     Ok(())
 }
 

--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -172,29 +172,27 @@ fn upgrade_redhat(ctx: &ExecutionContext) -> Result<()> {
             command.arg("upgrade");
             return command.status_checked();
         }
-    } else {
-        if let Some(sudo) = &ctx.sudo() {
-            let mut command = ctx.run_type().execute(sudo);
-            command
-                .arg(which("dnf").unwrap_or_else(|| Path::new("yum").to_path_buf()))
-                .arg(if ctx.config().redhat_distro_sync() {
-                    "distro-sync"
-                } else {
-                    "upgrade"
-                });
+    } else if let Some(sudo) = &ctx.sudo() {
+        let mut command = ctx.run_type().execute(sudo);
+        command
+            .arg(which("dnf").unwrap_or_else(|| Path::new("yum").to_path_buf()))
+            .arg(if ctx.config().redhat_distro_sync() {
+                "distro-sync"
+            } else {
+                "upgrade"
+            });
 
-            if let Some(args) = ctx.config().dnf_arguments() {
-                command.args(args.split_whitespace());
-            }
-
-            if ctx.config().yes(Step::System) {
-                command.arg("-y");
-            }
-
-            command.status_checked()?;
-        } else {
-            print_warning("No sudo detected. Skipping system upgrade");
+        if let Some(args) = ctx.config().dnf_arguments() {
+            command.args(args.split_whitespace());
         }
+
+        if ctx.config().yes(Step::System) {
+            command.arg("-y");
+        }
+
+        command.status_checked()?;
+    } else {
+        print_warning("No sudo detected. Skipping system upgrade");
     }
     Ok(())
 }


### PR DESCRIPTION
Closes #308 
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
