### PR TITLE
fix: remove deprecated brew option '--ignore-pinned'

### DIFF
--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -283,7 +283,7 @@ pub fn run_brew_formula(ctx: &ExecutionContext, variant: BrewVariant) -> Result<
     variant.execute(run_type).arg("update").status_checked()?;
     variant
         .execute(run_type)
-        .args(["upgrade", "--ignore-pinned", "--formula"])
+        .args(["upgrade", "--formula"])
         .status_checked()?;
 
     if ctx.config().cleanup() {


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
 
## For new steps
- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.


-----

According to issue #628, the brew option `--ignore-pinned` has been deprecated and is the default bahavior now, so let's remove it.
