### PR TITLE
Skip `nix upgrade-nix` when Nix is installed in a `nix profile`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -272,6 +272,7 @@ fn run() -> Result<()> {
     {
         runner.execute(Step::Yadm, "yadm", || unix::run_yadm(&ctx))?;
         runner.execute(Step::Nix, "nix", || unix::run_nix(&ctx))?;
+        runner.execute(Step::Nix, "nix upgrade-nix", || unix::run_nix_self_upgrade(&ctx))?;
         runner.execute(Step::Guix, "guix", || unix::run_guix(&ctx))?;
         runner.execute(Step::HomeManager, "home-manager", || unix::run_home_manager(&ctx))?;
         runner.execute(Step::Asdf, "asdf", || unix::run_asdf(&ctx))?;


### PR DESCRIPTION
`nix upgrade-nix` errors if `nix` is installed in a `nix profile`:

```
error: directory '/Users/wiggles/.nix-profile/bin' does not appear to be part of a Nix profile
```

Upstream issue: https://github.com/NixOS/nix/issues/5473

This patch duplicates the relevant Nix logic and skips running `nix upgrade-nix` if this error would occur: https://github.com/NixOS/nix/blob/f0180487a0e4c0091b46cb1469c44144f5400240/src/nix/upgrade-nix.cc#L102-L139

I've also split the `nix upgrade-nix` call into a separate step so we can use the `SkipStep` error messages appropriately.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
 
## For new steps
- [x] *Optional:* Topgrade skips this step where needed
- [x] *Optional:* The `--dry-run` option works with this step
- [x] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
