### PR TITLE
Allow apt-get update to continue to apt-get upgrade with error code 100

### DIFF
--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -431,7 +431,11 @@ fn upgrade_debian(ctx: &ExecutionContext) -> Result<()> {
 
         let is_nala = apt.ends_with("nala");
         if !is_nala {
-            ctx.run_type().execute(sudo).arg(&apt).arg("update").status_checked()?;
+            ctx.run_type()
+                .execute(sudo)
+                .arg(&apt)
+                .arg("update")
+                .status_checked_with_codes(&[0, 100])?;
         }
 
         let mut command = ctx.run_type().execute(sudo);


### PR DESCRIPTION
Closes #377  

## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
