### PR TITLE
fix: Write to correct config path when none exists.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -530,6 +530,7 @@ impl ConfigFile {
 
         // If no config file exists, create a default one in the config directory
         if !res.0.exists() && res.1.is_empty() {
+            res.0 = possible_config_paths[0].clone();
             debug!("No configuration exists");
             write(&res.0, EXAMPLE_CONFIG).map_err(|e| {
                 debug!(


### PR DESCRIPTION
## Standards checklist:

- [x The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
