### PR TITLE
steps/toolbx: Don't self-update and don't send notifications

### DIFF
--- a/src/steps/toolbx.rs
+++ b/src/steps/toolbx.rs
@@ -52,6 +52,8 @@ pub fn run_toolbx(ctx: &ExecutionContext) -> Result<()> {
             topgrade_path,
             "--only",
             "system",
+            "--no-self-update",
+            "--skip-notify",
         ];
         if ctx.config().yes(Step::Toolbx) {
             args.push("--yes");


### PR DESCRIPTION
This PR refines the `toolbx` update step, which is currently implemented as entering into the target toolbx container and then executing the running `topgrade` executable from there. The following changes to topgrades behavior in the toolbx container are made:

- Don't perform anther topgrade self-update (because the "outer" topgrade will have done that before)
- Don't show "update finished" notifications (because this is confusing and leads users to believe that topgrade finished rather quickly)

## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
