### PR TITLE
chore: add check for dry-run opt in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,10 @@
 - [ ] The code passes clippy (`cargo clippy`)
 - [ ] The code passes tests (`cargo test`)
 - [ ] *Optional:* I have tested the code myself
-    - [ ] I also tested that Topgrade skips the step where needed
+ 
+## For new steps
+- [ ] *Optional:* Topgrade skips this step where needed
+- [ ] *Optional:* The `--dry-run` option works with this step
 
 If you developed a feature or a bug fix for someone else and you do not have the
 means to test it, please tag this person here.


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`


-----

#### What does this PR do
1. Add a check for the `--dry-run` option in the PR template