### PR TITLE
fix: omz remote execution if ZSH is not present

### DIFF
--- a/src/steps/zsh.rs
+++ b/src/steps/zsh.rs
@@ -187,8 +187,8 @@ pub fn run_oh_my_zsh(ctx: &ExecutionContext) -> Result<()> {
 
         let stdout = output.stdout;
 
+        let prefix = "export ZSH=";
         for line in stdout.lines() {
-            let prefix = "export ZSH=";
             if line.contains(prefix) {
                 let zsh_env = line.trim_start_matches(prefix);
                 debug!("Oh-my-zsh: under SSH, setting ZSH={}", zsh_env);


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
 
## For new steps
- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

Closes #587 
