### PR TITLE
fix: run AM without sudo

### DIFF
--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -528,13 +528,18 @@ fn upgrade_solus(ctx: &ExecutionContext) -> Result<()> {
 
 pub fn run_am(ctx: &ExecutionContext) -> Result<()> {
     let am = require("am")?;
-    if let Some(sudo) = ctx.sudo() {
-        ctx.run_type().execute(sudo).arg(am).arg("-u").status_checked()?;
+
+    print_separator("AM");
+
+    let mut am = ctx.run_type().execute(am);
+
+    if ctx.config().yes(Step::AM) {
+        am.arg("-U");
     } else {
-        print_warning("No sudo detected. Skipping AM Step");
+        am.arg("-u");
     }
 
-    Ok(())
+    am.status_checked()
 }
 
 pub fn run_appman(ctx: &ExecutionContext) -> Result<()> {


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

-----

1. `AM` should not be executed with sudo
2. `am -u` requires the user to answer a prompt, `am -U` does not. So when [`assume_yes = true`](https://github.com/topgrade-rs/topgrade/blob/234ad4bdd7695e5c9961c0930bf9746dcb4a5635/config.example.toml#L9) is set in the configuration, we use `am -U`, otherwise, use `am -u`.

Closes #453
