### PR TITLE
refactor: use `sudo softwareupdate --install --all --restart` to update macOS

### DIFF
--- a/src/steps/os/macos.rs
+++ b/src/steps/os/macos.rs
@@ -56,8 +56,14 @@ pub fn upgrade_macos(ctx: &ExecutionContext) -> Result<()> {
         }
     }
 
-    let mut command = ctx.run_type().execute("softwareupdate");
-    command.args(["--install", "--all"]);
+    // We don't know what the proper command to use here cause the macOS man
+    // page is poor.
+    //
+    // man: https://keith.github.io/xcode-man-pages/softwareupdate.8.html
+    // issue: https://github.com/topgrade-rs/topgrade/issues/546
+    let sudo = require_option(ctx.sudo().as_ref(), REQUIRE_SUDO)?;
+    let mut command = ctx.run_type().execute(sudo);
+    command.args(["softwareupdate", "--install", "--all", "--restart"]);
 
     if should_ask {
         command.arg("--no-scan");


### PR DESCRIPTION
use sudo softwareupdate --install --all --restart to update macOS

for more info, see the discussion in #546

## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
 
## For new steps
- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
