### PR TITLE
refactor(config): move sudo_command to section misc

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -370,6 +370,8 @@ pub struct Vim {
 pub struct Misc {
     pre_sudo: Option<bool>,
 
+    sudo_command: Option<SudoKind>,
+
     #[merge(strategy = crate::utils::merge_strategies::vec_prepend_opt)]
     git_repos: Option<Vec<String>>,
 
@@ -439,8 +441,6 @@ pub struct ConfigFile {
 
     #[merge(strategy = crate::utils::merge_strategies::inner_merge_opt)]
     misc: Option<Misc>,
-
-    sudo_command: Option<SudoKind>,
 
     #[merge(strategy = crate::utils::merge_strategies::commands_merge_opt)]
     pre_commands: Option<Commands>,
@@ -1389,7 +1389,7 @@ impl Config {
     }
 
     pub fn sudo_command(&self) -> Option<SudoKind> {
-        self.config_file.sudo_command
+        self.config_file.misc.as_ref().and_then(|misc| misc.sudo_command)
     }
 
     /// If `true`, `sudo` should be called after `pre_commands` in order to elevate at the


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

-----

### What does this PR do
In the previous implementation, config entry `sudo_command` is not under the section `[misc]`, but in our example config file, it is. This PR moves it to the section `[misc]`, closes #483.

```
$ cat ~/.config/topgrade.toml
[misc]
sudo_command = "please"

$ topgrade 
ERROR Failed to deserialize /home/steve/.config/topgrade/topgrade.toml: unknown field `sudo_command`, expected one of `pre_sudo`, `git_repos`, `predefined_git_repos`, `disable`, `ignore_failures`, `remote_topgrades`, `remote_topgrade_path`, `ssh_arguments`, `git_arguments`, `tmux_arguments`, `set_title`, `display_time`, `assume_yes`, `yay_arguments`, `aura_aur_arguments`, `aura_pacman_arguments`, `no_retry`, `run_in_tmux`, `cleanup`, `notify_each_step`, `accept_all_windows_updates`, `skip_notify`, `bashit_branch`, `only`, `no_self_update` for key `misc` at line 1 column 1


$ ./target/debug/topgrade --verbose
Loaded configuration: ConfigFile { include: None, misc: Some(Misc { pre_sudo: None, sudo_command: Some(Please), git_repos: None, predefined_git_repos: None, disable: None, ignore_failures: None, remote_topgrades: None, remote_topgrade_path: None, ssh_arguments: None, git_arguments: None, tmux_arguments: None, set_title: None, display_time: None, assume_yes: None, yay_arguments: None, aura_aur_arguments: None, aura_pacman_arguments: None, no_retry: None, run_in_tmux: None, cleanup: None, notify_each_step: None, accept_all_windows_updates: None, skip_notify: None, bashit_branch: None, only: None, no_self_update: None }), pre_commands: None, post_commands: None, commands: None, python: None, composer: None, brew: None, linux: None, git: None, windows: None, npm: None, yarn: None, vim: None, firmware: None, vagrant: None, flatpak: None, distrobox: None }
```


### Breaking Change
This config change should be considered as a breaking change. 


