### PR TITLE
feat(brew): adds "greedy-latest" option to Brew

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "rust-analyzer.linkedProjects": [
-        "./Cargo.toml"
-    ]
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "rust-analyzer.linkedProjects": [
+        "./Cargo.toml"
+    ]
+}

--- a/config.example.toml
+++ b/config.example.toml
@@ -104,6 +104,7 @@
 
 [brew]
 # greedy_cask = true
+# greedy_latest = true
 # autoremove = true
 
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -252,6 +252,7 @@ pub struct Flatpak {
 #[serde(deny_unknown_fields)]
 pub struct Brew {
     greedy_cask: Option<bool>,
+    greedy_latest: Option<bool>,
     autoremove: Option<bool>,
 }
 
@@ -1083,6 +1084,15 @@ impl Config {
             .brew
             .as_ref()
             .and_then(|c| c.greedy_cask)
+            .unwrap_or(false)
+    }
+
+    /// Whether Brew cask should be greedy_latest
+    pub fn brew_greedy_latest(&self) -> bool {
+        self.config_file
+            .brew
+            .as_ref()
+            .and_then(|c| c.greedy_latest)
             .unwrap_or(false)
     }
 

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -331,7 +331,6 @@ pub fn run_brew_cask(ctx: &ExecutionContext, variant: BrewVariant) -> Result<()>
         if ctx.config().brew_greedy_latest() {
             brew_args.push("--greedy-latest");
         }
-
     }
 
     variant.execute(run_type).args(&brew_args).status_checked()?;

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -328,6 +328,10 @@ pub fn run_brew_cask(ctx: &ExecutionContext, variant: BrewVariant) -> Result<()>
         if ctx.config().brew_cask_greedy() {
             brew_args.push("--greedy");
         }
+        if ctx.config().brew_greedy_latest() {
+            brew_args.push("--greedy-latest");
+        }
+
     }
 
     variant.execute(run_type).args(&brew_args).status_checked()?;


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself

Adds a new boolean option `greedy_latest` in the config file for Brew/Homebrew, equivalent to the command line option `--greedy-latest` to `brew upgrade`, based on `greedy_cask` itself.

<img width="177" alt="image" src="https://github.com/topgrade-rs/topgrade/assets/53634214/196b5fe0-4a3f-427e-8141-d1aca53ff8f1">

This is because `greedy_cask` invokes brew's `--greddy`, that updates "casks with auto_updates or version :latest". As I've been having some issues in apps with auto update, I decided to add this new option to allow for the git casks to be updated without touching the auto update ones.
<img width="800" alt="image" src="https://github.com/topgrade-rs/topgrade/assets/53634214/7321f73f-fba8-4a77-a6c0-9730371a49e5">

Here is the result of the first test run:

