### PR TITLE
fix: warn user about bad pattern paths before skipping step git

### DIFF
--- a/src/steps/git.rs
+++ b/src/steps/git.rs
@@ -178,15 +178,21 @@ impl Git {
         None
     }
     pub fn multi_pull_step(&self, repositories: &Repositories, ctx: &ExecutionContext) -> Result<()> {
+        // Warn the user about the bad patterns.
+        //
+        // NOTE: this should be executed **before** skipping the Git step or the
+        // user won't receive this warning in the cases where all the paths configured
+        // are bad patterns.
+        repositories
+            .bad_patterns
+            .iter()
+            .for_each(|pattern| print_warning(format!("Path {pattern} did not contain any git repositories")));
+
         if repositories.repositories.is_empty() {
             return Err(SkipStep(String::from("No repositories to pull")).into());
         }
 
         print_separator("Git repositories");
-        repositories
-            .bad_patterns
-            .iter()
-            .for_each(|pattern| print_warning(format!("Path {pattern} did not contain any git repositories")));
         self.multi_pull(repositories, ctx)
     }
 


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

-----

We should warn the user about the bad pattern before skipping the step git:


```shell
$ cat ~/.config/topgrade/topgrade.toml
[git]
pull_predefined = false
repos = [
    "bad_pattern"
]

# No warning at all because all my configured paths are invalid, and thus 
# `Repositories.repositories` `is_empty()`, the git step is skipped
$ topgrade --dry-run --only git_repos
$ echo $?
0

$ ./target/debug/topgrade --dry-run --only git_repos
Path bad_pattern did not contain any git repositories
```



-----


I think besides `Skipped`, we should define another state `NotFound`, when a step's binary is not found in `$PATH`, we use `NotFound` to skip this step instead of `Skipped`. For the case where the binary is found but some conditions are not satisfied during execution (e.g., for git step, no repo is found, like the case described in this PR), we use `Skipped`.

And for a `Skipped` step, a separator should be printed and a warning should be given to the user telling the user why this step was skipped. For a `NotFound` step, we don't need to print a separator as users don't use it at all. 