### PR TITLE
refactor: make all step functions take &ExectutionContext

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -205,7 +205,7 @@ For more information about this issue see https://askubuntu.com/questions/110969
     #[cfg(windows)]
     {
         runner.execute(Step::Chocolatey, "Chocolatey", || windows::run_chocolatey(&ctx))?;
-        runner.execute(Step::Scoop, "Scoop", || windows::run_scoop(config.cleanup(), run_type))?;
+        runner.execute(Step::Scoop, "Scoop", || windows::run_scoop(config.cleanup(), &ctx))?;
         runner.execute(Step::Winget, "Winget", || windows::run_winget(&ctx))?;
     }
 
@@ -238,26 +238,22 @@ For more information about this issue see https://askubuntu.com/questions/110969
         runner.execute(Step::Nix, "nix", || unix::run_nix(&ctx))?;
         runner.execute(Step::Guix, "guix", || unix::run_guix(&ctx))?;
 
-        runner.execute(Step::HomeManager, "home-manager", || unix::run_home_manager(run_type))?;
-        runner.execute(Step::Asdf, "asdf", || unix::run_asdf(run_type))?;
+        runner.execute(Step::HomeManager, "home-manager", || unix::run_home_manager(&ctx))?;
+        runner.execute(Step::Asdf, "asdf", || unix::run_asdf(&ctx))?;
         runner.execute(Step::Pkgin, "pkgin", || unix::run_pkgin(&ctx))?;
         runner.execute(Step::Bun, "bun", || unix::run_bun(&ctx))?;
     }
 
     #[cfg(target_os = "dragonfly")]
     runner.execute(Step::Pkg, "DragonFly BSD Packages", || {
-        dragonfly::upgrade_packages(ctx.sudo().as_ref(), run_type)
+        dragonfly::upgrade_packages(&ctx)
     })?;
 
     #[cfg(target_os = "freebsd")]
-    runner.execute(Step::Pkg, "FreeBSD Packages", || {
-        freebsd::upgrade_packages(&ctx, ctx.sudo().as_ref(), run_type)
-    })?;
+    runner.execute(Step::Pkg, "FreeBSD Packages", || freebsd::upgrade_packages(&ctx))?;
 
     #[cfg(target_os = "openbsd")]
-    runner.execute(Step::Pkg, "OpenBSD Packages", || {
-        openbsd::upgrade_packages(ctx.sudo().as_ref(), run_type)
-    })?;
+    runner.execute(Step::Pkg, "OpenBSD Packages", || openbsd::upgrade_packages(&ctx))?;
 
     #[cfg(target_os = "android")]
     runner.execute(Step::Pkg, "Termux Packages", || android::upgrade_packages(&ctx))?;
@@ -332,30 +328,30 @@ For more information about this issue see https://askubuntu.com/questions/110969
 
     #[cfg(unix)]
     {
-        runner.execute(Step::Shell, "zr", || zsh::run_zr(run_type))?;
-        runner.execute(Step::Shell, "antibody", || zsh::run_antibody(run_type))?;
+        runner.execute(Step::Shell, "zr", || zsh::run_zr(&ctx))?;
+        runner.execute(Step::Shell, "antibody", || zsh::run_antibody(&ctx))?;
         runner.execute(Step::Shell, "antidote", || zsh::run_antidote(&ctx))?;
-        runner.execute(Step::Shell, "antigen", || zsh::run_antigen(run_type))?;
-        runner.execute(Step::Shell, "zgenom", || zsh::run_zgenom(run_type))?;
-        runner.execute(Step::Shell, "zplug", || zsh::run_zplug(run_type))?;
-        runner.execute(Step::Shell, "zinit", || zsh::run_zinit(run_type))?;
-        runner.execute(Step::Shell, "zi", || zsh::run_zi(run_type))?;
-        runner.execute(Step::Shell, "zim", || zsh::run_zim(run_type))?;
+        runner.execute(Step::Shell, "antigen", || zsh::run_antigen(&ctx))?;
+        runner.execute(Step::Shell, "zgenom", || zsh::run_zgenom(&ctx))?;
+        runner.execute(Step::Shell, "zplug", || zsh::run_zplug(&ctx))?;
+        runner.execute(Step::Shell, "zinit", || zsh::run_zinit(&ctx))?;
+        runner.execute(Step::Shell, "zi", || zsh::run_zi(&ctx))?;
+        runner.execute(Step::Shell, "zim", || zsh::run_zim(&ctx))?;
         runner.execute(Step::Shell, "oh-my-zsh", || zsh::run_oh_my_zsh(&ctx))?;
         runner.execute(Step::Shell, "oh-my-bash", || unix::run_oh_my_bash(&ctx))?;
-        runner.execute(Step::Shell, "fisher", || unix::run_fisher(run_type))?;
+        runner.execute(Step::Shell, "fisher", || unix::run_fisher(&ctx))?;
         runner.execute(Step::Shell, "bash-it", || unix::run_bashit(&ctx))?;
         runner.execute(Step::Shell, "oh-my-fish", || unix::run_oh_my_fish(&ctx))?;
         runner.execute(Step::Shell, "fish-plug", || unix::run_fish_plug(&ctx))?;
         runner.execute(Step::Shell, "fundle", || unix::run_fundle(&ctx))?;
-        runner.execute(Step::Tmux, "tmux", || tmux::run_tpm(run_type))?;
-        runner.execute(Step::Tldr, "TLDR", || unix::run_tldr(run_type))?;
-        runner.execute(Step::Pearl, "pearl", || unix::run_pearl(run_type))?;
+        runner.execute(Step::Tmux, "tmux", || tmux::run_tpm(&ctx))?;
+        runner.execute(Step::Tldr, "TLDR", || unix::run_tldr(&ctx))?;
+        runner.execute(Step::Pearl, "pearl", || unix::run_pearl(&ctx))?;
         #[cfg(not(any(target_os = "macos", target_os = "android")))]
         runner.execute(Step::GnomeShellExtensions, "Gnome Shell Extensions", || {
             unix::upgrade_gnome_extensions(&ctx)
         })?;
-        runner.execute(Step::Sdkman, "SDKMAN!", || unix::run_sdkman(config.cleanup(), run_type))?;
+        runner.execute(Step::Sdkman, "SDKMAN!", || unix::run_sdkman(config.cleanup(), &ctx))?;
         runner.execute(Step::Rcm, "rcm", || unix::run_rcm(&ctx))?;
         runner.execute(Step::Maza, "maza", || unix::run_maza(&ctx))?;
     }
