### PR TITLE
Fix small typo in warning when `notify-send` fails

### DIFF
--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -106,7 +106,7 @@ impl Terminal {
                     command.args(["-a", "Topgrade", "Topgrade"]);
                     command.arg(message.as_ref());
                     if let Err(err) = command.output_checked() {
-                        terminal::print_warning("Senfing notification failed with {err:?}");
+                        terminal::print_warning("Sending notification failed with {err:?}");
                     }
                 }
             }


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
