### PR TITLE
fix: Support yes option for opam upgrade

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -287,7 +287,13 @@ pub fn run_opam_update(ctx: &ExecutionContext) -> Result<()> {
     print_separator("OCaml Package Manager");
 
     ctx.run_type().execute(&opam).arg("update").status_checked()?;
-    ctx.run_type().execute(&opam).arg("upgrade").status_checked()?;
+
+    let mut command = ctx.run_type().execute(&opam);
+    command.args(["upgrade"]);
+    if ctx.config().yes(Step::Opam) {
+        command.arg("--yes");
+    }
+    command.status_checked()?;
 
     if ctx.config().cleanup() {
         ctx.run_type().execute(&opam).arg("clean").status_checked()?;

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -289,7 +289,7 @@ pub fn run_opam_update(ctx: &ExecutionContext) -> Result<()> {
     ctx.run_type().execute(&opam).arg("update").status_checked()?;
 
     let mut command = ctx.run_type().execute(&opam);
-    command.args(["upgrade"]);
+    command.arg("upgrade");
     if ctx.config().yes(Step::Opam) {
         command.arg("--yes");
     }


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] I have tested the code myself
 
This PR add support for the yes option for the opam package manager.