@@ -366,38 +362,38 @@ For more information about this issue see https://askubuntu.com/questions/110969
         target_os = "netbsd",
         target_os = "dragonfly"
     )))]
-    runner.execute(Step::Atom, "apm", || generic::run_apm(run_type))?;
-    runner.execute(Step::Fossil, "fossil", || generic::run_fossil(run_type))?;
+    runner.execute(Step::Atom, "apm", || generic::run_apm(&ctx))?;
+    runner.execute(Step::Fossil, "fossil", || generic::run_fossil(&ctx))?;
     runner.execute(Step::Rustup, "rustup", || generic::run_rustup(&ctx))?;
-    runner.execute(Step::Juliaup, "juliaup", || generic::run_juliaup(run_type))?;
+    runner.execute(Step::Juliaup, "juliaup", || generic::run_juliaup(&ctx))?;
     runner.execute(Step::Dotnet, ".NET", || generic::run_dotnet_upgrade(&ctx))?;
     runner.execute(Step::Choosenim, "choosenim", || generic::run_choosenim(&ctx))?;
     runner.execute(Step::Cargo, "cargo", || generic::run_cargo_update(&ctx))?;
-    runner.execute(Step::Flutter, "Flutter", || generic::run_flutter_upgrade(run_type))?;
-    runner.execute(Step::Go, "go-global-update", || go::run_go_global_update(run_type))?;
-    runner.execute(Step::Go, "gup", || go::run_go_gup(run_type))?;
+    runner.execute(Step::Flutter, "Flutter", || generic::run_flutter_upgrade(&ctx))?;
+    runner.execute(Step::Go, "go-global-update", || go::run_go_global_update(&ctx))?;
+    runner.execute(Step::Go, "gup", || go::run_go_gup(&ctx))?;
     runner.execute(Step::Emacs, "Emacs", || emacs.upgrade(&ctx))?;
     runner.execute(Step::Opam, "opam", || generic::run_opam_update(&ctx))?;
     runner.execute(Step::Vcpkg, "vcpkg", || generic::run_vcpkg_update(&ctx))?;
-    runner.execute(Step::Pipx, "pipx", || generic::run_pipx_update(run_type))?;
+    runner.execute(Step::Pipx, "pipx", || generic::run_pipx_update(&ctx))?;
     runner.execute(Step::Conda, "conda", || generic::run_conda_update(&ctx))?;
     runner.execute(Step::Mamba, "mamba", || generic::run_mamba_update(&ctx))?;
-    runner.execute(Step::Pip3, "pip3", || generic::run_pip3_update(run_type))?;
+    runner.execute(Step::Pip3, "pip3", || generic::run_pip3_update(&ctx))?;
     runner.execute(Step::PipReview, "pip-review", || generic::run_pip_review_update(&ctx))?;
     runner.execute(Step::PipReviewLocal, "pip-review (local)", || {
         generic::run_pip_review_local_update(&ctx)
     })?;
     runner.execute(Step::Pipupgrade, "pipupgrade", || generic::run_pipupgrade_update(&ctx))?;
-    runner.execute(Step::Ghcup, "ghcup", || generic::run_ghcup_update(run_type))?;
-    runner.execute(Step::Stack, "stack", || generic::run_stack_update(run_type))?;
+    runner.execute(Step::Ghcup, "ghcup", || generic::run_ghcup_update(&ctx))?;
+    runner.execute(Step::Stack, "stack", || generic::run_stack_update(&ctx))?;
     runner.execute(Step::Tlmgr, "tlmgr", || generic::run_tlmgr_update(&ctx))?;
-    runner.execute(Step::Myrepos, "myrepos", || generic::run_myrepos_update(run_type))?;
-    runner.execute(Step::Chezmoi, "chezmoi", || generic::run_chezmoi_update(run_type))?;
-    runner.execute(Step::Jetpack, "jetpack", || generic::run_jetpack(run_type))?;
+    runner.execute(Step::Myrepos, "myrepos", || generic::run_myrepos_update(&ctx))?;
+    runner.execute(Step::Chezmoi, "chezmoi", || generic::run_chezmoi_update(&ctx))?;
+    runner.execute(Step::Jetpack, "jetpack", || generic::run_jetpack(&ctx))?;
     runner.execute(Step::Vim, "vim", || vim::upgrade_vim(&ctx))?;
     runner.execute(Step::Vim, "Neovim", || vim::upgrade_neovim(&ctx))?;
     runner.execute(Step::Vim, "The Ultimate vimrc", || vim::upgrade_ultimate_vimrc(&ctx))?;
-    runner.execute(Step::Vim, "voom", || vim::run_voom(run_type))?;
+    runner.execute(Step::Vim, "voom", || vim::run_voom(&ctx))?;
     runner.execute(Step::Kakoune, "Kakoune", || kakoune::upgrade_kak_plug(&ctx))?;
     runner.execute(Step::Helix, "helix", || generic::run_helix_grammars(&ctx))?;
     runner.execute(Step::Node, "npm", || node::run_npm_upgrade(&ctx))?;
@@ -406,21 +402,19 @@ For more information about this issue see https://askubuntu.com/questions/110969
     runner.execute(Step::Containers, "Containers", || containers::run_containers(&ctx))?;
     runner.execute(Step::Deno, "deno", || node::deno_upgrade(&ctx))?;
     runner.execute(Step::Composer, "composer", || generic::run_composer_update(&ctx))?;
