### PR TITLE
fix: fix mist

### DIFF
--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -457,6 +457,7 @@ fn upgrade_debian(ctx: &ExecutionContext) -> Result<()> {
             })
             .unwrap_or_else(|| PathBuf::from("apt-get"));
 
+        let is_mist = apt.ends_with("mist");
         let is_nala = apt.ends_with("nala");
         if !is_nala {
             ctx.run_type()
@@ -468,7 +469,7 @@ fn upgrade_debian(ctx: &ExecutionContext) -> Result<()> {
 
         let mut command = ctx.run_type().execute(sudo);
         command.arg(&apt);
-        if is_nala {
+        if is_nala || is_mist {
             command.arg("upgrade");
         } else {
             command.arg("dist-upgrade");


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

Closes #463, cc @jonathan-realman

With this patch, `mist` should be invoked like:

```shell
$ sudo mist update
$ sudo mist upgrade
```
