### PR TITLE
docs: update README for alternative config path

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,18 @@ See `config.example.toml` for an example configuration file.
 
 ### Configuration Path
 
-The configuration should be placed in the following paths depending on the operating system:
+#### `CONFIG_DIR` on each platform
+- **Windows**: `%APPDATA%`
+- **macOS** and **other Unix systems**: `${XDG_CONFIG_HOME:-~/.config}`
 
-- **Windows** - `%APPDATA%/topgrade.toml`
-- **macOS** and **other Unix systems** - `${XDG_CONFIG_HOME:-~/.config}/topgrade.toml`
+`topgrade` will look for the configuration file in the following places, in order of priority:
+
+1. `CONFIG_DIR/topgrade.toml`
+2. `CONFIG_DIR/topgrade/topgrade.toml`
+
+If the file with higher priority is present, no matter it is valid or not, the other configuration files will be ignored.
+
+On the first run(no configuration file exists), `topgrade` will create a configuration file at `CONFIG_DIR/topgrade.toml` for you.
 
 ### Custom Commands
 


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [ ] The code compiles (`cargo build`)
- [ ] The code passes rustfmt (`cargo fmt`)
- [ ] The code passes clippy (`cargo clippy`)
- [ ] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

#418 implemented #411 but forgot to update the `README.md`, this PR is for that.
