### PR TITLE
Update only base conda env

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -339,7 +339,7 @@ pub fn run_conda_update(ctx: &ExecutionContext) -> Result<()> {
     print_separator("Conda");
 
     let mut command = ctx.run_type().execute(conda);
-    command.args(["update", "--all"]);
+    command.args(["update", "--all", "-n", "base"]);
     if ctx.config().yes(Step::Conda) {
         command.arg("--yes");
     }
@@ -360,7 +360,7 @@ pub fn run_mamba_update(ctx: &ExecutionContext) -> Result<()> {
     print_separator("Mamba");
 
     let mut command = ctx.run_type().execute(mamba);
-    command.args(["update", "--all"]);
+    command.args(["update", "--all", "-n", "base"]);
     if ctx.config().yes(Step::Mamba) {
         command.arg("--yes");
     }


### PR DESCRIPTION
Please update just the base env, it is common to have others environment activated and I don't want to update them. The important bit that should be updated is the base env, I modified the code to update just the base environment in conda and also in mamba.

## Standards checklist:

- [ ] The PR title is descriptive.
- [ ] I have read `CONTRIBUTING.md`
- [ ] The code compiles (`cargo build`)
- [ ] The code passes rustfmt (`cargo fmt`)
- [ ] The code passes clippy (`cargo clippy`)
- [ ] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
