### PR TITLE
feat: support deepin OS

### DIFF
--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -63,7 +63,7 @@ impl Distribution {
             }
 
             Some("void") => Distribution::Void,
-            Some("debian") | Some("pureos") => Distribution::Debian,
+            Some("debian") | Some("pureos") | Some("Deepin") => Distribution::Debian,
             Some("arch") | Some("anarchy") | Some("manjaro-arm") | Some("garuda") | Some("artix") => Distribution::Arch,
             Some("solus") => Distribution::Solus,
             Some("gentoo") => Distribution::Gentoo,
@@ -1010,5 +1010,10 @@ mod tests {
     #[test]
     fn test_pureos() {
         test_template(include_str!("os_release/pureos"), Distribution::Debian);
+    }
+
+    #[test]
+    fn test_deepin() {
+        test_template(include_str!("os_release/deepin"), Distribution::Debian);
     }
 }

--- a/src/steps/os/os_release/deepin
+++ b/src/steps/os/os_release/deepin
@@ -1,0 +1,8 @@
+PRETTY_NAME="Deepin 20.9"
+NAME="Deepin"
+VERSION_ID="20.9"
+VERSION="20.9"
+VERSION_CODENAME="apricot"
+ID=Deepin
+HOME_URL="https://www.deepin.org/"
+BUG_REPORT_URL="https://bbs.deepin.org/"


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

## What does this PR do
Support [deepin](https://www.deepin.org/index/en) Linux, it is a distro based on `debian`. In its `/etc/os-release` file, there is no `ID_LIKE` field so `topgrade` can not fall back to `debian` in the current impl.

```shell
# before
$ topgrade --dry-run --only system
Error detecting current distribution: Unknown Linux Distribution

# after
$ topgrade --dry-run --only system
── 13:21:35 - System update ────────────────────────────────────────────────────
Dry running: /usr/bin/sudo apt-get update
Dry running: /usr/bin/sudo apt-get dist-upgrade

── 13:21:35 - Summary ──────────────────────────────────────────────────────────
System update: OK
```

 