### PR TITLE
pacdef: support new version 1.x

### DIFF
--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -472,14 +472,14 @@ pub fn run_pacdef(ctx: &ExecutionContext) -> Result<()> {
         ctx.run_type()
             .execute(&pacdef)
             .args(["package", "review"])
-            .status_checked()
+            .status_checked()?;
     } else {
         ctx.run_type().execute(&pacdef).arg("sync").status_checked()?;
 
         println!();
-        ctx.run_type().execute(&pacdef).arg("review").status_checked()
+        ctx.run_type().execute(&pacdef).arg("review").status_checked()?;
     }
-
+    Ok(())
 }
 
 pub fn run_pacstall(ctx: &ExecutionContext) -> Result<()> {

--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -458,10 +458,28 @@ pub fn run_pacdef(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("pacdef");
 
-    ctx.run_type().execute(&pacdef).arg("sync").status_checked()?;
+    let output = ctx.run_type().execute(&pacdef).arg("version").output_checked()?;
+    let string = String::from_utf8(output.stdout)?;
+    let new_version = string.contains("version: 1");
 
-    println!();
-    ctx.run_type().execute(&pacdef).arg("review").status_checked()
+    if new_version {
+        ctx.run_type()
+            .execute(&pacdef)
+            .args(["package", "sync"])
+            .status_checked()?;
+
+        println!();
+        ctx.run_type()
+            .execute(&pacdef)
+            .args(["package", "review"])
+            .status_checked()
+    } else {
+        ctx.run_type().execute(&pacdef).arg("sync").status_checked()?;
+
+        println!();
+        ctx.run_type().execute(&pacdef).arg("review").status_checked()
+    }
+
 }
 
 pub fn run_pacstall(ctx: &ExecutionContext) -> Result<()> {


### PR DESCRIPTION
`pacdef` will release a new major version in the near future. Part of the release is a breaking change for the command line arguments.

This commit checks which version of pacdef is installed by parsing `pacdef version`, and uses either the old or the new syntax.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
