### PR TITLE
chore: add the check for the --yes opt in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,6 +11,8 @@
 ## For new steps
 - [ ] *Optional:* Topgrade skips this step where needed
 - [ ] *Optional:* The `--dry-run` option works with this step
+- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
+  the underlying command
 
 If you developed a feature or a bug fix for someone else and you do not have the
 means to test it, please tag this person here.


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)


----

Add check for the `--yes` option in the PR template