### PR TITLE
switch git push and pull order

### DIFF
--- a/src/steps/git.rs
+++ b/src/steps/git.rs
@@ -234,8 +234,8 @@ impl Git {
         }
 
         print_separator("Git repositories");
-        self.multi_push(repositories, ctx)?;
         self.multi_pull(repositories, ctx)?;
+        self.multi_push(repositories, ctx)?;
 
         Ok(())
     }


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
 
When I implemented this feature I maintained the push pull order for testing and forgot to switch it. Noticing now that this will make the step fail of only pulls are necessary. Switching the order should be good enough for the majority of cases, as it's what git itself suggests. 