### PR TITLE
fix: use env ZSH to compose oh-my-zsh install dir

### DIFF
--- a/src/steps/zsh.rs
+++ b/src/steps/zsh.rs
@@ -154,7 +154,11 @@ pub fn run_zim(run_type: RunType) -> Result<()> {
 
 pub fn run_oh_my_zsh(ctx: &ExecutionContext) -> Result<()> {
     require("zsh")?;
-    let oh_my_zsh = HOME_DIR.join(".oh-my-zsh").require()?;
+    let oh_my_zsh = env::var("ZSH")
+        .map(PathBuf::from)
+        // default to `~/.oh-my-zsh`
+        .unwrap_or(HOME_DIR.join(".oh-my-zsh"))
+        .require()?;
 
     print_separator("oh-my-zsh");
 
@@ -194,7 +198,10 @@ pub fn run_oh_my_zsh(ctx: &ExecutionContext) -> Result<()> {
 
     ctx.run_type()
         .execute("zsh")
-        .env("ZSH", &oh_my_zsh)
         .arg(&oh_my_zsh.join("tools/upgrade.sh"))
+        // oh-my-zsh returns 80 when it is already updated and no changes pulled
+        // in this update.
+        // See this comment: https://github.com/r-darwish/topgrade/issues/569#issuecomment-736756731
+        // for more information.
         .status_checked_with_codes(&[80])
 }


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

Closes #426

cc @lime-desu who has already found this and posted [it](https://github.com/topgrade-rs/topgrade/discussions/361) in discussions