### PR TITLE
refactor: rename update fn name & some cleanup

### DIFF
--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -498,7 +498,7 @@ fn upgrade_solus(ctx: &ExecutionContext) -> Result<()> {
     Ok(())
 }
 
-pub fn update_am(ctx: &ExecutionContext) -> Result<()> {
+pub fn run_am(ctx: &ExecutionContext) -> Result<()> {
     let am = require("am")?;
     if let Some(sudo) = ctx.sudo() {
         ctx.run_type().execute(sudo).arg(am).arg("-u").status_checked()?;
@@ -722,7 +722,7 @@ pub fn run_fwupdmgr(ctx: &ExecutionContext) -> Result<()> {
     updmgr.status_checked_with_codes(&[2])
 }
 
-pub fn flatpak_update(ctx: &ExecutionContext) -> Result<()> {
+pub fn run_flatpak(ctx: &ExecutionContext) -> Result<()> {
     let flatpak = require("flatpak")?;
     let sudo = require_option(ctx.sudo().as_ref(), String::from("sudo is not installed"))?;
     let cleanup = ctx.config().cleanup();


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

## What does this PR do
1. Rename two update functions to `run_xxx()`
2. Some cleanup in `main.rs`, put all update functions that belong to a specific OS together