### PR TITLE
chore: bump ci toolchain and MSRV

### DIFF
--- a/.github/workflows/check-and-lint.yaml
+++ b/.github/workflows/check-and-lint.yaml
@@ -7,7 +7,7 @@ on:
 name: CI
 
 env:
-  RUST_VER: '1.68.0'
+  RUST_VER: '1.71.0'
   CROSS_VER: '0.2.5'
   CARGO_NET_RETRY: 3
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ To remedy this, **Topgrade** detects which tools you use and runs the appropriat
 Other systems users can either use `cargo install` or the compiled binaries from the release page.
 The compiled binaries contain a self-upgrading feature.
 
-Topgrade requires Rust 1.60 or above.
+> Currently, Topgrade requires Rust 1.65 or above. In general, Topgrade tracks 
+> the latest stable toolchain.
 
 ## Usage
 

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -383,7 +383,7 @@ pub fn run_nix(ctx: &ExecutionContext) -> Result<()> {
 
     #[cfg(target_os = "macos")]
     {
-        if let Ok(..) = require("darwin-rebuild") {
+        if require("darwin-rebuild").is_ok() {
             return Err(SkipStep(String::from(
                 "Nix-darwin on macOS must be upgraded via darwin-rebuild switch",
             ))


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

-----

#### What does this PR do
1. bump CI toolchain to the latest stable toolchain: 1.71.0
2. Correct the MSRV in README