### PR TITLE
fix: fix wrong path in oh-my-bash

### DIFF
--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -155,7 +155,7 @@ pub fn run_oh_my_bash(ctx: &ExecutionContext) -> Result<()> {
     print_separator("oh-my-bash");
 
     let mut update_script = oh_my_bash;
-    update_script.push_str("tools/upgrade.sh");
+    update_script.push_str("/tools/upgrade.sh");
 
     ctx.run_type().execute("bash").arg(update_script).status_checked()
 }


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

Closes #476 

cc @BackSpace54, [here](https://github.com/SteveLauC/topgrade/releases/tag/oh-my-bash-fix) is a build for Linux with this patch included, you can try it so that we can know if this patch works or not:)
