### PR TITLE
cargo: add cleanup step (using cargo-cache)

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -56,7 +56,24 @@ pub fn run_cargo_update(ctx: &ExecutionContext) -> Result<()> {
     ctx.run_type()
         .execute(cargo_update)
         .args(["install-update", "--git", "--all"])
-        .status_checked()
+        .status_checked()?;
+
+    if ctx.config().cleanup() {
+        let cargo_cache = utils::require("cargo-cache")
+            .ok()
+            .or_else(|| cargo_dir.join("bin/cargo-cache").if_exists());
+        match cargo_cache {
+            Some(e) => {
+                ctx.run_type().execute(e).args(["-a"]).status_checked()?;
+            }
+            None => {
+                let message = String::from("cargo-cache isn't installed so Topgrade can't cleanup cargo packages.\nInstall cargo-cache by running `cargo install cargo-cache`");
+                print_warning(message);
+            }
+        }
+    }
+
+    Ok(())
 }
 
 pub fn run_flutter_upgrade(run_type: RunType) -> Result<()> {


### PR DESCRIPTION
This PR adds a cleanup step for cargo using the cargo-cache crate if cleanup is enabled in the configs. It will also warn the user if cargo-clean is not found, similar to cargo-install-update.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
