### PR TITLE
apt: Recognise mist

### DIFF
--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -362,6 +362,13 @@ fn upgrade_debian(ctx: &ExecutionContext) -> Result<()> {
     if let Some(sudo) = &ctx.sudo() {
         let apt = which("apt-fast")
             .or_else(|| {
+                if which("mist").is_some() {
+                    Some(PathBuf::from("mist"))
+                } else {
+                    None
+                }
+            })
+            .or_else(|| {
                 if Path::new("/usr/bin/nala").exists() {
                     Some(Path::new("/usr/bin/nala").to_path_buf())
                 } else {


### PR DESCRIPTION
Closes #207 
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
