### PR TITLE
feat: support Vscode packages updates

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -189,6 +189,7 @@ pub enum Step {
     Vagrant,
     Vcpkg,
     Vim,
+    Vscode,
     Winget,
     Wsl,
     WslUpdate,

--- a/src/main.rs
+++ b/src/main.rs
@@ -320,6 +320,9 @@ fn run() -> Result<()> {
     runner.execute(Step::Opam, "opam", || generic::run_opam_update(&ctx))?;
     runner.execute(Step::Vcpkg, "vcpkg", || generic::run_vcpkg_update(&ctx))?;
     runner.execute(Step::Pipx, "pipx", || generic::run_pipx_update(&ctx))?;
+    runner.execute(Step::Vscode, "Visual Studio Code extensions", || {
+        generic::run_vscode_extensions_upgrade(&ctx)
+    })?;
     runner.execute(Step::Conda, "conda", || generic::run_conda_update(&ctx))?;
     runner.execute(Step::Mamba, "mamba", || generic::run_mamba_update(&ctx))?;
     runner.execute(Step::Pip3, "pip3", || generic::run_pip3_update(&ctx))?;

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -318,6 +318,26 @@ pub fn run_vcpkg_update(ctx: &ExecutionContext) -> Result<()> {
     command.args(["upgrade", "--no-dry-run"]).status_checked()
 }
 
+pub fn run_vscode_extensions_upgrade(ctx: &ExecutionContext) -> Result<()> {
+    let vscode = require("code")?;
+    print_separator("Visual Studio Code");
+
+    let extensions = Command::new(&vscode)
+        .arg("--list-extensions")
+        .output_checked_utf8()?
+        .stdout;
+
+    for extension in extensions.split_whitespace() {
+        ctx.run_type()
+            .execute(&vscode)
+            .args(["--force", "--install-extension", extension])
+            .status_checked()
+            .with_context(|| format!("Failed to update Visual Studio Code extension {extension}"))?;
+    }
+
+    Ok(())
+}
+
 pub fn run_pipx_update(ctx: &ExecutionContext) -> Result<()> {
     let pipx = require("pipx")?;
     print_separator("pipx");

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -322,11 +322,14 @@ pub fn run_vscode_extensions_upgrade(ctx: &ExecutionContext) -> Result<()> {
     let vscode = require("code")?;
     print_separator("Visual Studio Code extensions");
 
+    // Vscode does not have CLI command to upgrade all extensions (see https://github.com/microsoft/vscode/issues/56578)
+    // Instead we get the list of installed extensions with `code --list-extensions` command (obtain a line-return separated list of installed extensions)
     let extensions = Command::new(&vscode)
         .arg("--list-extensions")
         .output_checked_utf8()?
         .stdout;
 
+    // Then we construct the upgrade command: `code --force --install-extension [ext0] --install-extension [ext1] ... --install-extension [extN]`
     if !extensions.is_empty() {
         let mut command_args = vec!["--force"];
         for extension in extensions.split_whitespace() {

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -327,12 +327,13 @@ pub fn run_vscode_extensions_upgrade(ctx: &ExecutionContext) -> Result<()> {
         .output_checked_utf8()?
         .stdout;
 
-    for extension in extensions.split_whitespace() {
-        ctx.run_type()
-            .execute(&vscode)
-            .args(["--force", "--install-extension", extension])
-            .status_checked()
-            .with_context(|| format!("Failed to update Visual Studio Code extension {extension}"))?;
+    if !extensions.is_empty() {
+        let mut command_args = vec!["--force"];
+        for extension in extensions.split_whitespace() {
+            command_args.extend(["--install-extension", extension]);
+        }
+
+        ctx.run_type().execute(&vscode).args(command_args).status_checked()?;
     }
 
     Ok(())

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -320,7 +320,7 @@ pub fn run_vcpkg_update(ctx: &ExecutionContext) -> Result<()> {
 
 pub fn run_vscode_extensions_upgrade(ctx: &ExecutionContext) -> Result<()> {
     let vscode = require("code")?;
-    print_separator("Visual Studio Code");
+    print_separator("Visual Studio Code extensions");
 
     let extensions = Command::new(&vscode)
         .arg("--list-extensions")


### PR DESCRIPTION
## What does this PR do

Visual studio code IDE automatically updates extensions only when it is opened. It forces then to reload its windows, which is a (small but existing) annoyance.
I use Topgrade regularly with great success but observed it does not yet handle these extensions. I consequently made this PR to add this update.

Vscode extensions cli update is not trivial because no universal upgrade command exists ( a [coresponding issue](https://github.com/microsoft/vscode/issues/56578) has been opened but not implemented). The steps I use are:
- get list of installed extensions with `code --list-extensions` (obtain a line-return separated list of installed extensions)
- construct the upgrade command and execute it
  - `code --force --install-extension [ext0] --install-extension [ext1] ... --install-extension [extN]`

I tested myself on Ubuntu 20.04 (including the case when no extension is installed) and on Windows 10.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [ ] I also tested that Topgrade skips the step where needed

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
