### PR TITLE
chore: bump CI toolchain to 1.73.0

### DIFF
--- a/.github/workflows/check-and-lint.yaml
+++ b/.github/workflows/check-and-lint.yaml
@@ -7,7 +7,7 @@ on:
 name: CI
 
 env:
-  RUST_VER: '1.72.1'
+  RUST_VER: '1.73.0'
   CROSS_VER: '0.2.5'
   CARGO_NET_RETRY: 3
 

--- a/src/steps/os/archlinux.rs
+++ b/src/steps/os/archlinux.rs
@@ -277,7 +277,7 @@ impl Aura {
 
 impl ArchPackageManager for Aura {
     fn upgrade(&self, ctx: &ExecutionContext) -> Result<()> {
-        let sudo = which("sudo").unwrap_or_else(PathBuf::new);
+        let sudo = which("sudo").unwrap_or_default();
         let mut aur_update = ctx.run_type().execute(&sudo);
 
         if sudo.ends_with("sudo") {


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
 
## For new steps
- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
