### PR TITLE
Make zinit and zi use parallel updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,14 +42,17 @@ The compiled binaries contain a self-upgrading feature.
 
 Just run `topgrade`.
 
-Visit the documentation at [topgrade-rs.github.io](https://topgrade-rs.github.io/) for more information.
-
-> **Warning**
-> Work in Progress
-
 ## Configuration 
 
 See `config.example.toml` for an example configuration file.
+
+## Migration and Breaking Changes
+
+Whenever there is a **breaking change**, the major version number will be bumped,
+and we will document these changes in the release note, please take a look at 
+it when updated to a major release.
+
+> Got a question? Feel free to open an issue or discussion!
 
 ### Configuration Path
 

--- a/src/steps/zsh.rs
+++ b/src/steps/zsh.rs
@@ -122,7 +122,10 @@ pub fn run_zinit(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("zinit");
 
-    let cmd = format!("source {} && zinit self-update && zinit update --all -p", zshrc.display(),);
+    let cmd = format!(
+        "source {} && zinit self-update && zinit update --all -p",
+        zshrc.display(),
+    );
     ctx.run_type()
         .execute(zsh)
         .args(["-i", "-c", cmd.as_str()])


### PR DESCRIPTION
## Standards checklist:

- [Y] The PR title is descriptive.
- [Y] I have read `CONTRIBUTING.md`
- [Y] The code compiles (`cargo build`)
- [ ] The code passes rustfmt (`cargo fmt`)
- [ ] The code passes clippy (`cargo clippy`)
- [Y] The code passes tests (`cargo test`)
- [Y] *Optional:* I have tested the code myself
 
## For new steps
- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
