### PR TITLE
Add sudo_command option

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -13,6 +13,9 @@
 # Do not ask to retry failed steps (default: false)
 #no_retry = true
 
+# Sudo command to be used
+#sudo_command = "sudo"
+
 # Run `sudo -v` to cache credentials at the start of the run; this avoids a
 # blocking password prompt in the middle of a possibly-unattended run.
 #pre_sudo = false

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,7 @@ use tracing::debug;
 use which_crate::which;
 
 use crate::command::CommandExt;
+use crate::sudo::SudoKind;
 
 use super::utils::{editor, hostname};
 
@@ -293,6 +294,7 @@ pub struct Vim {
 #[serde(deny_unknown_fields)]
 /// Configuration file
 pub struct ConfigFile {
+    sudo_command: Option<SudoKind>,
     pre_sudo: Option<bool>,
     pre_commands: Option<Commands>,
     post_commands: Option<Commands>,
@@ -1015,6 +1017,10 @@ impl Config {
             .as_ref()
             .and_then(|windows| windows.open_remotes_in_new_terminal)
             .unwrap_or(false)
+    }
+
+    pub fn sudo_command(&self) -> Option<SudoKind> {
+        self.config_file.sudo_command
     }
 
     /// If `true`, `sudo` should be called after `pre_commands` in order to elevate at the

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,7 +107,7 @@ For more information about this issue see https://askubuntu.com/questions/110969
     let git = git::Git::new();
     let mut git_repos = git::Repositories::new(&git);
 
-    let sudo = sudo::Sudo::detect();
+    let sudo = config.sudo_command().map_or_else(sudo::Sudo::detect, sudo::Sudo::new);
     let run_type = executor::RunType::new(config.dry_run());
 
     let ctx = execution_context::ExecutionContext::new(run_type, sudo, &git, &config, &base_dirs);

--- a/src/sudo.rs
+++ b/src/sudo.rs
@@ -4,6 +4,8 @@ use std::path::PathBuf;
 
 use color_eyre::eyre::Context;
 use color_eyre::eyre::Result;
+use serde::Deserialize;
+use strum::AsRefStr;
 
 use crate::command::CommandExt;
 use crate::execution_context::ExecutionContext;
@@ -29,6 +31,11 @@ impl Sudo {
             .or_else(|| which("gsudo").map(|p| (p, SudoKind::Gsudo)))
             .or_else(|| which("pkexec").map(|p| (p, SudoKind::Pkexec)))
             .map(|(path, kind)| Self { path, kind })
+    }
+
+    /// Create Sudo from SudoKind, if found in the system
+    pub fn new(kind: SudoKind) -> Option<Self> {
+        which(kind.as_ref()).map(|path| Self { path, kind })
     }
 
     /// Elevate permissions with `sudo`.
@@ -100,8 +107,10 @@ impl Sudo {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
-enum SudoKind {
+#[derive(Clone, Copy, Debug, Deserialize, AsRefStr)]
+#[serde(rename_all = "lowercase")]
+#[strum(serialize_all = "lowercase")]
+pub enum SudoKind {
     Doas,
     Please,
     Sudo,


### PR DESCRIPTION
This allows the user to specify the preferred sudo command to be used instead of the command chosen by Sudo::detect

I wanted to use the pre_sudo feature but couldn't since I have doas installed and doas doesn't support `-v`. There was no way to tell topgrade to use sudo so I added this option

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

