### PR TITLE
run_custom_command: use interactive shell on unix

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -467,7 +467,10 @@ pub fn run_myrepos_update(base_dirs: &BaseDirs, run_type: RunType) -> Result<()>
 
 pub fn run_custom_command(name: &str, command: &str, ctx: &ExecutionContext) -> Result<()> {
     print_separator(name);
-    ctx.run_type().execute(shell()).arg("-c").arg(command).status_checked()
+    let mut exec = ctx.run_type().execute(shell());
+    #[cfg(unix)]
+    exec.arg("-i");
+    exec.arg("-c").arg(command).status_checked()
 }
 
 pub fn run_composer_update(ctx: &ExecutionContext) -> Result<()> {


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

Tested on macOS 13.2 (M1 Pro) with homebrew zsh.