### PR TITLE
fix upgrade order of (n)vim plugins

### DIFF
--- a/src/steps/upgrade.vim
+++ b/src/steps/upgrade.vim
@@ -39,7 +39,7 @@ function! UpdateCoCAndTS()
         CocUpdateSync
     endif
 
-    if exists(":TSUpdate")
+    if exists(":TSUpdateSync")
         echo "TreeSitter Update"
         TSUpdate
     endif

--- a/src/steps/upgrade.vim
+++ b/src/steps/upgrade.vim
@@ -33,23 +33,24 @@ if exists(":PaqUpdate")
     PaqUpdate
 endif
 
-if exists(":CocUpdateSync")
-    echo "CocUpdateSync"
-    CocUpdateSync
-endif
+function! UpdateCoCAndTS()
+    if exists(":CocUpdateSync")
+        echo "CocUpdateSync"
+        CocUpdateSync
+    endif
 
-" TODO: Should this be after `PackerSync`?
-" Not sure how to sequence this after Packer without doing something weird
-" with that `PackerComplete` autocommand.
-if exists(":TSUpdate")
-    echo "TreeSitter Update"
-    TSUpdate
-endif
+    if exists(":TSUpdate")
+        echo "TreeSitter Update"
+        TSUpdate
+    endif
+
+    quitall
+endfunction
 
 if exists(':PackerSync')
-  echo "Packer"
-  autocmd User PackerComplete quitall
-  PackerSync
+    echo "Packer"
+    autocmd User PackerComplete * call UpdateCoCAndTS()
+    PackerSync
 else
-  quitall
+    call UpdateCoCAndTS()
 endif


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo`)
