### PR TITLE
feat: support miktex packages update

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -145,6 +145,7 @@ pub enum Step {
     Krew,
     Macports,
     Mamba,
+    Miktex,
     Mas,
     Maza,
     Micro,

--- a/src/main.rs
+++ b/src/main.rs
@@ -322,6 +322,7 @@ fn run() -> Result<()> {
     runner.execute(Step::Pipx, "pipx", || generic::run_pipx_update(&ctx))?;
     runner.execute(Step::Conda, "conda", || generic::run_conda_update(&ctx))?;
     runner.execute(Step::Mamba, "mamba", || generic::run_mamba_update(&ctx))?;
+    runner.execute(Step::Miktex, "miktex", || generic::run_miktex_packages_update(&ctx))?;
     runner.execute(Step::Pip3, "pip3", || generic::run_pip3_update(&ctx))?;
     runner.execute(Step::PipReview, "pip-review", || generic::run_pip_review_update(&ctx))?;
     runner.execute(Step::PipReviewLocal, "pip-review (local)", || {

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -367,6 +367,16 @@ pub fn run_mamba_update(ctx: &ExecutionContext) -> Result<()> {
     command.status_checked()
 }
 
+pub fn run_miktex_packages_update(ctx: &ExecutionContext) -> Result<()> {
+    let miktex = require("miktex")?;
+    print_separator("miktex");
+
+    ctx.run_type()
+        .execute(miktex)
+        .args(["packages", "update"])
+        .status_checked()
+}
+
 pub fn run_pip3_update(ctx: &ExecutionContext) -> Result<()> {
     let py = require("python").and_then(check_is_python_2_or_shim);
     let py3 = require("python3").and_then(check_is_python_2_or_shim);


### PR DESCRIPTION
## What does this PR do

MiKTeX is a modern TeX distribution, with integrated package manager which installs missing components from the Internet, if required. This allows you to keep your TeX installation as minimal as possible

Links of the project:
- https://miktex.org/
- https://github.com/MiKTeX/miktex

I use Topgrade regularly with great success but observed this upgrade is still missing. I consequently made this PR to fix it.
Update is done with the integrated updater with the command `miktex packages update`, and I tested myself on Ubuntu 20.04.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
