### PR TITLE
fix: Run AstroUpdate before Lazy sync

### DIFF
--- a/src/steps/upgrade.vim
+++ b/src/steps/upgrade.vim
@@ -1,3 +1,14 @@
+" AstroUpdate calls a plugin manager - Lazy as of this writing. So we check for it before
+" others. Add to init.lua:
+" updater = {
+"   auto_quit = true,
+"   skip_prompts = true,
+" },
+if exists(":AstroUpdate")
+   echo "AstroUpdate"
+   AstroUpdate
+endif
+
 if exists(":NeoBundleUpdate")
     echo "NeoBundle"
     NeoBundleUpdate
@@ -36,11 +47,6 @@ endif
 if exists(":Lazy")
     echo "Lazy Update"
     Lazy! sync | qa
-endif
-
-if exists(":AstroUpdate")
-   echo "AstroUpdate"
-   AstroUpdate
 endif
 
 if exists(':PackerSync')

--- a/src/steps/upgrade.vim
+++ b/src/steps/upgrade.vim
@@ -1,12 +1,12 @@
 " AstroUpdate calls a plugin manager - Lazy as of this writing. So we check for it before
 " others. Add to init.lua:
 " updater = {
-"   auto_quit = true,
 "   skip_prompts = true,
 " },
 if exists(":AstroUpdate")
    echo "AstroUpdate"
    AstroUpdate
+   quitall
 endif
 
 if exists(":NeoBundleUpdate")


### PR DESCRIPTION
AstroNvim switched to using `Lazy` to manage plugins some weeks back.
For users of AstroNvim:
- Without this PR, topgrade runs `Lazy sync` (since `:Lazy` exists via AstroNvim) and quits without updating AstroNvim.
- With this PR, AstroUpdate is called if it exists before checking for existence of `Lazy.nvim`. AstroUpdate will update the plugins (using Lazy currently) as needed. So the explicit call to `Lazy sync` in `upgrade.vim` becomes unnecessary.

I suggest that users of AstroNvim add
```
  updater = {
    skip_prompts = true,
  },
```
to their `init.lua` to automatically confirm and quit AstroNvim after `AstroUpdate` and skip the redundant call to `Lazy sync`.
Users not using AstroNvim should be unaffected.


## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
