### PR TITLE
No need to run self-update in Rustup

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -350,7 +350,7 @@ For more information about this issue see https://askubuntu.com/questions/110969
     )))]
     runner.execute(Step::Atom, "apm", || generic::run_apm(run_type))?;
     runner.execute(Step::Fossil, "fossil", || generic::run_fossil(run_type))?;
-    runner.execute(Step::Rustup, "rustup", || generic::run_rustup(&base_dirs, run_type))?;
+    runner.execute(Step::Rustup, "rustup", || generic::run_rustup(&ctx))?;
     runner.execute(Step::Juliaup, "juliaup", || generic::run_juliaup(&base_dirs, run_type))?;
     runner.execute(Step::Dotnet, ".NET", || generic::run_dotnet_upgrade(&ctx))?;
     runner.execute(Step::Choosenim, "choosenim", || generic::run_choosenim(&ctx))?;

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -189,16 +189,11 @@ pub fn run_apm(run_type: RunType) -> Result<()> {
         .status_checked()
 }
 
-pub fn run_rustup(base_dirs: &BaseDirs, run_type: RunType) -> Result<()> {
+pub fn run_rustup(ctx: &ExecutionContext) -> Result<()> {
     let rustup = utils::require("rustup")?;
 
     print_separator("rustup");
-
-    if rustup.canonicalize()?.is_descendant_of(base_dirs.home_dir()) {
-        run_type.execute(&rustup).args(["self", "update"]).status_checked()?;
-    }
-
-    run_type.execute(&rustup).arg("update").status_checked()
+    ctx.run_type().execute(rustup).arg("update").status_checked()
 }
 
 pub fn run_juliaup(base_dirs: &BaseDirs, run_type: RunType) -> Result<()> {


### PR DESCRIPTION
Running `rustup update` causes it to update itself when appropriate.

## Standards checklist:

- [ ] The PR title is descriptive.
- [ ] The code compiles (`cargo build`)
- [ ] The code passes rustfmt (`cargo fmt`)
- [ ] The code passes clippy (`cargo clippy`)
- [ ] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
