### PR TITLE
Fix oh-my-zsh upgrade

### DIFF
--- a/src/steps/zsh.rs
+++ b/src/steps/zsh.rs
@@ -239,7 +239,7 @@ pub fn run_oh_my_zsh(ctx: &ExecutionContext) -> Result<()> {
         println!("Pulling custom plugins and themes");
         ctx.git().multi_pull(&custom_repos, ctx)?;
     }
-
+    env::set_current_dir(&oh_my_zsh)?;
     ctx.run_type()
         .execute("zsh")
         .arg(&oh_my_zsh.join("tools/upgrade.sh"))


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
 
Without cd ~/.oh-my-zsh code fails with:

```
~ topgrade --only shell

── 22:05:31 - oh-my-zsh ────────────────────────────────────────────────────────
fatal: not a git repository (or any of the parent directories): .git
fatal: not in a git directory
fatal: not in a git directory
fatal: not in a git directory
fatal: not in a git directory
fatal: not in a git directory
fatal: not in a git directory
fatal: --local can only be used inside a git repository
fatal: --local can only be used inside a git repository
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
```