### PR TITLE
workflows(homebrew): replace `Homebrew/actions/bump-formulae` with `Homebrew/actions/bump-packages`

### DIFF
--- a/.github/workflows/update_homebrew.yml
+++ b/.github/workflows/update_homebrew.yml
@@ -29,7 +29,8 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       run: brew install-bundler-gems
     - name: Bump formulae
-      uses: Homebrew/actions/bump-formulae@master
+      uses: Homebrew/actions/bump-packages@master
+      continue-on-error: true
       with:
         # Custom GitHub access token with only the 'public_repo' scope enabled
         token: ${{secrets.HOMEBREW_ACCESS_TOKEN}}


### PR DESCRIPTION
## Standards checklist:

- [ ] The PR title is descriptive.
- [ ] I have read `CONTRIBUTING.md`
- [ ] The code compiles (`cargo build`)
- [ ] The code passes rustfmt (`cargo fmt`)
- [ ] The code passes clippy (`cargo clippy`)
- [ ] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
 
## For new steps
- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

---

> Warning: Homebrew/actions/bump-formulae is deprecated. Please use Homebrew/actions/bump-packages instead.

seeing in https://github.com/topgrade-rs/topgrade/actions/runs/7606040286/job/20711207212