### PR TITLE
fix: make logger work while loading config file

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -10,6 +10,8 @@ use color_eyre::eyre::Context;
 
 use crate::error::TopgradeError;
 
+use tracing::debug;
+
 /// Like [`Output`], but UTF-8 decoded.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Utf8Output {
@@ -183,7 +185,7 @@ impl CommandExt for Command {
             let err = TopgradeError::ProcessFailedWithOutput(program, output.status, stderr.into_owned());
 
             let ret = Err(err).with_context(|| message);
-            tracing::debug!("Command failed: {ret:?}");
+            debug!("Command failed: {ret:?}");
             ret
         }
     }
@@ -203,7 +205,7 @@ impl CommandExt for Command {
             let (program, _) = get_program_and_args(self);
             let err = TopgradeError::ProcessFailed(program, status);
             let ret = Err(err).with_context(|| format!("Command failed: `{command}`"));
-            tracing::debug!("Command failed: {ret:?}");
+            debug!("Command failed: {ret:?}");
             ret
         }
     }
@@ -239,6 +241,6 @@ fn format_program_and_args(cmd: &Command) -> String {
 
 fn log(cmd: &Command) -> String {
     let command = format_program_and_args(cmd);
-    tracing::debug!("Executing command `{command}`");
+    debug!("Executing command `{command}`");
     command
 }

--- a/src/ctrlc/windows.rs
+++ b/src/ctrlc/windows.rs
@@ -1,5 +1,6 @@
 //! A stub for Ctrl + C handling.
 use crate::ctrlc::interrupted::set_interrupted;
+use tracing::error;
 use winapi::shared::minwindef::{BOOL, DWORD, FALSE, TRUE};
 use winapi::um::consoleapi::SetConsoleCtrlHandler;
 use winapi::um::wincon::CTRL_C_EVENT;
@@ -16,6 +17,6 @@ extern "system" fn handler(ctrl_type: DWORD) -> BOOL {
 
 pub fn set_handler() {
     if 0 == unsafe { SetConsoleCtrlHandler(Some(handler), TRUE) } {
-        tracing::error!("Cannot set a control C handler")
+        error!("Cannot set a control C handler")
     }
 }


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
 
## For new steps
- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

## What does this PR do

1. Make the logger work while loading the configuration file
  
    A few days ago, I noticed that the configuration file was no longer printed in verbose mode, and found that our logger will ONLY be initialized after loading the config file, this behavior was introduced in #552, and this PR fixes it by setting our logger in 2 phases:

    1. Set up it with the log level (filter directives) specified in the CLI option
        ```rs
        let reload_handle = install_tracing(&opt.tracing_filter_directives())?;
        ```
    2. Update it with the log levels specified in the CLI option and the config file
        ```rs
       update_tracing(&reload_handle, &config.tracing_filter_directives())?;
        ```
       
        For more details, see the code comments
2. Replace the default log level setting with a const variable `DEFAULT_LOG_LEVEL`
3. Style change, import `tracing::<log_macro!>` when using it