### PR TITLE
Adds notify-send bug warning when topgrade is run

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -44,6 +44,9 @@
 # Skip sending a notification at the end of a run
 #skip_notify = true
 
+# Skip the preamble displayed when topgrade is run
+#display_preamble = false
+
 [git]
 #max_concurrency = 5
 # Additional git repositories to pull

--- a/src/config.rs
+++ b/src/config.rs
@@ -294,7 +294,7 @@ pub struct ConfigFile {
     tmux_arguments: Option<String>,
     set_title: Option<bool>,
     display_time: Option<bool>,
-    display_preambe: Option<bool>,
+    display_preamble: Option<bool>,
     assume_yes: Option<bool>,
     yay_arguments: Option<String>,
     aura_aur_arguments: Option<String>,
@@ -1052,7 +1052,7 @@ impl Config {
     }
 
     pub fn display_preamble(&self) -> bool {
-        self.config_file.display_preambe.unwrap_or(true)
+        self.config_file.display_preamble.unwrap_or(true)
     }
 
     pub fn should_run_custom_command(&self, name: &str) -> bool {

--- a/src/config.rs
+++ b/src/config.rs
@@ -294,6 +294,7 @@ pub struct ConfigFile {
     tmux_arguments: Option<String>,
     set_title: Option<bool>,
     display_time: Option<bool>,
+    display_preambe: Option<bool>,
     assume_yes: Option<bool>,
     yay_arguments: Option<String>,
     aura_aur_arguments: Option<String>,
@@ -1048,6 +1049,10 @@ impl Config {
 
     pub fn display_time(&self) -> bool {
         self.config_file.display_time.unwrap_or(true)
+    }
+
+    pub fn display_preamble(&self) -> bool {
+        self.config_file.display_preambe.unwrap_or(true)
     }
 
     pub fn should_run_custom_command(&self, name: &str) -> bool {

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,6 +86,13 @@ fn run() -> Result<()> {
     debug!("Binary path: {:?}", std::env::current_exe());
     debug!("Self Update: {:?}", cfg!(feature = "self-update"));
 
+    if config.display_preamble() {
+        print_warning(format!("Due to a design issue with notify-send it could be that topgrade hangs when it's finished.
+If this is the case on your system add the --skip-notify flag to the topgrade command or set skip_notify = true in the config file.
+If you don't want this message to appear any longer set display_preamble = false in the config file.
+For more information about this issue see https://askubuntu.com/questions/110969/notify-send-ignores-timeout and https://github.com/topgrade-rs/topgrade/issues/288."));
+    }
+
     if config.run_in_tmux() && env::var("TOPGRADE_INSIDE_TMUX").is_err() {
         #[cfg(unix)]
         {

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,10 +87,10 @@ fn run() -> Result<()> {
     debug!("Self Update: {:?}", cfg!(feature = "self-update"));
 
     if config.display_preamble() {
-        print_warning(format!("Due to a design issue with notify-send it could be that topgrade hangs when it's finished.
+        print_warning("Due to a design issue with notify-send it could be that topgrade hangs when it's finished.
 If this is the case on your system add the --skip-notify flag to the topgrade command or set skip_notify = true in the config file.
 If you don't want this message to appear any longer set display_preamble = false in the config file.
-For more information about this issue see https://askubuntu.com/questions/110969/notify-send-ignores-timeout and https://github.com/topgrade-rs/topgrade/issues/288."));
+For more information about this issue see https://askubuntu.com/questions/110969/notify-send-ignores-timeout and https://github.com/topgrade-rs/topgrade/issues/288.");
     }
 
     if config.run_in_tmux() && env::var("TOPGRADE_INSIDE_TMUX").is_err() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,7 +86,7 @@ fn run() -> Result<()> {
     debug!("Binary path: {:?}", std::env::current_exe());
     debug!("Self Update: {:?}", cfg!(feature = "self-update"));
 
-    if config.display_preamble() {
+    if config.display_preamble() || !config.skip_notify() {
         print_warning("Due to a design issue with notify-send it could be that topgrade hangs when it's finished.
 If this is the case on your system add the --skip-notify flag to the topgrade command or set skip_notify = true in the config file.
 If you don't want this message to appear any longer set display_preamble = false in the config file.

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 use std::env;
 use std::io;
 use std::process::exit;
+use std::time::Duration;
 
 use clap::CommandFactory;
 use clap::{crate_version, Parser};
@@ -517,8 +518,8 @@ fn run() -> Result<()> {
                 "Topgrade finished {}",
                 if failed { "with errors" } else { "successfully" }
             ),
-            None,
-        );
+            Some(Duration::from_secs(10)),
+        )
     }
 
     if failed {


### PR DESCRIPTION
Closes #288 
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
