### PR TITLE
refactor: deprioritize please-sudo

### DIFF
--- a/src/sudo.rs
+++ b/src/sudo.rs
@@ -26,10 +26,10 @@ impl Sudo {
     pub fn detect() -> Option<Self> {
         which("doas")
             .map(|p| (p, SudoKind::Doas))
-            .or_else(|| which("please").map(|p| (p, SudoKind::Please)))
             .or_else(|| which("sudo").map(|p| (p, SudoKind::Sudo)))
             .or_else(|| which("gsudo").map(|p| (p, SudoKind::Gsudo)))
             .or_else(|| which("pkexec").map(|p| (p, SudoKind::Pkexec)))
+            .or_else(|| which("please").map(|p| (p, SudoKind::Please)))
             .map(|(path, kind)| Self { path, kind })
     }
 
@@ -55,12 +55,6 @@ impl Sudo {
                 // See: https://man.openbsd.org/doas
                 cmd.arg("echo");
             }
-            SudoKind::Please => {
-                // From `man please`
-                //   -w, --warm
-                //   Warm the access token and exit.
-                cmd.arg("-w");
-            }
             SudoKind::Sudo => {
                 // From `man sudo` on macOS:
                 //   -v, --validate
@@ -84,6 +78,12 @@ impl Sudo {
                 //
                 // See: https://linux.die.net/man/1/pkexec
                 cmd.arg("echo");
+            }
+            SudoKind::Please => {
+                // From `man please`
+                //   -w, --warm
+                //   Warm the access token and exit.
+                cmd.arg("-w");
             }
         }
         cmd.status_checked().wrap_err("Failed to elevate permissions")
@@ -112,10 +112,10 @@ impl Sudo {
 #[strum(serialize_all = "lowercase")]
 pub enum SudoKind {
     Doas,
-    Please,
     Sudo,
     Gsudo,
     Pkexec,
+    Please,
 }
 
 impl AsRef<OsStr> for Sudo {


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
 
## For new steps
- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

-----

#### What does this PR do

1. Deprioritize the `please` sudo in `Sudo::detect()` as it is [not that popular](https://crates.io/crates/pleaser) when compared to other sudo commands

#### Breaking Change

1. For guys that are using `please`, if you have other sudo commands installed, this is a breaking change,  you need to manually set the sudo command to `please`:

    ```
    [misc]
    sudo_command = "please"
    ```

Closes #539