### PR TITLE
fix(oh-my-zsh): fix remote oh-my-zsh issue

### DIFF
--- a/src/steps/zsh.rs
+++ b/src/steps/zsh.rs
@@ -180,6 +180,7 @@ pub fn run_oh_my_zsh(ctx: &ExecutionContext) -> Result<()> {
         let output = Command::new("zsh")
             .args([
                 "-c",
+                // ` > /dev/null` is used in case the user's zshrc will have some stdout output.
                 format!("source {} > /dev/null && echo $ZSH", zshrc_path.display()).as_str(),
             ])
             .output_checked_utf8()?;


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

Closes #477 

-----

#### Root cause of that issue

See [this comment](https://github.com/topgrade-rs/topgrade/issues/477#issuecomment-1629936602)

#### Solution
We judge if we are running under `ssh` [through environment variables `SSH_CLIENT` and `SSH_TTY`](https://unix.stackexchange.com/a/9607/498440), if yes, we spawn a `zsh` process and make `zshrc` sourced, then we extract the environment variable `ZSH` from this process, and set it in the `topgrade` process.

#### Fixed issues
1. #477 
2. If a user has a custom `oh-my-zsh` installation (not `~/.oh-my-zsh`) on a remote machine and the user tries to update `oh-my-zsh` on that remote machine through topgrade, then this step will be skipped as environment variable `ZSH` is absent and the hardcoded fallback path (`~/.oh-my-zsh`) does not exist. This is pretty similar to #426 but on a remote machine, this patch also fixes it.
