### PR TITLE
feat: extra arguments for Home Manager

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -57,6 +57,9 @@
 # Whether to self update (this is ignored if the binary has been built without self update support, available also via setting the environment variable TOPGRADE_NO_SELF_UPGRADE)
 #no_self_update = true
 
+# Extra Home Manager arguments
+#home_manager_arguments = "--flake"
+
 # Commands to run before anything
 [pre_commands]
 #"Emacs Snapshot" = "rm -rf ~/.emacs.d/elpa.bak && cp -rl ~/.emacs.d/elpa ~/.emacs.d/elpa.bak"

--- a/config.example.toml
+++ b/config.example.toml
@@ -58,7 +58,7 @@
 #no_self_update = true
 
 # Extra Home Manager arguments
-#home_manager_arguments = "--flake"
+#home_manager_arguments = ["--flake", "file"]
 
 # Commands to run before anything
 [pre_commands]

--- a/src/config.rs
+++ b/src/config.rs
@@ -430,6 +430,8 @@ pub struct Misc {
     only: Option<Vec<Step>>,
 
     no_self_update: Option<bool>,
+
+    home_manager_arguments: Option<String>,
 }
 
 #[derive(Deserialize, Default, Debug, Merge)]
@@ -1273,6 +1275,14 @@ impl Config {
             .linux
             .as_ref()
             .and_then(|linux| linux.nix_arguments.as_deref())
+    }
+
+    /// Extra Home Manager arguments
+    pub fn home_manager(&self) -> Option<&str> {
+        self.config_file
+            .misc
+            .as_ref()
+            .and_then(|misc| misc.home_manager_arguments.as_deref())
     }
 
     /// Distrobox use root

--- a/src/config.rs
+++ b/src/config.rs
@@ -351,6 +351,9 @@ pub struct Linux {
 
     #[merge(strategy = crate::utils::merge_strategies::string_append_opt)]
     emerge_update_flags: Option<String>,
+
+    #[merge(strategy = crate::utils::merge_strategies::vec_prepend_opt)]
+    home_manager_arguments: Option<Vec<String>>,
 }
 
 #[derive(Deserialize, Default, Debug, Merge)]
@@ -430,8 +433,6 @@ pub struct Misc {
     only: Option<Vec<Step>>,
 
     no_self_update: Option<bool>,
-
-    home_manager_arguments: Option<String>,
 }
 
 #[derive(Deserialize, Default, Debug, Merge)]
@@ -1278,11 +1279,11 @@ impl Config {
     }
 
     /// Extra Home Manager arguments
-    pub fn home_manager(&self) -> Option<&str> {
+    pub fn home_manager(&self) -> Option<&Vec<String>> {
         self.config_file
-            .misc
+            .linux
             .as_ref()
-            .and_then(|misc| misc.home_manager_arguments.as_deref())
+            .and_then(|misc| misc.home_manager_arguments.as_ref())
     }
 
     /// Distrobox use root

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -442,7 +442,15 @@ pub fn run_home_manager(ctx: &ExecutionContext) -> Result<()> {
     let home_manager = require("home-manager")?;
 
     print_separator("home-manager");
-    ctx.run_type().execute(home_manager).arg("switch").status_checked()
+
+    let mut cmd = ctx.run_type().execute(home_manager);
+    cmd.arg("switch");
+
+    if let Some(extra_args) = ctx.config().home_manager() {
+        cmd.arg(extra_args);
+    }
+
+    cmd.status_checked()
 }
 
 pub fn run_tldr(ctx: &ExecutionContext) -> Result<()> {

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -447,7 +447,7 @@ pub fn run_home_manager(ctx: &ExecutionContext) -> Result<()> {
     cmd.arg("switch");
 
     if let Some(extra_args) = ctx.config().home_manager() {
-        cmd.arg(extra_args);
+        cmd.args(extra_args);
     }
 
     cmd.status_checked()


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

-----

#### What does this PR do
1. Add a config entry, enabling users to add extra arguments to Home Manager, closes #497
