### PR TITLE
Add option to ignore containers to pull

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -223,3 +223,5 @@
 # use_root = false
 
 # containers = ["archlinux-latest"]
+[containers]
+# ignored_containers = ["ghcr.io/rancher-sandbox/rancher-desktop/rdx-proxy:latest"]

--- a/src/config.rs
+++ b/src/config.rs
@@ -161,6 +161,13 @@ pub struct Include {
 
 #[derive(Deserialize, Default, Debug, Merge)]
 #[serde(deny_unknown_fields)]
+pub struct Containers {
+    #[merge(strategy = crate::utils::merge_strategies::vec_prepend_opt)]
+    ignored_containers: Option<Vec<String>>,
+}
+
+#[derive(Deserialize, Default, Debug, Merge)]
+#[serde(deny_unknown_fields)]
 pub struct Git {
     max_concurrency: Option<usize>,
 
@@ -410,6 +417,9 @@ pub struct ConfigFile {
 
     #[merge(strategy = crate::utils::merge_strategies::inner_merge_opt)]
     git: Option<Git>,
+
+    #[merge(strategy = crate::utils::merge_strategies::inner_merge_opt)]
+    containers: Option<Containers>,
 
     #[merge(strategy = crate::utils::merge_strategies::inner_merge_opt)]
     windows: Option<Windows>,
@@ -840,6 +850,14 @@ impl Config {
     /// The list of additional git repositories to pull.
     pub fn git_repos(&self) -> Option<&Vec<String>> {
         self.config_file.git.as_ref().and_then(|git| git.repos.as_ref())
+    }
+
+    /// The list of docker/podman containers to ignore.
+    pub fn containers_ignored_tags(&self) -> Option<&Vec<String>> {
+        self.config_file
+            .containers
+            .as_ref()
+            .and_then(|containers| containers.ignored_containers.as_ref())
     }
 
     /// Tell whether the specified step should run.


### PR DESCRIPTION
## What
Add a new option to skip containers to pull. This is my first time writing rust, so feedback is appreciated.

## Why

Tools like rancher-desktop add containers that cannot be pulled, resulting in errors.
This option allows to skip containers like these.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
 
