### PR TITLE
Fix clippy warning about non_minimal_cfg

### DIFF
--- a/src/steps/emacs.rs
+++ b/src/steps/emacs.rs
@@ -1,4 +1,4 @@
-#[cfg(any(windows))]
+#[cfg(windows)]
 use std::env;
 use std::path::{Path, PathBuf};
 


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

A new [`non_minimal_cfg`](https://rust-lang.github.io/rust-clippy/master/index.html#/non_minimal_cfg) warning was added in Rust 1.71.0, fixing the occurence here