### PR TITLE
Assume Fedora Silverblue based on os-release and not on existence of rpm-ostree

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -996,7 +996,7 @@ impl Config {
             .linux
             .as_ref()
             .and_then(|linux| linux.rpm_ostree)
-            .unwrap_or(true)
+            .unwrap_or(false)
     }
 
     /// Should we ignore failures for this step

--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -56,7 +56,7 @@ impl Distribution {
                     if variant.contains(&"Silverblue") {
                         return Ok(Distribution::FedoraSilverblue);
                     } else {
-                        return Ok(Distribution::FedoraSilverblue);
+                        return Ok(Distribution::Fedora);
                     };
                 } else {
                     return Ok(Distribution::Fedora);

--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -218,11 +218,9 @@ fn upgrade_redhat(ctx: &ExecutionContext) -> Result<()> {
 
 fn upgrade_fedora_silverblue(ctx: &ExecutionContext) -> Result<()> {
     let ostree = require("rpm-ostree")?;
-    if ctx.config().rpm_ostree() {
-        let mut command = ctx.run_type().execute(ostree);
-        command.arg("upgrade");
-        command.status_checked()?
-    }
+    let mut command = ctx.run_type().execute(ostree);
+    command.arg("upgrade");
+    command.status_checked()?;
     Ok(())
 }
 


### PR DESCRIPTION
Closes #387 
# Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

@AWHubGit could you check this patch out
