### PR TITLE
fix: oh-my-zsh step issue #646

### DIFF
--- a/src/steps/zsh.rs
+++ b/src/steps/zsh.rs
@@ -180,9 +180,12 @@ pub fn run_oh_my_zsh(ctx: &ExecutionContext) -> Result<()> {
     // the ZSH variable for topgrade here.
     if ctx.under_ssh() {
         let res_env_zsh = Command::new("zsh")
-            .args(["-ic", "print -- ${ZSH:?}"])
+            // don't remove the `-r` option as it can cause problems
+            // see https://github.com/topgrade-rs/topgrade/commit/2edeadfc1c914bf2d9a12cd24ee021f191107041#r137513092
+            .args(["-ic", "print -r -- ${ZSH:?}"])
             .output_checked_utf8();
 
+        // this command will fail if `ZSH` is not set
         if let Ok(output) = res_env_zsh {
             let env_zsh = output.stdout;
             debug!("Oh-my-zsh: under SSH, setting ZSH={}", env_zsh);

--- a/src/steps/zsh.rs
+++ b/src/steps/zsh.rs
@@ -180,14 +180,12 @@ pub fn run_oh_my_zsh(ctx: &ExecutionContext) -> Result<()> {
     // the ZSH variable for topgrade here.
     if ctx.under_ssh() {
         let res_env_zsh = Command::new("zsh")
-            // don't remove the `-r` option as it can cause problems
-            // see https://github.com/topgrade-rs/topgrade/commit/2edeadfc1c914bf2d9a12cd24ee021f191107041#r137513092
-            .args(["-ic", "print -r -- ${ZSH:?}"])
+            .args(["-ic", "print -rn -- ${ZSH:?}"])
             .output_checked_utf8();
 
         // this command will fail if `ZSH` is not set
         if let Ok(output) = res_env_zsh {
-            let env_zsh = output.stdout.trim();
+            let env_zsh = output.stdout;
             debug!("Oh-my-zsh: under SSH, setting ZSH={}", env_zsh);
             env::set_var("ZSH", env_zsh);
         }

--- a/src/steps/zsh.rs
+++ b/src/steps/zsh.rs
@@ -180,7 +180,7 @@ pub fn run_oh_my_zsh(ctx: &ExecutionContext) -> Result<()> {
     // the ZSH variable for topgrade here.
     if ctx.under_ssh() {
         let res_env_zsh = Command::new("zsh")
-            .args(["-ic", "print -- ${ABC:?}"])
+            .args(["-ic", "print -- ${ZSH:?}"])
             .output_checked_utf8();
 
         if let Ok(output) = res_env_zsh {

--- a/src/steps/zsh.rs
+++ b/src/steps/zsh.rs
@@ -187,7 +187,7 @@ pub fn run_oh_my_zsh(ctx: &ExecutionContext) -> Result<()> {
 
         // this command will fail if `ZSH` is not set
         if let Ok(output) = res_env_zsh {
-            let env_zsh = output.stdout;
+            let env_zsh = output.stdout.trim();
             debug!("Oh-my-zsh: under SSH, setting ZSH={}", env_zsh);
             env::set_var("ZSH", env_zsh);
         }

--- a/src/steps/zsh.rs
+++ b/src/steps/zsh.rs
@@ -180,7 +180,7 @@ pub fn run_oh_my_zsh(ctx: &ExecutionContext) -> Result<()> {
     // the ZSH variable for topgrade here.
     if ctx.under_ssh() {
         let res_env_zsh = Command::new("zsh")
-            .args([ "-ic", "print -- ${ABC:?}"])
+            .args(["-ic", "print -- ${ABC:?}"])
             .output_checked_utf8();
 
         if let Ok(output) = res_env_zsh {


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself


This PR fixes #646 by using the script provided by @romkatv, I am not entirely sure about the root cause of that issue, but obviously, [the new script is better](https://github.com/topgrade-rs/topgrade/issues/646#issuecomment-1902569885), so let's use it instead, thanks for your help:)
