### PR TITLE
Allow setting `misc.log_filters` in `config.toml`

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -60,6 +60,11 @@
 # Extra Home Manager arguments
 #home_manager_arguments = ["--flake", "file"]
 
+# Extra tracing filter directives
+# These are prepended to the `--log-filter` argument
+# See: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives
+#log_filters = ["topgrade::command=debug", "warn"]
+
 # Commands to run before anything
 [pre_commands]
 #"Emacs Snapshot" = "rm -rf ~/.emacs.d/elpa.bak && cp -rl ~/.emacs.d/elpa ~/.emacs.d/elpa.bak"

--- a/src/config.rs
+++ b/src/config.rs
@@ -436,6 +436,8 @@ pub struct Misc {
     only: Option<Vec<Step>>,
 
     no_self_update: Option<bool>,
+
+    log_filters: Option<Vec<String>>,
 }
 
 #[derive(Deserialize, Default, Debug, Merge)]
@@ -831,14 +833,6 @@ impl CommandLineArgs {
 
     pub fn env_variables(&self) -> &Vec<String> {
         &self.env
-    }
-
-    pub fn tracing_filter_directives(&self) -> String {
-        if self.verbose {
-            "debug".into()
-        } else {
-            self.log_filter.clone()
-        }
     }
 }
 
@@ -1388,6 +1382,19 @@ impl Config {
 
     pub fn verbose(&self) -> bool {
         self.opt.verbose
+    }
+
+    pub fn tracing_filter_directives(&self) -> String {
+        let mut ret = String::new();
+        if let Some(directives) = self.config_file.misc.as_ref().and_then(|m| m.log_filters.as_ref()) {
+            ret.push_str(&directives.join(","));
+        }
+        ret.push(',');
+        ret.push_str(&self.opt.log_filter);
+        if self.verbose() {
+            ret.push_str(",debug");
+        }
+        ret
     }
 
     pub fn show_skipped(&self) -> bool {

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,8 +64,6 @@ fn run() -> Result<()> {
         return Ok(());
     }
 
-    install_tracing(&opt.tracing_filter_directives())?;
-
     for env in opt.env_variables() {
         let mut splitted = env.split('=');
         let var = splitted.next().unwrap();
@@ -84,6 +82,7 @@ fn run() -> Result<()> {
     }
 
     let config = Config::load(opt)?;
+    install_tracing(&config.tracing_filter_directives())?;
     set_title(config.set_title());
     display_time(config.display_time());
     set_desktop_notifications(config.notify_each_step());


### PR DESCRIPTION
This allows setting a list of `log_filters` in the `[misc]` section in the `config.toml`. These filters are prepended to any filters listed with `--log-filters`. Finally, `--verbose` can now be used with `--log-filters`, and it will append `debug` to the list of filters rather than replacing it entirely.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
