### PR TITLE
fix: shellexpand git.pull_only_repos & git.push_only_repos

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -697,6 +697,22 @@ impl ConfigFile {
             }
         }
 
+        if let Some(paths) = result.git.as_mut().and_then(|git| git.pull_only_repos.as_mut()) {
+            for path in paths.iter_mut() {
+                let expanded = shellexpand::tilde::<&str>(&path.as_ref()).into_owned();
+                debug!("Path {} expanded to {}", path, expanded);
+                *path = expanded;
+            }
+        }
+
+        if let Some(paths) = result.git.as_mut().and_then(|git| git.push_only_repos.as_mut()) {
+            for path in paths.iter_mut() {
+                let expanded = shellexpand::tilde::<&str>(&path.as_ref()).into_owned();
+                debug!("Path {} expanded to {}", path, expanded);
+                *path = expanded;
+            }
+        }
+
         debug!("Loaded configuration: {:?}", result);
 
         Ok(result)


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
 
## For new steps
- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

In #574, we forgot to shell expand the paths, this PR fixes it.

```
$ cat ~/.config/topgrade/topgrade.toml
[misc]
assume_yes = true
disable = ["pip3", "gnome_shell_extensions", "node", "rustup", "containers", "firmware"]
pre_sudo = true

[git]
pull_predefined = false
pull_only_repos = [
    "~/Documents/dotfiles",
]

# before
$ topgrade --only git_repos -v --dry-run
DEBUG Step "Git repositories"
Path ~/Documents/dotfiles did not contain any git repositories

# after
$ ./target/topgrade --only git_repos -v --dry-run
── 18:19:46 - Git repositories ─────────────────────────────────────────────────
Would pull /home/steve/Documents/dotfiles
```


