### PR TITLE
fix(generic): add alternate binary name for spicetify

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -720,7 +720,8 @@ pub fn bin_update(ctx: &ExecutionContext) -> Result<()> {
 }
 
 pub fn spicetify_upgrade(ctx: &ExecutionContext) -> Result<()> {
-    let spicetify = require("spicetify")?;
+    // As of 04-07-2023 NixOS packages Spicetify with the `spicetify-cli` binary name
+    let spicetify = require("spicetify").or(require("spicetify-cli"))?;
 
     print_separator("Spicetify");
     ctx.run_type().execute(spicetify).arg("upgrade").status_checked()


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

[NixOS](https://github.com/NixOS/nixpkgs) packages spicetify as `spicetify-cli` which means the step is skipped on NixOS machines even if spicetify is actually present.