<details>
  <summary>Code test result</summary>
  
  ### Output
  ```code
topgrade/target/debug on  main [!] 
🍎 ❯ ./topgrade --only brew_cask brew_formula

── 21:19:04 - Topgrade 13.0.0 Breaking Changes ─────────────────────────────────
No Breaking changes

Confirmed? (y)es/(N)o
── 21:19:12 - Brew ─────────────────────────────────────────────────────────────
Updated 1 tap (homebrew/cask-fonts).
No changes to formulae or casks.

── 21:19:17 - Brew - Cask ──────────────────────────────────────────────────────
==> Casks with 'auto_updates true' will not be upgraded; pass `--greedy-auto-updates` to upgrade them.
==> Upgrading 5 outdated packages:
homebrew/cask-fonts/font-montserrat latest -> latest
homebrew/cask-fonts/font-red-hat-display latest -> latest
homebrew/cask-fonts/font-red-hat-mono latest -> latest
homebrew/cask-fonts/font-red-hat-text latest -> latest
homebrew/cask-fonts/font-source-code-pro latest -> latest
==> Upgrading font-montserrat
==> Cloning https://github.com/google/fonts.git
Updating /Users/lucio/Library/Caches/Homebrew/Cask/font-montserrat--git-sparse
From https://github.com/google/fonts
   b8198929..837b031e  main       -> origin/main
==> Checking out branch main
Already on 'main'
Your branch is behind 'origin/main' by 221 commits, and can be fast-forwarded.
  (use "git pull" to update your local branch)
HEAD is now at 837b031e Merge pull request #7146 from google/lang-v0515
Warning: No checksum defined for cask 'font-montserrat', skipping verification.
==> Backing Font 'Montserrat-Italic[wght].ttf' up to '/opt/homebrew/Caskroom/font-montserrat/latest/ofl/montse
==> Removing Font '/Users/lucio/Library/Fonts/Montserrat-Italic[wght].ttf'
==> Backing Font 'Montserrat[wght].ttf' up to '/opt/homebrew/Caskroom/font-montserrat/latest/ofl/montserrat/Mo
==> Removing Font '/Users/lucio/Library/Fonts/Montserrat[wght].ttf'
==> Moving Font 'Montserrat-Italic[wght].ttf' to '/Users/lucio/Library/Fonts/Montserrat-Italic[wght].ttf'
==> Moving Font 'Montserrat[wght].ttf' to '/Users/lucio/Library/Fonts/Montserrat[wght].ttf'
==> Purging files for version latest of Cask font-montserrat
🍺  font-montserrat was successfully upgraded!
==> Upgrading font-red-hat-display
==> Cloning https://github.com/google/fonts.git
Updating /Users/lucio/Library/Caches/Homebrew/Cask/font-red-hat-display--git-sparse
From https://github.com/google/fonts
   b8198929..837b031e  main       -> origin/main
==> Checking out branch main
Already on 'main'
Your branch is behind 'origin/main' by 221 commits, and can be fast-forwarded.
  (use "git pull" to update your local branch)
HEAD is now at 837b031e Merge pull request #7146 from google/lang-v0515
Warning: No checksum defined for cask 'font-red-hat-display', skipping verification.
==> Backing Font 'RedHatDisplay-Italic[wght].ttf' up to '/opt/homebrew/Caskroom/font-red-hat-display/latest/of
==> Removing Font '/Users/lucio/Library/Fonts/RedHatDisplay-Italic[wght].ttf'
==> Backing Font 'RedHatDisplay[wght].ttf' up to '/opt/homebrew/Caskroom/font-red-hat-display/latest/ofl/redha
==> Removing Font '/Users/lucio/Library/Fonts/RedHatDisplay[wght].ttf'
==> Moving Font 'RedHatDisplay-Italic[wght].ttf' to '/Users/lucio/Library/Fonts/RedHatDisplay-Italic[wght]
==> Moving Font 'RedHatDisplay[wght].ttf' to '/Users/lucio/Library/Fonts/RedHatDisplay[wght].ttf'
==> Purging files for version latest of Cask font-red-hat-display
🍺  font-red-hat-display was successfully upgraded!
==> Upgrading font-red-hat-mono
==> Cloning https://github.com/google/fonts.git
Updating /Users/lucio/Library/Caches/Homebrew/Cask/font-red-hat-mono--git-sparse
From https://github.com/google/fonts
   b8198929..837b031e  main       -> origin/main
==> Checking out branch main
Already on 'main'
Your branch is behind 'origin/main' by 221 commits, and can be fast-forwarded.
  (use "git pull" to update your local branch)
HEAD is now at 837b031e Merge pull request #7146 from google/lang-v0515
Warning: No checksum defined for cask 'font-red-hat-mono', skipping verification.
==> Backing Font 'RedHatMono-Italic[wght].ttf' up to '/opt/homebrew/Caskroom/font-red-hat-mono/latest/ofl/redh
==> Removing Font '/Users/lucio/Library/Fonts/RedHatMono-Italic[wght].ttf'
==> Backing Font 'RedHatMono[wght].ttf' up to '/opt/homebrew/Caskroom/font-red-hat-mono/latest/ofl/redhatmono/
==> Removing Font '/Users/lucio/Library/Fonts/RedHatMono[wght].ttf'
==> Moving Font 'RedHatMono-Italic[wght].ttf' to '/Users/lucio/Library/Fonts/RedHatMono-Italic[wght].ttf'
==> Moving Font 'RedHatMono[wght].ttf' to '/Users/lucio/Library/Fonts/RedHatMono[wght].ttf'
==> Purging files for version latest of Cask font-red-hat-mono
🍺  font-red-hat-mono was successfully upgraded!
==> Upgrading font-red-hat-text
==> Cloning https://github.com/google/fonts.git
Updating /Users/lucio/Library/Caches/Homebrew/Cask/font-red-hat-text--git-sparse
From https://github.com/google/fonts
   b8198929..837b031e  main       -> origin/main
==> Checking out branch main
Already on 'main'
Your branch is behind 'origin/main' by 221 commits, and can be fast-forwarded.
  (use "git pull" to update your local branch)
HEAD is now at 837b031e Merge pull request #7146 from google/lang-v0515
Warning: No checksum defined for cask 'font-red-hat-text', skipping verification.
==> Backing Font 'RedHatText-Italic[wght].ttf' up to '/opt/homebrew/Caskroom/font-red-hat-text/latest/ofl/redh
==> Removing Font '/Users/lucio/Library/Fonts/RedHatText-Italic[wght].ttf'
==> Backing Font 'RedHatText[wght].ttf' up to '/opt/homebrew/Caskroom/font-red-hat-text/latest/ofl/redhattext/
==> Removing Font '/Users/lucio/Library/Fonts/RedHatText[wght].ttf'
==> Moving Font 'RedHatText-Italic[wght].ttf' to '/Users/lucio/Library/Fonts/RedHatText-Italic[wght].ttf'
==> Moving Font 'RedHatText[wght].ttf' to '/Users/lucio/Library/Fonts/RedHatText[wght].ttf'
==> Purging files for version latest of Cask font-red-hat-text
🍺  font-red-hat-text was successfully upgraded!
==> Upgrading font-source-code-pro
==> Cloning https://github.com/google/fonts.git
Updating /Users/lucio/Library/Caches/Homebrew/Cask/font-source-code-pro--git-sparse
From https://github.com/google/fonts
   b8198929..837b031e  main       -> origin/main
==> Checking out branch main
Already on 'main'
Your branch is behind 'origin/main' by 221 commits, and can be fast-forwarded.
  (use "git pull" to update your local branch)
HEAD is now at 837b031e Merge pull request #7146 from google/lang-v0515
Warning: No checksum defined for cask 'font-source-code-pro', skipping verification.
==> Backing Font 'SourceCodePro-Italic[wght].ttf' up to '/opt/homebrew/Caskroom/font-source-code-pro/latest/of
==> Removing Font '/Users/lucio/Library/Fonts/SourceCodePro-Italic[wght].ttf'
==> Backing Font 'SourceCodePro[wght].ttf' up to '/opt/homebrew/Caskroom/font-source-code-pro/latest/ofl/sourc
==> Removing Font '/Users/lucio/Library/Fonts/SourceCodePro[wght].ttf'
==> Moving Font 'SourceCodePro-Italic[wght].ttf' to '/Users/lucio/Library/Fonts/SourceCodePro-Italic[wght]
==> Moving Font 'SourceCodePro[wght].ttf' to '/Users/lucio/Library/Fonts/SourceCodePro[wght].ttf'
==> Purging files for version latest of Cask font-source-code-pro
🍺  font-source-code-pro was successfully upgraded!

── 21:19:31 - Summary ──────────────────────────────────────────────────────────
Brew (ARM): OK
Brew Cask (ARM): OK
  ```
</details>