### PR TITLE
Adding local pip-review

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -106,8 +106,9 @@
 #nix_arguments = "--flake"
 
 [python]
-#enable_pip_review = true   ###disabled by default
-#enable_pipupgrade = true   ###disabled by default
+#enable_pip_review = true         ###disabled by default
+#enable_pip_review_local = true   ###disabled by default
+#enable_pipupgrade = true         ###disabled by default
 
 [windows]
 # Manually select Windows updates

--- a/src/config.rs
+++ b/src/config.rs
@@ -130,6 +130,7 @@ pub enum Step {
     Pearl,
     Pip3,
     PipReview,
+    PipReviewLocal,
     Pipupgrade,
     Pipx,
     Pkg,
@@ -200,6 +201,7 @@ pub struct Windows {
 #[serde(deny_unknown_fields)]
 pub struct Python {
     enable_pip_review: Option<bool>,
+    enable_pip_review_local: Option<bool>,
     enable_pipupgrade: Option<bool>,
 }
 
@@ -1136,6 +1138,14 @@ impl Config {
             .python
             .as_ref()
             .and_then(|python| python.enable_pip_review)
+            .unwrap_or(false);
+    }
+    pub fn enable_pip_review_local(&self) -> bool {
+        return self
+            .config_file
+            .python
+            .as_ref()
+            .and_then(|python| python.enable_pip_review_local)
             .unwrap_or(false);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -384,6 +384,9 @@ For more information about this issue see https://askubuntu.com/questions/110969
     runner.execute(Step::Mamba, "mamba", || generic::run_mamba_update(&ctx))?;
     runner.execute(Step::Pip3, "pip3", || generic::run_pip3_update(run_type))?;
     runner.execute(Step::PipReview, "pip-review", || generic::run_pip_review_update(&ctx))?;
+    runner.execute(Step::PipReviewLocal, "pip-review (local)", || {
+        generic::run_pip_review_local_update(&ctx)
+    })?;
     runner.execute(Step::Pipupgrade, "pipupgrade", || generic::run_pipupgrade_update(&ctx))?;
     runner.execute(Step::Ghcup, "ghcup", || generic::run_ghcup_update(run_type))?;
     runner.execute(Step::Stack, "stack", || generic::run_stack_update(run_type))?;

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -414,6 +414,25 @@ pub fn run_pip_review_update(ctx: &ExecutionContext) -> Result<()> {
 
     Ok(())
 }
+pub fn run_pip_review_local_update(ctx: &ExecutionContext) -> Result<()> {
+    let pip_review = require("pip-review")?;
+
+    print_separator("pip-review (local)");
+
+    if !ctx.config().enable_pip_review_local() {
+        print_warning(
+            "Pip-review (local) is disabled by default. Enable it by setting enable_pip_review_local=true in the configuration.",
+        );
+        return Err(SkipStep(String::from("Pip-review (local) is disabled by default")).into());
+    }
+    ctx.run_type()
+        .execute(pip_review)
+        .arg("--local")
+        .arg("--auto")
+        .status_checked_with_codes(&[1])?;
+
+    Ok(())
+}
 pub fn run_pipupgrade_update(ctx: &ExecutionContext) -> Result<()> {
     let pipupgrade = require("pipupgrade")?;
 


### PR DESCRIPTION
I've always used the command `pip-review --local --auto` to upgrade python packages since I install them in my home directory. Since topgrade skips the `--local` flag by default, I added it myself. I made it a new step because some people may have both local and system-wide packages installed on their system.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed
