### PR TITLE
fix: handle no topgrade.toml but files in topgrade.d

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -602,6 +602,12 @@ impl ConfigFile {
             path
         };
 
+        if config_path == PathBuf::default() {
+            // Here we expect topgrade.d and consequently result is not empty.
+            // If empty, Self:: ensure() would have created the default config.
+            return Ok(result);
+        }
+
         let mut contents_non_split = fs::read_to_string(&config_path).map_err(|e| {
             tracing::error!("Unable to read {}", config_path.display());
             e


### PR DESCRIPTION
When config file(s) exist in `topgrade.d` but no `topgrade.toml` exists, `ensure()`  does not create a default config file.  This causes an error as `read()` assumes the `topgrade.toml` file exists.

This PR assumes the desired behavior is to use just the contents of the files in `topgrade.d`.

Else, one could change `ensure()` to create `topgrade.toml`.
 
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
