### PR TITLE
Omz remote

### DIFF
--- a/src/steps/zsh.rs
+++ b/src/steps/zsh.rs
@@ -188,7 +188,10 @@ pub fn run_oh_my_zsh(ctx: &ExecutionContext) -> Result<()> {
                 .as_str(),
             ])
             .output_checked_utf8()?;
-        env::set_var("ZSH", output.stdout.trim());
+        let zsh_env = output.stdout.trim();
+        if !zsh_env.is_empty() {
+            env::set_var("ZSH", zsh_env);
+        }
     }
 
     let oh_my_zsh = env::var("ZSH")

--- a/src/steps/zsh.rs
+++ b/src/steps/zsh.rs
@@ -181,7 +181,11 @@ pub fn run_oh_my_zsh(ctx: &ExecutionContext) -> Result<()> {
             .args([
                 "-c",
                 // ` > /dev/null` is used in case the user's zshrc will have some stdout output.
-                format!("source {} > /dev/null && echo $ZSH", zshrc_path.display()).as_str(),
+                format!(
+                    "source {} > /dev/null && export -p | grep ZSH > /dev/null && echo $ZSH",
+                    zshrc_path.display()
+                )
+                .as_str(),
             ])
             .output_checked_utf8()?;
         env::set_var("ZSH", output.stdout.trim());


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

-----

@OldWorldOrdr This patch should resolve the issue you posted [here](https://github.com/topgrade-rs/topgrade/issues/514#issuecomment-1650127732)

This time we check if `ZSH` is exported or not, and ONLY set it for topgrade when `ZSH` is set and exported.