### PR TITLE
fix: run deb-get without sudo

### DIFF
--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -473,11 +473,11 @@ pub fn run_deb_get(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("deb-get");
 
-    ctx.execute_elevated(&deb_get, false)?.arg("update").status_checked()?;
-    ctx.execute_elevated(&deb_get, false)?.arg("upgrade").status_checked()?;
+    ctx.run_type().execute(&deb_get).arg("update").status_checked()?;
+    ctx.run_type().execute(&deb_get).arg("upgrade").status_checked()?;
 
     if ctx.config().cleanup() {
-        ctx.execute_elevated(&deb_get, false)?.arg("clean").status_checked()?;
+        ctx.run_type().execute(&deb_get).arg("clean").status_checked()?;
     }
 
     Ok(())


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

-----

Related to #429, see [this comment](https://github.com/topgrade-rs/topgrade/issues/429?notification_referrer_id=NT_kwDOBcZH5LM2NDY2OTkzNjAxOjk2ODgwNjEy#issuecomment-1548867273)