### PR TITLE
Add option for nix-env arguments

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -112,6 +112,7 @@
 #suse_dup = false
 #rpm_ostree = false
 #nix_arguments = "--flake"
+#nix_env_arguments = "--prebuilt-only"
 
 [git]
 #max_concurrency = 5

--- a/src/config.rs
+++ b/src/config.rs
@@ -342,6 +342,9 @@ pub struct Linux {
     nix_arguments: Option<String>,
 
     #[merge(strategy = crate::utils::merge_strategies::string_append_opt)]
+    nix_env_arguments: Option<String>,
+
+    #[merge(strategy = crate::utils::merge_strategies::string_append_opt)]
     apt_arguments: Option<String>,
 
     enable_tlmgr: Option<bool>,
@@ -1273,6 +1276,14 @@ impl Config {
             .linux
             .as_ref()
             .and_then(|linux| linux.nix_arguments.as_deref())
+    }
+
+    /// Extra nix-env arguments
+    pub fn nix_env_arguments(&self) -> Option<&str> {
+        self.config_file
+            .linux
+            .as_ref()
+            .and_then(|linux| linux.nix_env_arguments.as_deref())
     }
 
     /// Extra Home Manager arguments

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -423,7 +423,12 @@ pub fn run_nix(ctx: &ExecutionContext) -> Result<()> {
             .arg("--verbose")
             .status_checked()
     } else {
-        run_type.execute(nix_env).arg("--upgrade").status_checked()
+        let mut command = run_type.execute(nix_env);
+        command.arg("--upgrade");
+        if let Some(args) = ctx.config().nix_env_arguments() {
+            command.args(args.split_whitespace());
+        };
+        command.status_checked()
     }
 }
 


### PR DESCRIPTION
Last week `nix-env --upgrade` started compiling chromium because [its build](https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.ungoogled-chromium.x86_64-linux) had not succeeded. To avoid compiling packages myself, I would like to be able to add `--prebuilt-only` to the nix-env arguments.

I have little experience with Rust, but everything seems to work as intended.