### PR TITLE
feat: Add arguments to pipupgrade and fix enable_pipupgrade check

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -110,9 +110,10 @@
 #nix_arguments = "--flake"
 
 [python]
-#enable_pip_review = true         ###disabled by default
-#enable_pip_review_local = true   ###disabled by default
-#enable_pipupgrade = true         ###disabled by default
+#enable_pip_review = true                         ###disabled by default
+#enable_pip_review_local = true                   ###disabled by default
+#enable_pipupgrade = true                         ###disabled by default
+#pipupgrade_arguments = "-y -u --pip-path pip"    ###disabled by default
 
 [windows]
 # Manually select Windows updates

--- a/src/config.rs
+++ b/src/config.rs
@@ -243,6 +243,7 @@ pub struct Python {
     enable_pip_review: Option<bool>,
     enable_pip_review_local: Option<bool>,
     enable_pipupgrade: Option<bool>,
+    pipupgrade_arguments: Option<String>,
 }
 
 #[derive(Deserialize, Default, Debug, Merge)]
@@ -1461,6 +1462,13 @@ impl Config {
             .as_ref()
             .and_then(|python| python.enable_pipupgrade)
             .unwrap_or(false);
+    }
+    pub fn pipupgrade_arguments(&self) -> &str {
+        self.config_file
+            .python
+            .as_ref()
+            .and_then(|s| s.pipupgrade_arguments.as_deref())
+            .unwrap_or("")
     }
     pub fn enable_pip_review(&self) -> bool {
         return self

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -444,17 +444,19 @@ pub fn run_pipupgrade_update(ctx: &ExecutionContext) -> Result<()> {
     let pipupgrade = require("pipupgrade")?;
 
     print_separator("Pipupgrade");
-    if !ctx.config().enable_pip_review() {
+    if !ctx.config().enable_pipupgrade() {
         print_warning(
             "Pipupgrade is disabled by default. Enable it by setting enable_pipupgrade=true in the configuration.",
         );
         return Err(SkipStep(String::from("Pipupgrade is disabled by default")).into());
     }
-    ctx.run_type().execute(pipupgrade).status_checked()?;
+    ctx.run_type()
+        .execute(pipupgrade)
+        .args(ctx.config().pipupgrade_arguments().split_whitespace())
+        .status_checked()?;
 
     Ok(())
 }
-
 pub fn run_stack_update(ctx: &ExecutionContext) -> Result<()> {
     if require("ghcup").is_ok() {
         // `ghcup` is present and probably(?) being used to install `stack`.


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
