### PR TITLE
skip skip-notify warning on Win

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -87,11 +87,13 @@ fn run() -> Result<()> {
     debug!("Self Update: {:?}", cfg!(feature = "self-update"));
 
     #[cfg(target_os = "linux")]
-    if config.display_preamble() && !config.skip_notify() {
-        print_warning("Due to a design issue with notify-send it could be that topgrade hangs when it's finished.
+    {
+        if config.display_preamble() && !config.skip_notify() {
+            print_warning("Due to a design issue with notify-send it could be that topgrade hangs when it's finished.
 If this is the case on your system add the --skip-notify flag to the topgrade command or set skip_notify = true in the config file.
 If you don't want this message to appear any longer set display_preamble = false in the config file.
 For more information about this issue see https://askubuntu.com/questions/110969/notify-send-ignores-timeout and https://github.com/topgrade-rs/topgrade/issues/288.");
+        }
     }
 
     if config.run_in_tmux() && env::var("TOPGRADE_INSIDE_TMUX").is_err() {


### PR DESCRIPTION
Closes #357 

# Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
