### PR TITLE
fix: fix panic during container update

### DIFF
--- a/src/steps/containers.rs
+++ b/src/steps/containers.rs
@@ -24,7 +24,7 @@ const NONEXISTENT_REPO: &str = "repository does not exist";
 struct Container {
     /// `Repository` and `Tag`
     ///
-    /// format: `Repository:Tag`, e.g., `fedora:latest`.
+    /// format: `Repository:Tag`, e.g., `nixos/nix:latest`.
     repo_tag: String,
     /// Platform
     ///
@@ -41,7 +41,7 @@ impl Container {
 
 impl Display for Container {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        // e.g., "`fedora/latest` for `linux/amd64`"
+        // e.g., "`fedora:latest` for `linux/amd64`"
         write!(f, "`{}` for `{}`", self.repo_tag, self.platform)
     }
 }
@@ -54,7 +54,7 @@ fn list_containers(crt: &Path) -> Result<Vec<Container>> {
         crt.display()
     );
     let output = Command::new(crt)
-        .args(["image", "ls", "--format", "{{.Repository}}:{{.Tag}}/{{.ID}}"])
+        .args(["image", "ls", "--format", "{{.Repository}}:{{.Tag}} {{.ID}}"])
         .output_checked_with_utf8(|_| Ok(()))?;
 
     let mut retval = vec![];
@@ -78,8 +78,8 @@ fn list_containers(crt: &Path) -> Result<Vec<Container>> {
 
         debug!("Using container '{}'", line);
 
-        // line is of format: `Repository:Tag/ImageID`, e.g., `fedora:latest/be300d2b6d94`.
-        let split_res = line.split('/').collect::<Vec<&str>>();
+        // line is of format: `Repository:Tag ImageID`, e.g., `nixos/nix:latest d80fea9c32b4`
+        let split_res = line.split(' ').collect::<Vec<&str>>();
         assert_eq!(split_res.len(), 2);
         let (repo_tag, image_id) = (split_res[0], split_res[1]);
 


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

-----

This issue is due to a mistake made in #435, in that PR, while listing installed containers, I use `'/'` to separate `repo_tag` and `id`, in the case where `repo_tag` contains `'/'`, e.g., `nixos/nix`, this approach won't work and will panic the whole program:

```shell
$ topgrade --only containers

── 14:28:54 - Containers ───────────────────────────────────────────────────────
The application panicked (crashed).
Message:  assertion failed: `(left == right)`
  left: `3`,
 right: `2`
Location: src/steps/containers.rs:83
```

Related code is here:

```rust
        let split_res = line.split('/').collect::<Vec<&str>>();
        assert_eq!(split_res.len(), 2);
```
If `repo_tag` contains `'/'`, then `split_res` will have length 3 instead of 2.

This patch resolves the issue by separating `repo_tag` and `id` with a blank char `' '` rather than `'/'`.

```shell
$ ./target/debug/topgrade --only containers

── 14:34:31 - Containers ───────────────────────────────────────────────────────
/* omitted */
── 14:35:03 - Summary ──────────────────────────────────────────────────────────
Containers: OK
```