### PR TITLE
nix: Adds additional arguments support

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -95,6 +95,7 @@
 #emerge_update_flags = "-uDNa --with-bdeps=y world"
 #redhat_distro_sync = false
 #rpm_ostree = false
+#nix_arguments = "--flake"
 
 [windows]
 # Manually select Windows updates

--- a/src/config.rs
+++ b/src/config.rs
@@ -255,6 +255,7 @@ pub struct Linux {
     pikaur_arguments: Option<String>,
     pamac_arguments: Option<String>,
     dnf_arguments: Option<String>,
+    nix_arguments: Option<String>,
     apt_arguments: Option<String>,
     enable_tlmgr: Option<bool>,
     redhat_distro_sync: Option<bool>,
@@ -877,6 +878,14 @@ impl Config {
             .linux
             .as_ref()
             .and_then(|linux| linux.dnf_arguments.as_deref())
+    }
+
+    /// Extra nix arguments
+    pub fn nix_arguments(&self) -> Option<&str> {
+        self.config_file
+            .linux
+            .as_ref()
+            .and_then(|linux| linux.nix_arguments.as_deref())
     }
 
     /// Distrobox use root

--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -510,10 +510,13 @@ fn upgrade_exherbo(ctx: &ExecutionContext) -> Result<()> {
 
 fn upgrade_nixos(ctx: &ExecutionContext) -> Result<()> {
     if let Some(sudo) = ctx.sudo() {
-        ctx.run_type()
-            .execute(sudo)
-            .args(["/run/current-system/sw/bin/nixos-rebuild", "switch", "--upgrade"])
-            .status_checked()?;
+        let mut command = ctx.run_type().execute(sudo);
+        command.args(["/run/current-system/sw/bin/nixos-rebuild", "switch", "--upgrade"]);
+
+        if let Some(args) = ctx.config().nix_arguments() {
+            command.args(args.split_whitespace());
+        }
+        command.status_checked()?;
 
         if ctx.config().cleanup() {
             ctx.run_type()


### PR DESCRIPTION
Closes #323 

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
