### PR TITLE
refactor: make SelfUpdate a step

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -127,6 +127,7 @@ pub enum Step {
     Rustup,
     Scoop,
     Sdkman,
+    SelfUpdate,
     Sheldon,
     Shell,
     Snap,

--- a/src/self_update.rs
+++ b/src/self_update.rs
@@ -3,6 +3,7 @@ use std::env;
 use std::os::unix::process::CommandExt as _;
 use std::process::Command;
 
+use crate::config::Step;
 use color_eyre::eyre::{bail, Result};
 use self_update_crate::backends::github::Update;
 use self_update_crate::update::UpdateStatus;
@@ -20,6 +21,7 @@ pub fn self_update(ctx: &ExecutionContext) -> Result<()> {
         println!("Would self-update");
         Ok(())
     } else {
+        let assume_yes = ctx.config().yes(Step::SelfUpdate);
         let current_exe = env::current_exe();
 
         let target = self_update_crate::get_target();
@@ -31,7 +33,7 @@ pub fn self_update(ctx: &ExecutionContext) -> Result<()> {
             .show_output(true)
             .show_download_progress(true)
             .current_version(self_update_crate::cargo_crate_version!())
-            .no_confirm(true)
+            .no_confirm(assume_yes)
             .build()?
             .update_extended()?;
 

--- a/src/self_update.rs
+++ b/src/self_update.rs
@@ -11,52 +11,60 @@ use super::terminal::*;
 #[cfg(windows)]
 use crate::error::Upgraded;
 
-pub fn self_update() -> Result<()> {
+use crate::execution_context::ExecutionContext;
+
+pub fn self_update(ctx: &ExecutionContext) -> Result<()> {
     print_separator("Self update");
-    let current_exe = env::current_exe();
 
-    let target = self_update_crate::get_target();
-    let result = Update::configure()
-        .repo_owner("topgrade-rs")
-        .repo_name("topgrade")
-        .target(target)
-        .bin_name(if cfg!(windows) { "topgrade.exe" } else { "topgrade" })
-        .show_output(false)
-        .show_download_progress(true)
-        .current_version(self_update_crate::cargo_crate_version!())
-        .no_confirm(true)
-        .build()?
-        .update_extended()?;
-
-    if let UpdateStatus::Updated(release) = &result {
-        println!("\nTopgrade upgraded to {}:\n", release.version);
-        if let Some(body) = &release.body {
-            println!("{body}");
-        }
+    if ctx.run_type().dry() {
+        println!("Would self-update");
+        Ok(())
     } else {
-        println!("Topgrade is up-to-date");
-    }
+        let current_exe = env::current_exe();
 
-    {
-        if result.updated() {
-            print_warning("Respawning...");
-            let mut command = Command::new(current_exe?);
-            command.args(env::args().skip(1)).env("TOPGRADE_NO_SELF_UPGRADE", "");
+        let target = self_update_crate::get_target();
+        let result = Update::configure()
+            .repo_owner("topgrade-rs")
+            .repo_name("topgrade")
+            .target(target)
+            .bin_name(if cfg!(windows) { "topgrade.exe" } else { "topgrade" })
+            .show_output(true)
+            .show_download_progress(true)
+            .current_version(self_update_crate::cargo_crate_version!())
+            .no_confirm(true)
+            .build()?
+            .update_extended()?;
 
-            #[cfg(unix)]
-            {
-                let err = command.exec();
-                bail!(err);
+        if let UpdateStatus::Updated(release) = &result {
+            println!("\nTopgrade upgraded to {}:\n", release.version);
+            if let Some(body) = &release.body {
+                println!("{body}");
             }
+        } else {
+            println!("Topgrade is up-to-date");
+        }
 
-            #[cfg(windows)]
-            {
-                #[allow(clippy::disallowed_methods)]
-                let status = command.status()?;
-                bail!(Upgraded(status));
+        {
+            if result.updated() {
+                print_info("Respawning...");
+                let mut command = Command::new(current_exe?);
+                command.args(env::args().skip(1)).env("TOPGRADE_NO_SELF_UPGRADE", "");
+
+                #[cfg(unix)]
+                {
+                    let err = command.exec();
+                    bail!(err);
+                }
+
+                #[cfg(windows)]
+                {
+                    #[allow(clippy::disallowed_methods)]
+                    let status = command.status()?;
+                    bail!(Upgraded(status));
+                }
             }
         }
-    }
 
-    Ok(())
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
 
## For new steps
- [x] *Optional:* Topgrade skips this step where needed
- [x] *Optional:* The `--dry-run` option works with this step
- [x] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

## What does this PR do

Make self_update a step

```sh
$ cargo b --features self-update -q

$ ./target/debug/topgrade  --only self_update

── 12:14:01 - Self update ──────────────────────────────────────────────────────
Checking target-arch... x86_64-unknown-linux-gnu
Checking current version... v10.0.2
Checking latest released version... v12.0.2
New release found! v10.0.2 --> v12.0.2
New release is *NOT* compatible

topgrade release status:
  * Current exe: "/tmp/topgrade/target/debug/topgrade"
  * New exe release: "topgrade-v12.0.2-x86_64-unknown-linux-gnu.tar.gz"
  * New exe download url: "https://api.github.com/repos/topgrade-rs/topgrade/releases/assets/118492348"

The new release will be downloaded/extracted and the existing binary will be replaced.
Downloading...
[00:00:01] [========================================] 5.54MiB/5.54MiB (0s) Done
Extracting archive... Done
Replacing binary file... Done

Topgrade upgraded to 12.0.2:
```