### PR TITLE
Silence misleading warning on other platforms.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -86,6 +86,7 @@ fn run() -> Result<()> {
     debug!("Binary path: {:?}", std::env::current_exe());
     debug!("Self Update: {:?}", cfg!(feature = "self-update"));
 
+    #[cfg(target_os = "linux")]
     if config.display_preamble() && !config.skip_notify() {
         print_warning("Due to a design issue with notify-send it could be that topgrade hangs when it's finished.
 If this is the case on your system add the --skip-notify flag to the topgrade command or set skip_notify = true in the config file.


### PR DESCRIPTION
## Standards checklist:

- [ x] The PR title is descriptive.
- [ x] The code compiles (`cargo build`)
- [ x] The code passes rustfmt (`cargo fmt`)
- [ x] The code passes clippy (`cargo clippy`)
- [ x] The code passes tests (`cargo test`)
- [ x] *Optional:* I have tested the code myself
    - [x ] I also tested that Topgrade skips the step where needed

# Why:
On macos I got the warning about `notify-send` and had no idea macos even used it.

Turns out, it doesn't. My arch boxes do tho. So I tweaked things such that the warning only appears on linux hosts vs say unix or macos hosts.

Tested it on my macs and didn't get the warning. Tested it on arch and was dutifully warned.

There's probably a slicker way to do do it than a #cfg block, but hey, this works. I'm pretty sure this will do the right thing on windows boxes too but don't have one to test. It's one line of condition checking.
