### PR TITLE
Fix builds and runs on DragonFly BSD

### DIFF
--- a/src/steps/os/dragonfly.rs
+++ b/src/steps/os/dragonfly.rs
@@ -20,6 +20,7 @@ pub fn upgrade_packages(ctx: &ExecutionContext) -> Result<()> {
 pub fn audit_packages(ctx: &ExecutionContext) -> Result<()> {
     let sudo = require_option(ctx.sudo().as_ref(), REQUIRE_SUDO.to_string())?;
     println!();
+    #[allow(clippy::disallowed_methods)]
     if !Command::new(sudo)
         .args(["/usr/local/sbin/pkg", "audit", "-Fr"])
         .status()?

--- a/src/steps/os/dragonfly.rs
+++ b/src/steps/os/dragonfly.rs
@@ -2,13 +2,14 @@ use crate::command::CommandExt;
 use crate::execution_context::ExecutionContext;
 use crate::terminal::print_separator;
 use crate::utils::{require_option, REQUIRE_SUDO};
+use crate::Step;
 use color_eyre::eyre::Result;
 use std::process::Command;
 
 pub fn upgrade_packages(ctx: &ExecutionContext) -> Result<()> {
     let sudo = require_option(ctx.sudo().as_ref(), REQUIRE_SUDO.to_string())?;
     print_separator("DragonFly BSD Packages");
-    let mut cmd = ctx.execute(sudo);
+    let mut cmd = ctx.run_type().execute(sudo);
     cmd.args(["/usr/local/sbin/pkg", "upgrade"]);
     if ctx.config().yes(Step::System) {
         cmd.arg("-y");
@@ -19,8 +20,12 @@ pub fn upgrade_packages(ctx: &ExecutionContext) -> Result<()> {
 pub fn audit_packages(ctx: &ExecutionContext) -> Result<()> {
     let sudo = require_option(ctx.sudo().as_ref(), REQUIRE_SUDO.to_string())?;
     println!();
-    Command::new(sudo)
+    if !Command::new(sudo)
         .args(["/usr/local/sbin/pkg", "audit", "-Fr"])
-        .status_checked()?;
+        .status()?
+        .success()
+    {
+        println!("The package audit was successful, but vulnerable packages still remain on the system");
+    }
     Ok(())
 }


### PR DESCRIPTION
* Include a missing use for a referenced type

* Add a missing step to do as is done on the FreeBSD code, which should be the same on this step as for DragonFly BSD

* Go against what clippy says for the sake of not actually crashing if an audit of packages fails. Absent this change, status_checked() will actually cause the run to crash at that step rather than say that that specific step failed and continue, which is not the expected behavior.

## Standards checklist:

- [ X] The PR title is descriptive.
- [X] I have read `CONTRIBUTING.md`
- [X ] The code compiles (`cargo build`)
- [X ] The code passes rustfmt (`cargo fmt`)
- [ ] The code passes clippy (`cargo clippy`)
- [ X] The code passes tests (`cargo test`)
- [ X] *Optional:* I have tested the code myself
 
## For new steps
- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
