### PR TITLE
Adds notify-send timeout of 10s

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 use std::env;
 use std::io;
 use std::process::exit;
+use std::time::Duration;
 
 use clap::CommandFactory;
 use clap::{crate_version, Parser};
@@ -517,8 +518,8 @@ fn run() -> Result<()> {
                 "Topgrade finished {}",
                 if failed { "with errors" } else { "successfully" }
             ),
-            None,
-        );
+            Some(Duration::from_secs(10)),
+        )
     }
 
     if failed {


### PR DESCRIPTION
Closes #288 
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