-    runner.execute(Step::Krew, "krew", || generic::run_krew_upgrade(run_type))?;
-    runner.execute(Step::Helm, "helm", || generic::run_helm_repo_update(run_type))?;
-    runner.execute(Step::Gem, "gem", || generic::run_gem(run_type))?;
+    runner.execute(Step::Krew, "krew", || generic::run_krew_upgrade(&ctx))?;
+    runner.execute(Step::Helm, "helm", || generic::run_helm_repo_update(&ctx))?;
+    runner.execute(Step::Gem, "gem", || generic::run_gem(&ctx))?;
     runner.execute(Step::RubyGems, "rubygems", || generic::run_rubygems(&ctx))?;
     runner.execute(Step::Julia, "julia", || generic::update_julia_packages(&ctx))?;
     runner.execute(Step::Haxelib, "haxelib", || generic::run_haxelib_update(&ctx))?;
     runner.execute(Step::Sheldon, "sheldon", || generic::run_sheldon(&ctx))?;
-    runner.execute(Step::Stew, "stew", || generic::run_stew(run_type))?;
+    runner.execute(Step::Stew, "stew", || generic::run_stew(&ctx))?;
     runner.execute(Step::Rtcl, "rtcl", || generic::run_rtcl(&ctx))?;
     runner.execute(Step::Bin, "bin", || generic::bin_update(&ctx))?;
