### PR TITLE
fix: disable dotnet greeting msg with DOTNET_NOLOGO=true

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -676,6 +676,10 @@ pub fn run_dotnet_upgrade(ctx: &ExecutionContext) -> Result<()> {
         .run_type()
         .execute(&dotnet)
         .args(["tool", "list", "--global"])
+        // dotnet will print a greeting message on its first run, from this question:
+        // https://stackoverflow.com/q/70493706/14092446
+        // Setting `DOTNET_NOLOGO` to `true` should disable it
+        .env("DOTNET_NOLOGO", "true")
         .output_checked_utf8()
     {
         Ok(output) => output,


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
 
## For new steps
- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

Closes #572 