### PR TITLE
run_custom_command: allow using interactive shell on unix

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -74,6 +74,7 @@
 # Custom commands
 [commands]
 #"Python Environment" = "~/dev/.env/bin/pip install -i https://pypi.python.org/simple -U --upgrade-strategy eager jupyter"
+#"Custom command using interactive shell (unix)" = "-i vim_upgrade"
 
 [brew]
 #greedy_cask = true

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -505,7 +505,15 @@ pub fn run_myrepos_update(base_dirs: &BaseDirs, run_type: RunType) -> Result<()>
 
 pub fn run_custom_command(name: &str, command: &str, ctx: &ExecutionContext) -> Result<()> {
     print_separator(name);
-    ctx.run_type().execute(shell()).arg("-c").arg(command).status_checked()
+    let mut exec = ctx.run_type().execute(shell());
+    #[cfg(unix)]
+    let command = if let Some(command) = command.strip_prefix("-i ") {
+        exec.arg("-i");
+        command
+    } else {
+        command
+    };
+    exec.arg("-c").arg(command).status_checked()
 }
 
 pub fn run_composer_update(ctx: &ExecutionContext) -> Result<()> {


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

This allows loading environment & aliases from the user's rc files.

@reini-1 @ealap Please test once for any regressions.