-    runner.execute(Step::Gcloud, "gcloud", || {
-        generic::run_gcloud_components_update(run_type)
-    })?;
-    runner.execute(Step::Micro, "micro", || generic::run_micro(run_type))?;
-    runner.execute(Step::Raco, "raco", || generic::run_raco_update(run_type))?;
+    runner.execute(Step::Gcloud, "gcloud", || generic::run_gcloud_components_update(&ctx))?;
+    runner.execute(Step::Micro, "micro", || generic::run_micro(&ctx))?;
+    runner.execute(Step::Raco, "raco", || generic::run_raco_update(&ctx))?;
     runner.execute(Step::Spicetify, "spicetify", || generic::spicetify_upgrade(&ctx))?;
     runner.execute(Step::GithubCliExtensions, "GitHub CLI Extensions", || {
         generic::run_ghcli_extensions_upgrade(&ctx)
@@ -433,7 +427,7 @@ For more information about this issue see https://askubuntu.com/questions/110969
         runner.execute(Step::DebGet, "deb-get", || linux::run_deb_get(&ctx))?;
         runner.execute(Step::Toolbx, "toolbx", || toolbx::run_toolbx(&ctx))?;
         runner.execute(Step::Flatpak, "Flatpak", || linux::flatpak_update(&ctx))?;
-        runner.execute(Step::Snap, "snap", || linux::run_snap(ctx.sudo().as_ref(), run_type))?;
+        runner.execute(Step::Snap, "snap", || linux::run_snap(&ctx))?;
         runner.execute(Step::Pacstall, "pacstall", || linux::run_pacstall(&ctx))?;
         runner.execute(Step::Pacdef, "pacdef", || linux::run_pacdef(&ctx))?;
         runner.execute(Step::Protonup, "protonup", || linux::run_protonup_update(&ctx))?;
@@ -453,31 +447,23 @@ For more information about this issue see https://askubuntu.com/questions/110969
 
     #[cfg(target_os = "linux")]
     {
-        runner.execute(Step::System, "pihole", || {
-            linux::run_pihole_update(ctx.sudo().as_ref(), run_type)
-        })?;
+        runner.execute(Step::System, "pihole", || linux::run_pihole_update(&ctx))?;
         runner.execute(Step::Firmware, "Firmware upgrades", || linux::run_fwupdmgr(&ctx))?;
-        runner.execute(Step::Restarts, "Restarts", || {
-            linux::run_needrestart(ctx.sudo().as_ref(), run_type)
-        })?;
+        runner.execute(Step::Restarts, "Restarts", || linux::run_needrestart(&ctx))?;
     }
 
     #[cfg(target_os = "macos")]
     {
         runner.execute(Step::Sparkle, "Sparkle", || macos::run_sparkle(&ctx))?;
-        runner.execute(Step::Mas, "App Store", || macos::run_mas(run_type))?;
+        runner.execute(Step::Mas, "App Store", || macos::run_mas(&ctx))?;
         runner.execute(Step::System, "System upgrade", || macos::upgrade_macos(&ctx))?;
     }
 
     #[cfg(target_os = "freebsd")]
-    runner.execute(Step::System, "FreeBSD Upgrade", || {
-        freebsd::upgrade_freebsd(ctx.sudo().as_ref(), run_type)
-    })?;
+    runner.execute(Step::System, "FreeBSD Upgrade", || freebsd::upgrade_freebsd(&ctx))?;
 
     #[cfg(target_os = "openbsd")]
-    runner.execute(Step::System, "OpenBSD Upgrade", || {
-        openbsd::upgrade_openbsd(ctx.sudo().as_ref(), run_type)
-    })?;
+    runner.execute(Step::System, "OpenBSD Upgrade", || openbsd::upgrade_openbsd(&ctx))?;
 
     #[cfg(windows)]
     runner.execute(Step::System, "Windows update", || windows::windows_update(&ctx))?;

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -13,7 +13,7 @@ use tracing::{debug, error};
 
 use crate::command::{CommandExt, Utf8Output};
 use crate::execution_context::ExecutionContext;
-use crate::executor::{ExecutorOutput, RunType};
+use crate::executor::ExecutorOutput;
 use crate::terminal::{print_separator, shell};
 use crate::utils::{self, require, require_option, which, PathExt};
 use crate::Step;
@@ -77,20 +77,20 @@ pub fn run_cargo_update(ctx: &ExecutionContext) -> Result<()> {
     Ok(())
 }
 
-pub fn run_flutter_upgrade(run_type: RunType) -> Result<()> {
+pub fn run_flutter_upgrade(ctx: &ExecutionContext) -> Result<()> {
     let flutter = utils::require("flutter")?;
 
     print_separator("Flutter");
-    run_type.execute(flutter).arg("upgrade").status_checked()
+    ctx.run_type().execute(flutter).arg("upgrade").status_checked()
 }
 
-pub fn run_gem(run_type: RunType) -> Result<()> {
+pub fn run_gem(ctx: &ExecutionContext) -> Result<()> {
     let gem = utils::require("gem")?;
     HOME_DIR.join(".gem").require()?;
 
     print_separator("Gems");
 
-    let mut command = run_type.execute(gem);
+    let mut command = ctx.run_type().execute(gem);
     command.arg("update");
 
     if env::var_os("RBENV_SHELL").is_none() {
@@ -163,20 +163,21 @@ pub fn run_sheldon(ctx: &ExecutionContext) -> Result<()> {
         .status_checked()
 }
 
-pub fn run_fossil(run_type: RunType) -> Result<()> {
+pub fn run_fossil(ctx: &ExecutionContext) -> Result<()> {
     let fossil = utils::require("fossil")?;
 
     print_separator("Fossil");
 
-    run_type.execute(fossil).args(["all", "sync"]).status_checked()
+    ctx.run_type().execute(fossil).args(["all", "sync"]).status_checked()
 }
 
-pub fn run_micro(run_type: RunType) -> Result<()> {
+pub fn run_micro(ctx: &ExecutionContext) -> Result<()> {
     let micro = utils::require("micro")?;
 
     print_separator("micro");
 
-    let stdout = run_type
+    let stdout = ctx
+        .run_type()
         .execute(micro)
         .args(["-plugin", "update"])
         .output_checked_utf8()?
@@ -196,12 +197,12 @@ pub fn run_micro(run_type: RunType) -> Result<()> {
     target_os = "netbsd",
     target_os = "dragonfly"
 )))]
-pub fn run_apm(run_type: RunType) -> Result<()> {
+pub fn run_apm(ctx: &ExecutionContext) -> Result<()> {
     let apm = utils::require("apm")?;
 
     print_separator("Atom Package Manager");
 
-    run_type
+    ctx.run_type()
         .execute(apm)
         .args(["upgrade", "--confirm=false"])
         .status_checked()
@@ -214,16 +215,19 @@ pub fn run_rustup(ctx: &ExecutionContext) -> Result<()> {
     ctx.run_type().execute(rustup).arg("update").status_checked()
 }
 
-pub fn run_juliaup(run_type: RunType) -> Result<()> {
+pub fn run_juliaup(ctx: &ExecutionContext) -> Result<()> {
     let juliaup = utils::require("juliaup")?;
 
     print_separator("juliaup");
 
     if juliaup.canonicalize()?.is_descendant_of(&HOME_DIR) {
-        run_type.execute(&juliaup).args(["self", "update"]).status_checked()?;
+        ctx.run_type()
+            .execute(&juliaup)
+            .args(["self", "update"])
+            .status_checked()?;
     }
 
-    run_type.execute(&juliaup).arg("update").status_checked()
+    ctx.run_type().execute(&juliaup).arg("update").status_checked()
 }
 
 pub fn run_choosenim(ctx: &ExecutionContext) -> Result<()> {
@@ -236,15 +240,15 @@ pub fn run_choosenim(ctx: &ExecutionContext) -> Result<()> {
     run_type.execute(&choosenim).args(["update", "stable"]).status_checked()
 }
 
-pub fn run_krew_upgrade(run_type: RunType) -> Result<()> {
+pub fn run_krew_upgrade(ctx: &ExecutionContext) -> Result<()> {
     let krew = utils::require("kubectl-krew")?;
 
     print_separator("Krew");
 
-    run_type.execute(krew).args(["upgrade"]).status_checked()
+    ctx.run_type().execute(krew).args(["upgrade"]).status_checked()
 }
 
-pub fn run_gcloud_components_update(run_type: RunType) -> Result<()> {
+pub fn run_gcloud_components_update(ctx: &ExecutionContext) -> Result<()> {
     let gcloud = utils::require("gcloud")?;
 
     if gcloud.starts_with("/snap") {
@@ -252,19 +256,22 @@ pub fn run_gcloud_components_update(run_type: RunType) -> Result<()> {
     } else {
         print_separator("gcloud");
 
-        run_type
+        ctx.run_type()
             .execute(gcloud)
             .args(["components", "update", "--quiet"])
             .status_checked()
     }
 }
 
-pub fn run_jetpack(run_type: RunType) -> Result<()> {
+pub fn run_jetpack(ctx: &ExecutionContext) -> Result<()> {
     let jetpack = utils::require("jetpack")?;
 
     print_separator("Jetpack");
 
-    run_type.execute(jetpack).args(["global", "update"]).status_checked()
+    ctx.run_type()
+        .execute(jetpack)
+        .args(["global", "update"])
+        .status_checked()
 }
 
 pub fn run_rtcl(ctx: &ExecutionContext) -> Result<()> {
@@ -313,11 +320,11 @@ pub fn run_vcpkg_update(ctx: &ExecutionContext) -> Result<()> {
     command.args(["upgrade", "--no-dry-run"]).status_checked()
 }
 
-pub fn run_pipx_update(run_type: RunType) -> Result<()> {
+pub fn run_pipx_update(ctx: &ExecutionContext) -> Result<()> {
     let pipx = utils::require("pipx")?;
     print_separator("pipx");
 
-    run_type.execute(pipx).arg("upgrade-all").status_checked()
+    ctx.run_type().execute(pipx).arg("upgrade-all").status_checked()
 }
 
 pub fn run_conda_update(ctx: &ExecutionContext) -> Result<()> {
@@ -362,7 +369,7 @@ pub fn run_mamba_update(ctx: &ExecutionContext) -> Result<()> {
     command.status_checked()
 }
 
-pub fn run_pip3_update(run_type: RunType) -> Result<()> {
+pub fn run_pip3_update(ctx: &ExecutionContext) -> Result<()> {
     let python3 = utils::require("python3")?;
     Command::new(&python3)
         .args(["-m", "pip"])
@@ -390,7 +397,7 @@ pub fn run_pip3_update(run_type: RunType) -> Result<()> {
         return Err(SkipStep("Does not run inside a virtual environment".to_string()).into());
     }
 
-    run_type
+    ctx.run_type()
         .execute(&python3)
         .args(["-m", "pip", "install", "--upgrade", "--user", "pip"])
         .status_checked()
@@ -448,7 +455,7 @@ pub fn run_pipupgrade_update(ctx: &ExecutionContext) -> Result<()> {
     Ok(())
 }
 
-pub fn run_stack_update(run_type: RunType) -> Result<()> {
+pub fn run_stack_update(ctx: &ExecutionContext) -> Result<()> {
     if utils::require("ghcup").is_ok() {
         // `ghcup` is present and probably(?) being used to install `stack`.
         // Don't upgrade `stack`, let `ghcup` handle it. Per `ghcup install stack`:
@@ -459,14 +466,14 @@ pub fn run_stack_update(run_type: RunType) -> Result<()> {
     let stack = utils::require("stack")?;
     print_separator("stack");
 
-    run_type.execute(stack).arg("upgrade").status_checked()
+    ctx.run_type().execute(stack).arg("upgrade").status_checked()
 }
 
-pub fn run_ghcup_update(run_type: RunType) -> Result<()> {
+pub fn run_ghcup_update(ctx: &ExecutionContext) -> Result<()> {
     let ghcup = utils::require("ghcup")?;
     print_separator("ghcup");
 
-    run_type.execute(ghcup).arg("upgrade").status_checked()
+    ctx.run_type().execute(ghcup).arg("upgrade").status_checked()
 }
 
 pub fn run_tlmgr_update(ctx: &ExecutionContext) -> Result<()> {
@@ -512,28 +519,28 @@ pub fn run_tlmgr_update(ctx: &ExecutionContext) -> Result<()> {
     command.status_checked()
 }
 
-pub fn run_chezmoi_update(run_type: RunType) -> Result<()> {
+pub fn run_chezmoi_update(ctx: &ExecutionContext) -> Result<()> {
     let chezmoi = utils::require("chezmoi")?;
     HOME_DIR.join(".local/share/chezmoi").require()?;
 
     print_separator("chezmoi");
 
-    run_type.execute(chezmoi).arg("update").status_checked()
+    ctx.run_type().execute(chezmoi).arg("update").status_checked()
 }
 
-pub fn run_myrepos_update(run_type: RunType) -> Result<()> {
+pub fn run_myrepos_update(ctx: &ExecutionContext) -> Result<()> {
     let myrepos = utils::require("mr")?;
     HOME_DIR.join(".mrconfig").require()?;
 
     print_separator("myrepos");
 
-    run_type
+    ctx.run_type()
         .execute(&myrepos)
         .arg("--directory")
         .arg(&*HOME_DIR)
         .arg("checkout")
         .status_checked()?;
-    run_type
+    ctx.run_type()
         .execute(&myrepos)
         .arg("--directory")
         .arg(&*HOME_DIR)
@@ -672,12 +679,15 @@ pub fn run_helix_grammars(ctx: &ExecutionContext) -> Result<()> {
     Ok(())
 }
 
-pub fn run_raco_update(run_type: RunType) -> Result<()> {
+pub fn run_raco_update(ctx: &ExecutionContext) -> Result<()> {
     let raco = utils::require("raco")?;
 
     print_separator("Racket Package Manager");
 
-    run_type.execute(raco).args(["pkg", "update", "--all"]).status_checked()
+    ctx.run_type()
+        .execute(raco)
+        .args(["pkg", "update", "--all"])
+        .status_checked()
 }
 
 pub fn bin_update(ctx: &ExecutionContext) -> Result<()> {
@@ -720,14 +730,14 @@ pub fn update_julia_packages(ctx: &ExecutionContext) -> Result<()> {
         .status_checked()
 }
 
-pub fn run_helm_repo_update(run_type: RunType) -> Result<()> {
+pub fn run_helm_repo_update(ctx: &ExecutionContext) -> Result<()> {
     let helm = utils::require("helm")?;
 
     print_separator("Helm");
 
     let no_repo = "no repositories found";
     let mut success = true;
-    let mut exec = run_type.execute(helm);
+    let mut exec = ctx.run_type().execute(helm);
     if let Err(e) = exec.arg("repo").arg("update").status_checked() {
         error!("Updating repositories failed: {}", e);
         success = match exec.output_checked_utf8() {
@@ -746,9 +756,9 @@ pub fn run_helm_repo_update(run_type: RunType) -> Result<()> {
     }
 }
 
-pub fn run_stew(run_type: RunType) -> Result<()> {
+pub fn run_stew(ctx: &ExecutionContext) -> Result<()> {
     let stew = require("stew")?;
 
     print_separator("stew");
-    run_type.execute(stew).args(["upgrade", "--all"]).status_checked()
+    ctx.run_type().execute(stew).args(["upgrade", "--all"]).status_checked()
 }

--- a/src/steps/git.rs
+++ b/src/steps/git.rs
@@ -14,7 +14,6 @@ use tracing::{debug, error};
 
 use crate::command::CommandExt;
 use crate::execution_context::ExecutionContext;
-use crate::executor::RunType;
 use crate::terminal::print_separator;
 use crate::utils::{which, PathExt};
 use crate::{error::SkipStep, terminal::print_warning};
@@ -194,7 +193,7 @@ impl Git {
     pub fn multi_pull(&self, repositories: &Repositories, ctx: &ExecutionContext) -> Result<()> {
         let git = self.git.as_ref().unwrap();
 
-        if let RunType::Dry = ctx.run_type() {
+        if ctx.run_type().dry() {
             repositories
                 .repositories
                 .iter()

--- a/src/steps/go.rs
+++ b/src/steps/go.rs
@@ -4,27 +4,27 @@ use std::process::Command;
 use color_eyre::eyre::Result;
 
 use crate::command::CommandExt;
-use crate::executor::RunType;
+use crate::execution_context::ExecutionContext;
 use crate::terminal::print_separator;
 use crate::utils;
 use crate::utils::PathExt;
 
 /// <https://github.com/Gelio/go-global-update>
-pub fn run_go_global_update(run_type: RunType) -> Result<()> {
+pub fn run_go_global_update(ctx: &ExecutionContext) -> Result<()> {
     let go_global_update = require_go_bin("go-global-update")?;
 
     print_separator("go-global-update");
 
-    run_type.execute(go_global_update).status_checked()
+    ctx.run_type().execute(go_global_update).status_checked()
 }
 
 /// <https://github.com/nao1215/gup>
-pub fn run_go_gup(run_type: RunType) -> Result<()> {
+pub fn run_go_gup(ctx: &ExecutionContext) -> Result<()> {
     let gup = require_go_bin("gup")?;
 
     print_separator("gup");
 
-    run_type.execute(gup).arg("update").status_checked()
+    ctx.run_type().execute(gup).arg("update").status_checked()
 }
 
 /// Get the path of a Go binary.

--- a/src/steps/os/dragonfly.rs
+++ b/src/steps/os/dragonfly.rs
@@ -1,16 +1,15 @@
 use crate::command::CommandExt;
-use crate::executor::RunType;
+use crate::execution_context::ExecutionContext;
 use crate::sudo::Sudo;
 use crate::terminal::print_separator;
 use crate::utils::require_option;
 use color_eyre::eyre::Result;
 use std::process::Command;
 
-pub fn upgrade_packages(sudo: Option<&Sudo>, run_type: RunType) -> Result<()> {
-    let sudo = require_option(sudo, String::from("No sudo detected"))?;
+pub fn upgrade_packages(ctx: &ExecutionContext) -> Result<()> {
+    let sudo = require_option(ctx.sudo().as_ref(), String::from("No sudo detected"))?;
     print_separator("DragonFly BSD Packages");
-    run_type
-        .execute(sudo)
+    ctx.execute(sudo)
         .args(["/usr/local/sbin/pkg", "upgrade"])
         .status_checked()
 }

--- a/src/steps/os/freebsd.rs
+++ b/src/steps/os/freebsd.rs
@@ -1,6 +1,5 @@
 use crate::command::CommandExt;
 use crate::execution_context::ExecutionContext;
-use crate::executor::RunType;
 use crate::sudo::Sudo;
 use crate::terminal::print_separator;
 use crate::utils::require_option;
@@ -8,20 +7,20 @@ use crate::Step;
 use color_eyre::eyre::Result;
 use std::process::Command;
 
-pub fn upgrade_freebsd(sudo: Option<&Sudo>, run_type: RunType) -> Result<()> {
-    let sudo = require_option(sudo, String::from("No sudo detected"))?;
+pub fn upgrade_freebsd(ctx: &ExecutionContext) -> Result<()> {
+    let sudo = require_option(ctx.sudo().as_ref(), String::from("No sudo detected"))?;
     print_separator("FreeBSD Update");
-    run_type
+    ctx.run_type()
         .execute(sudo)
         .args(["/usr/sbin/freebsd-update", "fetch", "install"])
         .status_checked()
 }
 
-pub fn upgrade_packages(ctx: &ExecutionContext, sudo: Option<&Sudo>, run_type: RunType) -> Result<()> {
-    let sudo = require_option(sudo, String::from("No sudo detected"))?;
+pub fn upgrade_packages(ctx: &ExecutionContext) -> Result<()> {
+    let sudo = require_option(ctx.sudo().as_ref(), String::from("No sudo detected"))?;
     print_separator("FreeBSD Packages");
 
-    let mut command = run_type.execute(sudo);
+    let mut command = ctx.run_type().execute(sudo);
 
     command.args(["/usr/sbin/pkg", "upgrade"]);
     if ctx.config().yes(Step::System) {

--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -8,9 +8,7 @@ use tracing::{debug, warn};
 use crate::command::CommandExt;
 use crate::error::{SkipStep, TopgradeError};
 use crate::execution_context::ExecutionContext;
-use crate::executor::RunType;
 use crate::steps::os::archlinux;
-use crate::sudo::Sudo;
 use crate::terminal::{print_separator, print_warning};
 use crate::utils::{require, require_option, which, PathExt};
 use crate::{Step, HOME_DIR};
@@ -677,8 +675,8 @@ fn upgrade_neon(ctx: &ExecutionContext) -> Result<()> {
     Ok(())
 }
 
-pub fn run_needrestart(sudo: Option<&Sudo>, run_type: RunType) -> Result<()> {
-    let sudo = require_option(sudo, String::from("sudo is not installed"))?;
+pub fn run_needrestart(ctx: &ExecutionContext) -> Result<()> {
+    let sudo = require_option(ctx.sudo().as_ref(), String::from("sudo is not installed"))?;
     let needrestart = require("needrestart")?;
     let distribution = Distribution::detect()?;
 
@@ -688,7 +686,7 @@ pub fn run_needrestart(sudo: Option<&Sudo>, run_type: RunType) -> Result<()> {
 
     print_separator("Check for needed restarts");
 
-    run_type.execute(sudo).arg(needrestart).status_checked()?;
+    ctx.run_type().execute(sudo).arg(needrestart).status_checked()?;
 
     Ok(())
 }
@@ -782,8 +780,8 @@ pub fn flatpak_update(ctx: &ExecutionContext) -> Result<()> {
     Ok(())
 }
 
-pub fn run_snap(sudo: Option<&Sudo>, run_type: RunType) -> Result<()> {
-    let sudo = require_option(sudo, String::from("sudo is not installed"))?;
+pub fn run_snap(ctx: &ExecutionContext) -> Result<()> {
+    let sudo = require_option(ctx.sudo().as_ref(), String::from("sudo is not installed"))?;
     let snap = require("snap")?;
 
     if !PathBuf::from("/var/snapd.socket").exists() && !PathBuf::from("/run/snapd.socket").exists() {
@@ -791,17 +789,17 @@ pub fn run_snap(sudo: Option<&Sudo>, run_type: RunType) -> Result<()> {
     }
     print_separator("snap");
 
-    run_type.execute(sudo).arg(snap).arg("refresh").status_checked()
+    ctx.run_type().execute(sudo).arg(snap).arg("refresh").status_checked()
 }
 
-pub fn run_pihole_update(sudo: Option<&Sudo>, run_type: RunType) -> Result<()> {
-    let sudo = require_option(sudo, String::from("sudo is not installed"))?;
+pub fn run_pihole_update(ctx: &ExecutionContext) -> Result<()> {
+    let sudo = require_option(ctx.sudo().as_ref(), String::from("sudo is not installed"))?;
     let pihole = require("pihole")?;
     Path::new("/opt/pihole/update.sh").require()?;
 
     print_separator("pihole");
 
-    run_type.execute(sudo).arg(pihole).arg("-up").status_checked()
+    ctx.run_type().execute(sudo).arg(pihole).arg("-up").status_checked()
 }
 
 pub fn run_protonup_update(ctx: &ExecutionContext) -> Result<()> {

--- a/src/steps/os/macos.rs
+++ b/src/steps/os/macos.rs
@@ -1,6 +1,5 @@
 use crate::command::CommandExt;
 use crate::execution_context::ExecutionContext;
-use crate::executor::RunType;
 use crate::terminal::{print_separator, prompt_yesno};
 use crate::{utils::require, Step};
 use color_eyre::eyre::Result;
@@ -30,11 +29,11 @@ pub fn run_macports(ctx: &ExecutionContext) -> Result<()> {
     Ok(())
 }
 
-pub fn run_mas(run_type: RunType) -> Result<()> {
+pub fn run_mas(ctx: &ExecutionContext) -> Result<()> {
     let mas = require("mas")?;
     print_separator("macOS App Store");
 
-    run_type.execute(mas).arg("upgrade").status_checked()
+    ctx.run_type().execute(mas).arg("upgrade").status_checked()
 }
 
 pub fn upgrade_macos(ctx: &ExecutionContext) -> Result<()> {

--- a/src/steps/os/openbsd.rs
+++ b/src/steps/os/openbsd.rs
@@ -1,22 +1,22 @@
-use crate::executor::RunType;
+use crate::execution_context::ExecutionContext;
 use crate::terminal::print_separator;
 use crate::utils::require_option;
 use color_eyre::eyre::Result;
 use std::path::PathBuf;
 
-pub fn upgrade_openbsd(sudo: Option<&PathBuf>, run_type: RunType) -> Result<()> {
-    let sudo = require_option(sudo, String::from("No sudo detected"))?;
+pub fn upgrade_openbsd(ctx: &ExecutionContext) -> Result<()> {
+    let sudo = require_option(ctx.sudo().as_ref(), String::from("No sudo detected"))?;
     print_separator("OpenBSD Update");
-    run_type
+    ctx.run_type()
         .execute(sudo)
         .args(&["/usr/sbin/sysupgrade", "-n"])
         .status_checked()
 }
 
-pub fn upgrade_packages(sudo: Option<&PathBuf>, run_type: RunType) -> Result<()> {
-    let sudo = require_option(sudo, String::from("No sudo detected"))?;
+pub fn upgrade_packages(ctx: &ExecutionContext) -> Result<()> {
+    let sudo = require_option(ctx.sudo().as_ref(), String::from("No sudo detected"))?;
     print_separator("OpenBSD Packages");
-    run_type
+    ctx.run_type()
         .execute(sudo)
         .args(&["/usr/sbin/pkg_add", "-u"])
         .status_checked()

--- a/src/steps/os/windows.rs
+++ b/src/steps/os/windows.rs
@@ -8,7 +8,6 @@ use tracing::debug;
 
 use crate::command::CommandExt;
 use crate::execution_context::ExecutionContext;
-use crate::executor::RunType;
 use crate::terminal::{print_separator, print_warning};
 use crate::utils::require;
 use crate::{error::SkipStep, steps::git::Repositories};
@@ -54,16 +53,16 @@ pub fn run_winget(ctx: &ExecutionContext) -> Result<()> {
         .status_checked()
 }
 
-pub fn run_scoop(cleanup: bool, run_type: RunType) -> Result<()> {
+pub fn run_scoop(cleanup: bool, ctx: &ExecutionContext) -> Result<()> {
     let scoop = require("scoop")?;
 
     print_separator("Scoop");
 
-    run_type.execute(&scoop).args(["update"]).status_checked()?;
-    run_type.execute(&scoop).args(["update", "*"]).status_checked()?;
+    ctx.run_type().execute(&scoop).args(["update"]).status_checked()?;
+    ctx.run_type().execute(&scoop).args(["update", "*"]).status_checked()?;
 
     if cleanup {
-        run_type.execute(&scoop).args(["cleanup", "*"]).status_checked()?;
+        ctx.run_type().execute(&scoop).args(["cleanup", "*"]).status_checked()?;
     }
 
     Ok(())

--- a/src/steps/tmux.rs
+++ b/src/steps/tmux.rs
@@ -7,7 +7,6 @@ use color_eyre::eyre::Context;
 use color_eyre::eyre::Result;
 
 use crate::command::CommandExt;
-use crate::executor::RunType;
 use crate::terminal::print_separator;
 use crate::HOME_DIR;
 use crate::{
@@ -18,12 +17,12 @@ use crate::{
 #[cfg(unix)]
 use std::os::unix::process::CommandExt as _;
 
-pub fn run_tpm(run_type: RunType) -> Result<()> {
+pub fn run_tpm(ctx: &ExecutionContext) -> Result<()> {
     let tpm = HOME_DIR.join(".tmux/plugins/tpm/bin/update_plugins").require()?;
 
     print_separator("tmux plugins");
 
-    run_type.execute(tpm).arg("all").status_checked()
+    ctx.run_type().execute(tpm).arg("all").status_checked()
 }
 
 struct Tmux {

--- a/src/steps/vim.rs
+++ b/src/steps/vim.rs
@@ -4,7 +4,7 @@ use crate::HOME_DIR;
 use color_eyre::eyre::Result;
 use etcetera::base_strategy::BaseStrategy;
 
-use crate::executor::{Executor, ExecutorOutput, RunType};
+use crate::executor::{Executor, ExecutorOutput};
 use crate::terminal::print_separator;
 use crate::{
     execution_context::ExecutionContext,
@@ -141,10 +141,10 @@ pub fn upgrade_neovim(ctx: &ExecutionContext) -> Result<()> {
     )
 }
 
-pub fn run_voom(run_type: RunType) -> Result<()> {
+pub fn run_voom(ctx: &ExecutionContext) -> Result<()> {
     let voom = require("voom")?;
 
     print_separator("voom");
 
-    run_type.execute(voom).arg("update").status_checked()
+    ctx.run_type().execute(voom).arg("update").status_checked()
 }

--- a/src/steps/zsh.rs
+++ b/src/steps/zsh.rs
@@ -8,13 +8,12 @@ use walkdir::WalkDir;
 
 use crate::command::CommandExt;
 use crate::execution_context::ExecutionContext;
-use crate::executor::RunType;
 use crate::git::Repositories;
 use crate::terminal::print_separator;
 use crate::utils::{require, PathExt};
 use crate::HOME_DIR;
 
-pub fn run_zr(run_type: RunType) -> Result<()> {
+pub fn run_zr(ctx: &ExecutionContext) -> Result<()> {
     let zsh = require("zsh")?;
 
     require("zr")?;
@@ -22,7 +21,10 @@ pub fn run_zr(run_type: RunType) -> Result<()> {
     print_separator("zr");
 
     let cmd = format!("source {} && zr --update", zshrc().display());
-    run_type.execute(zsh).args(["-l", "-c", cmd.as_str()]).status_checked()
+    ctx.run_type()
+        .execute(zsh)
+        .args(["-l", "-c", cmd.as_str()])
+        .status_checked()
 }
 
 fn zdotdir() -> PathBuf {
@@ -49,16 +51,16 @@ pub fn run_antidote(ctx: &ExecutionContext) -> Result<()> {
         .status_checked()
 }
 
-pub fn run_antibody(run_type: RunType) -> Result<()> {
+pub fn run_antibody(ctx: &ExecutionContext) -> Result<()> {
     require("zsh")?;
     let antibody = require("antibody")?;
 
     print_separator("antibody");
 
-    run_type.execute(antibody).arg("update").status_checked()
+    ctx.run_type().execute(antibody).arg("update").status_checked()
 }
 
-pub fn run_antigen(run_type: RunType) -> Result<()> {
+pub fn run_antigen(ctx: &ExecutionContext) -> Result<()> {
     let zsh = require("zsh")?;
     let zshrc = zshrc().require()?;
     env::var("ADOTDIR")
@@ -69,10 +71,13 @@ pub fn run_antigen(run_type: RunType) -> Result<()> {
     print_separator("antigen");
 
     let cmd = format!("source {} && (antigen selfupdate ; antigen update)", zshrc.display());
-    run_type.execute(zsh).args(["-l", "-c", cmd.as_str()]).status_checked()
+    ctx.run_type()
+        .execute(zsh)
+        .args(["-l", "-c", cmd.as_str()])
+        .status_checked()
 }
 
-pub fn run_zgenom(run_type: RunType) -> Result<()> {
+pub fn run_zgenom(ctx: &ExecutionContext) -> Result<()> {
     let zsh = require("zsh")?;
     let zshrc = zshrc().require()?;
     env::var("ZGEN_SOURCE")
@@ -83,10 +88,13 @@ pub fn run_zgenom(run_type: RunType) -> Result<()> {
     print_separator("zgenom");
 
     let cmd = format!("source {} && zgenom selfupdate && zgenom update", zshrc.display());
-    run_type.execute(zsh).args(["-l", "-c", cmd.as_str()]).status_checked()
+    ctx.run_type()
+        .execute(zsh)
+        .args(["-l", "-c", cmd.as_str()])
+        .status_checked()
 }
 
-pub fn run_zplug(run_type: RunType) -> Result<()> {
+pub fn run_zplug(ctx: &ExecutionContext) -> Result<()> {
     let zsh = require("zsh")?;
     zshrc().require()?;
 
@@ -97,13 +105,13 @@ pub fn run_zplug(run_type: RunType) -> Result<()> {
 
     print_separator("zplug");
 
-    run_type
+    ctx.run_type()
         .execute(zsh)
         .args(["-i", "-c", "zplug update"])
         .status_checked()
 }
 
-pub fn run_zinit(run_type: RunType) -> Result<()> {
+pub fn run_zinit(ctx: &ExecutionContext) -> Result<()> {
     let zsh = require("zsh")?;
     let zshrc = zshrc().require()?;
 
@@ -115,10 +123,13 @@ pub fn run_zinit(run_type: RunType) -> Result<()> {
     print_separator("zinit");
 
     let cmd = format!("source {} && zinit self-update && zinit update --all", zshrc.display(),);
-    run_type.execute(zsh).args(["-i", "-c", cmd.as_str()]).status_checked()
+    ctx.run_type()
+        .execute(zsh)
+        .args(["-i", "-c", cmd.as_str()])
+        .status_checked()
 }
 
-pub fn run_zi(run_type: RunType) -> Result<()> {
+pub fn run_zi(ctx: &ExecutionContext) -> Result<()> {
     let zsh = require("zsh")?;
     let zshrc = zshrc().require()?;
 
@@ -127,10 +138,10 @@ pub fn run_zi(run_type: RunType) -> Result<()> {
     print_separator("zi");
 
     let cmd = format!("source {} && zi self-update && zi update --all", zshrc.display(),);
-    run_type.execute(zsh).args(["-i", "-c", &cmd]).status_checked()
+    ctx.run_type().execute(zsh).args(["-i", "-c", &cmd]).status_checked()
 }
 
-pub fn run_zim(run_type: RunType) -> Result<()> {
+pub fn run_zim(ctx: &ExecutionContext) -> Result<()> {
     let zsh = require("zsh")?;
     env::var("ZIM_HOME")
         .or_else(|_| {
@@ -146,7 +157,7 @@ pub fn run_zim(run_type: RunType) -> Result<()> {
 
     print_separator("zim");
 
-    run_type
+    ctx.run_type()
         .execute(zsh)
         .args(["-i", "-c", "zimfw upgrade && zimfw update"])
         .status_checked()


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

Closes #223 

 The step functions take all sorts of parameters, when I first contributed to `topgrade`, this really confused me and is obviously unfriendly to the new contributors, we should make them all consistent, and add some doc on how to add new steps in `CONTRIBUTING.md`