### PR TITLE
Make `zypper dist-upgrade` opt-in on SLE/Leap

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -101,6 +101,7 @@
 #emerge_sync_flags = "-q"
 #emerge_update_flags = "-uDNa --with-bdeps=y world"
 #redhat_distro_sync = false
+#suse_dup = false
 #rpm_ostree = false
 #nix_arguments = "--flake"
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -274,6 +274,7 @@ pub struct Linux {
     apt_arguments: Option<String>,
     enable_tlmgr: Option<bool>,
     redhat_distro_sync: Option<bool>,
+    suse_dup: Option<bool>,
     rpm_ostree: Option<bool>,
     emerge_sync_flags: Option<String>,
     emerge_update_flags: Option<String>,
@@ -988,6 +989,15 @@ impl Config {
             .linux
             .as_ref()
             .and_then(|linux| linux.redhat_distro_sync)
+            .unwrap_or(false)
+    }
+
+    /// Use zypper dist-upgrade (same as distro-sync on RH) instead of update (default: false on SLE/Leap, ignored on Tumbleweed (dup is always ran))
+    pub fn suse_dup(&self) -> bool {
+        self.config_file
+            .linux
+            .as_ref()
+            .and_then(|linux| linux.suse_dup)
             .unwrap_or(false)
     }
 


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
