### PR TITLE
ci: separate code-coverage and test-config-creation

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -57,10 +57,3 @@ jobs:
           # token: ${{ secrets.CODECOV_TOKEN }}
           files: ./lcov.info
           fail_ci_if_error: true
-      - name: Test creation of config file
-        run: |
-          CONFIG_PATH=~/.config/topgrade.toml;
-          if [ -f "$CONFIG_PATH" ]; then rm $CONFIG_PATH; fi
-          cargo build; 
-          ./target/debug/topgrade --dry-run --only system;
-          stat $CONFIG_PATH;

--- a/.github/workflows/test-config-creation.yml
+++ b/.github/workflows/test-config-creation.yml
@@ -1,0 +1,21 @@
+name: Test Configuration File Creation
+
+on:
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+
+jobs:
+  TestConfig:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - run: |
+          CONFIG_PATH=~/.config/topgrade.toml;
+          if [ -f "$CONFIG_PATH" ]; then rm $CONFIG_PATH; fi
+          cargo build; 
+          ./target/debug/topgrade --dry-run --only system;
+          stat $CONFIG_PATH;


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
-----

### What does this PR do

CI `code-coverage` is kinda useless? It makes CI fail for almost all the PRs, this PR separates `code-coverage` and `test-config-creation` so that we can disable `code-coverage`.