### PR TITLE
fix: zinit default install location

### DIFF
--- a/src/steps/zsh.rs
+++ b/src/steps/zsh.rs
@@ -12,6 +12,8 @@ use crate::git::Repositories;
 use crate::terminal::print_separator;
 use crate::utils::{require, PathExt};
 use crate::HOME_DIR;
+use crate::XDG_DIRS;
+use etcetera::base_strategy::BaseStrategy;
 
 pub fn run_zr(ctx: &ExecutionContext) -> Result<()> {
     let zsh = require("zsh")?;
@@ -117,7 +119,7 @@ pub fn run_zinit(ctx: &ExecutionContext) -> Result<()> {
 
     env::var("ZINIT_HOME")
         .map(PathBuf::from)
-        .unwrap_or_else(|_| HOME_DIR.join(".zinit"))
+        .unwrap_or_else(|_| XDG_DIRS.data_dir().join("zinit"))
         .require()?;
 
     print_separator("zinit");


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
 
## For new steps
- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

From zinit's [README](https://github.com/zdharma-continuum/zinit#automatic), it seems that they have changed their default install location from `~/.zinit` to `~/.local/share/zinit`, making our detection fail, this PR fixes it.
