### PR TITLE
fix ignored config `display_preamble = false`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -86,7 +86,7 @@ fn run() -> Result<()> {
     debug!("Binary path: {:?}", std::env::current_exe());
     debug!("Self Update: {:?}", cfg!(feature = "self-update"));
 
-    if config.display_preamble() || !config.skip_notify() {
+    if config.display_preamble() && !config.skip_notify() {
         print_warning("Due to a design issue with notify-send it could be that topgrade hangs when it's finished.
 If this is the case on your system add the --skip-notify flag to the topgrade command or set skip_notify = true in the config file.
 If you don't want this message to appear any longer set display_preamble = false in the config file.


### PR DESCRIPTION
Bug was introduced in f1e4009. Fixes #337.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
