### PR TITLE
fix vscode extensions update step

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -349,7 +349,7 @@ fn run() -> Result<()> {
     runner.execute(Step::Vcpkg, "vcpkg", || generic::run_vcpkg_update(&ctx))?;
     runner.execute(Step::Pipx, "pipx", || generic::run_pipx_update(&ctx))?;
     runner.execute(Step::Vscode, "Visual Studio Code extensions", || {
-        generic::run_vscode_extensions_upgrade(&ctx)
+        generic::run_vscode_extensions_update(&ctx)
     })?;
     runner.execute(Step::Conda, "conda", || generic::run_conda_update(&ctx))?;
     runner.execute(Step::Mamba, "mamba", || generic::run_mamba_update(&ctx))?;

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -15,7 +15,6 @@ use tracing::{debug, error};
 use crate::command::{CommandExt, Utf8Output};
 use crate::execution_context::ExecutionContext;
 use crate::executor::ExecutorOutput;
-use crate::os::linux::is_wsl;
 use crate::terminal::{print_separator, shell};
 use crate::utils::{self, check_is_python_2_or_shim, require, require_option, which, PathExt, REQUIRE_SUDO};
 use crate::Step;
@@ -24,6 +23,18 @@ use crate::{
     error::{SkipStep, StepFailed, TopgradeError},
     terminal::print_warning,
 };
+
+#[cfg(target_os = "linux")]
+pub fn is_wsl() -> Result<bool> {
+    let output = Command::new("uname").arg("-r").output_checked_utf8()?.stdout;
+    debug!("Uname output: {}", output);
+    Ok(output.contains("microsoft"))
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn is_wsl() -> Result<bool> {
+    Ok(false)
+}
 
 pub fn run_cargo_update(ctx: &ExecutionContext) -> Result<()> {
     let cargo_dir = env::var_os("CARGO_HOME")

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -15,6 +15,7 @@ use tracing::{debug, error};
 use crate::command::{CommandExt, Utf8Output};
 use crate::execution_context::ExecutionContext;
 use crate::executor::ExecutorOutput;
+use crate::os::linux::is_wsl;
 use crate::terminal::{print_separator, shell};
 use crate::utils::{self, check_is_python_2_or_shim, require, require_option, which, PathExt, REQUIRE_SUDO};
 use crate::Step;
@@ -325,28 +326,37 @@ pub fn run_vcpkg_update(ctx: &ExecutionContext) -> Result<()> {
     command.args(["upgrade", "--no-dry-run"]).status_checked()
 }
 
-pub fn run_vscode_extensions_upgrade(ctx: &ExecutionContext) -> Result<()> {
-    let vscode = require("code")?;
-    print_separator("Visual Studio Code extensions");
-
-    // Vscode does not have CLI command to upgrade all extensions (see https://github.com/microsoft/vscode/issues/56578)
-    // Instead we get the list of installed extensions with `code --list-extensions` command (obtain a line-return separated list of installed extensions)
-    let extensions = Command::new(&vscode)
-        .arg("--list-extensions")
-        .output_checked_utf8()?
-        .stdout;
-
-    // Then we construct the upgrade command: `code --force --install-extension [ext0] --install-extension [ext1] ... --install-extension [extN]`
-    if !extensions.is_empty() {
-        let mut command_args = vec!["--force"];
-        for extension in extensions.split_whitespace() {
-            command_args.extend(["--install-extension", extension]);
-        }
-
-        ctx.run_type().execute(&vscode).args(command_args).status_checked()?;
+pub fn run_vscode_extensions_update(ctx: &ExecutionContext) -> Result<()> {
+    // Calling vscode in WSL may install a server instead of updating extensions (https://github.com/topgrade-rs/topgrade/issues/594#issuecomment-1782157367)
+    if is_wsl()? {
+        return Err(SkipStep(String::from("Should not run in WSL")).into());
     }
 
-    Ok(())
+    let vscode = require("code")?;
+
+    // Vscode has update command only since 1.86 version ("january 2024" update), disable the update for prior versions
+    // Use command `code --version` which returns 3 lines: version, git commit, instruction set. We parse only the first one
+    let version: Result<Version> = match Command::new("code")
+        .arg("--version")
+        .output_checked_utf8()?
+        .stdout
+        .lines()
+        .next()
+    {
+        Some(item) => Version::parse(item).map_err(|err| err.into()),
+        _ => return Err(SkipStep(String::from("Cannot find vscode version")).into()),
+    };
+
+    if !matches!(version, Ok(version) if version >= Version::new(1, 86, 0)) {
+        return Err(SkipStep(String::from("Too old vscode version to have update extensions command")).into());
+    }
+
+    print_separator("Visual Studio Code extensions");
+
+    ctx.run_type()
+        .execute(vscode)
+        .arg("--update-extensions")
+        .status_checked()
 }
 
 pub fn run_pipx_update(ctx: &ExecutionContext) -> Result<()> {

--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -189,10 +189,16 @@ fn update_bedrock(ctx: &ExecutionContext) -> Result<()> {
     Ok(())
 }
 
-fn is_wsl() -> Result<bool> {
+#[cfg(target_os = "linux")]
+pub fn is_wsl() -> Result<bool> {
     let output = Command::new("uname").arg("-r").output_checked_utf8()?.stdout;
     debug!("Uname output: {}", output);
     Ok(output.contains("microsoft"))
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn is_wsl() -> Result<bool> {
+    Ok(false)
 }
 
 fn upgrade_alpine_linux(ctx: &ExecutionContext) -> Result<()> {

--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -8,6 +8,7 @@ use tracing::{debug, warn};
 use crate::command::CommandExt;
 use crate::error::{SkipStep, TopgradeError};
 use crate::execution_context::ExecutionContext;
+use crate::steps::generic::is_wsl;
 use crate::steps::os::archlinux;
 use crate::terminal::print_separator;
 use crate::utils::{require, require_option, which, PathExt, REQUIRE_SUDO};
@@ -187,18 +188,6 @@ fn update_bedrock(ctx: &ExecutionContext) -> Result<()> {
     }
 
     Ok(())
-}
-
-#[cfg(target_os = "linux")]
-pub fn is_wsl() -> Result<bool> {
-    let output = Command::new("uname").arg("-r").output_checked_utf8()?.stdout;
-    debug!("Uname output: {}", output);
-    Ok(output.contains("microsoft"))
-}
-
-#[cfg(not(target_os = "linux"))]
-pub fn is_wsl() -> Result<bool> {
-    Ok(false)
 }
 
 fn upgrade_alpine_linux(ctx: &ExecutionContext) -> Result<()> {


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
 
## For new steps
- [ ] *Optional:* Topgrade skips this step where needed
- [x] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

Fixes #589
Fixes #593
Fixes #594
Fixes #609

This PR fixes the vscode extensions update in quite a few tricky situations by using the now upstreamed `code --update-extensions` command in the text editor ( [vscode/pull#199893](https://github.com/microsoft/vscode/pull/199893) ). This mean the step was completely rewritten.

Note that the command will only be released with January 2024 release (which should be published by early February) so this means I have NOT been able to properly test the code. This is why I create this as a draft until I can properly test it on the release.

Note also that `is_wls` is now a global function defined and compiled even if the target is not linux. 
This is because I needed `is_wsl` to be global function to be able to properly deactivate the unusual behavior of WSL launching vscode server.