### PR TITLE
fix: fix Mist

### DIFF
--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -439,26 +439,37 @@ fn upgrade_gentoo(ctx: &ExecutionContext) -> Result<()> {
 }
 
 fn upgrade_debian(ctx: &ExecutionContext) -> Result<()> {
-    if let Some(sudo) = &ctx.sudo() {
-        let apt = which("apt-fast")
-            .or_else(|| {
-                if which("mist").is_some() {
-                    Some(PathBuf::from("mist"))
-                } else {
-                    None
-                }
-            })
-            .or_else(|| {
-                if Path::new("/usr/bin/nala").exists() {
-                    Some(Path::new("/usr/bin/nala").to_path_buf())
-                } else {
-                    None
-                }
-            })
-            .unwrap_or_else(|| PathBuf::from("apt-get"));
+    let apt = which("apt-fast")
+        .or_else(|| {
+            if which("mist").is_some() {
+                Some(PathBuf::from("mist"))
+            } else {
+                None
+            }
+        })
+        .or_else(|| {
+            if Path::new("/usr/bin/nala").exists() {
+                Some(Path::new("/usr/bin/nala").to_path_buf())
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| PathBuf::from("apt-get"));
 
-        let is_mist = apt.ends_with("mist");
-        let is_nala = apt.ends_with("nala");
+    let is_mist = apt.ends_with("mist");
+    let is_nala = apt.ends_with("nala");
+
+    // MIST does not require `sudo`
+    if is_mist {
+        ctx.run_type().execute(&apt).arg("update").status_checked()?;
+        ctx.run_type().execute(&apt).arg("upgrade").status_checked()?;
+
+        // Simply return as MIST does not have `clean` and `autoremove`
+        // subcommands, neither the `-y` option (for now maybe?).
+        return Ok(());
+    }
+
+    if let Some(sudo) = &ctx.sudo() {
         if !is_nala {
             ctx.run_type()
                 .execute(sudo)
@@ -469,7 +480,7 @@ fn upgrade_debian(ctx: &ExecutionContext) -> Result<()> {
 
         let mut command = ctx.run_type().execute(sudo);
         command.arg(&apt);
-        if is_nala || is_mist {
+        if is_nala {
             command.arg("upgrade");
         } else {
             command.arg("dist-upgrade");

--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -457,6 +457,7 @@ fn upgrade_debian(ctx: &ExecutionContext) -> Result<()> {
             })
             .unwrap_or_else(|| PathBuf::from("apt-get"));
 
+        let is_mist = apt.ends_with("mist");
         let is_nala = apt.ends_with("nala");
         if !is_nala {
             ctx.run_type()
@@ -468,7 +469,7 @@ fn upgrade_debian(ctx: &ExecutionContext) -> Result<()> {
 
         let mut command = ctx.run_type().execute(sudo);
         command.arg(&apt);
-        if is_nala {
+        if is_nala || is_mist {
             command.arg("upgrade");
         } else {
             command.arg("dist-upgrade");


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

Closes https://github.com/topgrade-rs/topgrade/issues/463, cc @jonathan-realman

With this patch, mist should be invoked like:
```shell
$ mist update
$ mist upgrade
```
