### PR TITLE
test: test for config file creation and default config file parsing

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -57,3 +57,10 @@ jobs:
           # token: ${{ secrets.CODECOV_TOKEN }}
           files: ./lcov.info
           fail_ci_if_error: true
+      - name: Test creation of config file
+        run: |
+          CONFIG_PATH=~/.config/topgrade.toml;
+          if [ -f "$CONFIG_PATH" ]; then rm $CONFIG_PATH; fi
+          cargo build; 
+          ./target/debug/topgrade --dry-run --only system;
+          stat $CONFIG_PATH;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1508,3 +1508,16 @@ impl Config {
         self.opt.custom_commands.iter().any(|s| s == name)
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::config::ConfigFile;
+
+    /// Test the default configuration in `config.example.toml` is valid.
+    #[test]
+    fn test_default_config() {
+        let str = include_str!("../config.example.toml");
+
+        assert!(toml::from_str::<ConfigFile>(str).is_ok());
+    }
+}


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code passes tests (`cargo test`)

-----

Closes #451

# What does this PR do
1. Add test for:
   1. check the default configuration in `config.example.toml` is valid in `config.rs` (unit test)
   2. `topgrade`  will create a default configuration file in `~/.config.topgrade.toml` (CI)
  

# Some questions
1. It seems that `.github/workflow/test.yaml` is not being run in the CI, only `check-and-lint.yaml` is.
2. Unit tests are not covered in the CI for the reason stated in `1`