### PR TITLE
feat(wsl): pass verbose to topgrade-in-wsl

### DIFF
--- a/src/steps/os/windows.rs
+++ b/src/steps/os/windows.rs
@@ -143,17 +143,22 @@ fn upgrade_wsl_distribution(wsl: &Path, dist: &str, ctx: &ExecutionContext) -> R
     //
     // ```rust
     // command
-    //  .args(["bash", "-c"])
-    //  .arg(format!("exec {topgrade}"));
+    //  .args(["-d", dist, "bash", "-c"])
+    //  .arg(format!("TOPGRADE_PREFIX={dist} exec {topgrade}"));
     // ```
     //
     // creates a command string like:
-    //  `bash -c 'exec /bin/topgrade'`
-    // and using `command.args(...).arg("topgrade").arg("-v")`
-    // on that again creates
-    //  `bash -c 'exec /bin/topgrade' -v`
-    // which means `-v` isn't passed to `topgrade`.
+    // > `C:\WINDOWS\system32\wsl.EXE -d Ubuntu bash -c 'TOPGRADE_PREFIX=Ubuntu exec /bin/topgrade'`
+    //
+    // Adding the following:
+    //
+    // ```rust
+    // command.arg("-v");
     // ```
+    // 
+    // appends the next argument like so:
+    // > `C:\WINDOWS\system32\wsl.EXE -d Ubuntu bash -c 'TOPGRADE_PREFIX=Ubuntu exec /bin/topgrade' -v`
+    // which means `-v` isn't passed to `topgrade`.
     let mut args = String::new();
     if ctx.config().verbose() {
         args.push_str("-v");

--- a/src/steps/os/windows.rs
+++ b/src/steps/os/windows.rs
@@ -128,12 +128,40 @@ fn upgrade_wsl_distribution(wsl: &Path, dist: &str, ctx: &ExecutionContext) -> R
     let topgrade = Command::new(wsl)
         .args(["-d", dist, "bash", "-lc", "which topgrade"])
         .output_checked_utf8()
-        .map_err(|_| SkipStep(String::from("Could not find Topgrade installed in WSL")))?;
+        .map_err(|_| SkipStep(String::from("Could not find Topgrade installed in WSL")))?
+        .stdout // The normal output from `which topgrade` appends a newline, so we trim it here.
+        .trim_end()
+        .to_owned();
 
     let mut command = ctx.run_type().execute(wsl);
+
+    // The `arg` method automatically quotes its arguments.
+    // This means we can't append additional arguments to `topgrade` in WSL
+    // by calling `arg` successively.
+    //
+    // For example:
+    //
+    // ```rust
+    // command
+    //  .args(["bash", "-c"])
+    //  .arg(format!("exec {topgrade}"));
+    // ```
+    //
+    // creates a command string like:
+    //  `bash -c 'exec /bin/topgrade'`
+    // and using `command.args(...).arg("topgrade").arg("-v")`
+    // on that again creates
+    //  `bash -c 'exec /bin/topgrade' -v`
+    // which means `-v` isn't passed to `topgrade`.
+    // ```
+    let mut args = String::new();
+    if ctx.config().verbose() {
+        args.push_str("-v");
+    }
+
     command
         .args(["-d", dist, "bash", "-c"])
-        .arg(format!("TOPGRADE_PREFIX={dist} exec {topgrade}"));
+        .arg(format!("TOPGRADE_PREFIX={dist} exec {topgrade} {args}"));
 
     if ctx.config().yes(Step::Wsl) {
         command.arg("-y");

--- a/src/steps/os/windows.rs
+++ b/src/steps/os/windows.rs
@@ -155,7 +155,7 @@ fn upgrade_wsl_distribution(wsl: &Path, dist: &str, ctx: &ExecutionContext) -> R
     // ```rust
     // command.arg("-v");
     // ```
-    // 
+    //
     // appends the next argument like so:
     // > `C:\WINDOWS\system32\wsl.EXE -d Ubuntu bash -c 'TOPGRADE_PREFIX=Ubuntu exec /bin/topgrade' -v`
     // which means `-v` isn't passed to `topgrade`.


### PR DESCRIPTION
Closes #521



## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
 
## For new steps
- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

@SteveLauC

---

I'd appreciate any feedback about this PR.