### PR TITLE
Added support to 'mamba' (alternative to 'conda' with the exact same commands/interface)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -116,6 +116,7 @@ pub enum Step {
     Helix,
     Krew,
     Macports,
+    Mamba,
     Mas,
     Micro,
     Myrepos,

--- a/src/main.rs
+++ b/src/main.rs
@@ -368,6 +368,7 @@ For more information about this issue see https://askubuntu.com/questions/110969
     runner.execute(Step::Vcpkg, "vcpkg", || generic::run_vcpkg_update(&ctx))?;
     runner.execute(Step::Pipx, "pipx", || generic::run_pipx_update(run_type))?;
     runner.execute(Step::Conda, "conda", || generic::run_conda_update(&ctx))?;
+    runner.execute(Step::Mamba, "mamba", || generic::run_mamba_update(&ctx))?;
     runner.execute(Step::Pip3, "pip3", || generic::run_pip3_update(run_type))?;
     runner.execute(Step::PipReview, "pip-review", || generic::run_pip_review_update(&ctx))?;
     runner.execute(Step::Pipupgrade, "pipupgrade", || generic::run_pipupgrade_update(&ctx))?;

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -343,6 +343,25 @@ pub fn run_conda_update(ctx: &ExecutionContext) -> Result<()> {
         .status_checked()
 }
 
+pub fn run_mamba_update(ctx: &ExecutionContext) -> Result<()> {
+    let mamba = utils::require("mamba")?;
+
+    let output = Command::new("mamba")
+        .args(["config", "--show", "auto_activate_base"])
+        .output_checked_utf8()?;
+    debug!("Mamba output: {}", output.stdout);
+    if output.stdout.contains("False") {
+        return Err(SkipStep("auto_activate_base is set to False".to_string()).into());
+    }
+
+    print_separator("Mamba");
+
+    ctx.run_type()
+        .execute(mamba)
+        .args(["update", "--all", "-y"])
+        .status_checked()
+}
+
 pub fn run_pip3_update(run_type: RunType) -> Result<()> {
     let python3 = utils::require("python3")?;
     Command::new(&python3)


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [ ] The code passes rustfmt (`cargo fmt`) -- there are errors from lines I did not modified
- [ ] The code passes clippy (`cargo clippy`) -- clippy is no more available from cargo
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
