### PR TITLE
chore: always use the latest stable toolchain for CI

### DIFF
--- a/.github/workflows/check-and-lint.yaml
+++ b/.github/workflows/check-and-lint.yaml
@@ -7,7 +7,7 @@ on:
 name: CI
 
 env:
-  RUST_VER: '1.73.0'
+  RUST_VER: 'stable'
   CROSS_VER: '0.2.5'
   CARGO_NET_RETRY: 3
 


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
 
## For new steps
- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.


## What does this PR do

In the past, I was manually bumping our CI toolchain when a new release was available, this is stupid, so let's make the GitHub action `rust-toolchain` do this for us.
