### PR TITLE
feat: skip breaking changes notification with env var

### DIFF
--- a/.github/workflows/test-config-creation.yml
+++ b/.github/workflows/test-config-creation.yml
@@ -17,5 +17,5 @@ jobs:
           CONFIG_PATH=~/.config/topgrade.toml;
           if [ -f "$CONFIG_PATH" ]; then rm $CONFIG_PATH; fi
           cargo build; 
-          ./target/debug/topgrade --dry-run --only system;
+          TOPGRADE_SKIP_BRKC_NOTIFY=true ./target/debug/topgrade --dry-run --only system;
           stat $CONFIG_PATH;

--- a/src/breaking_changes.rs
+++ b/src/breaking_changes.rs
@@ -12,6 +12,7 @@ use crate::XDG_DIRS;
 use color_eyre::eyre::Result;
 use etcetera::base_strategy::BaseStrategy;
 use std::{
+    env::var,
     fs::{read_to_string, OpenOptions},
     io::Write,
     path::PathBuf,
@@ -87,6 +88,16 @@ fn data_dir() -> PathBuf {
 fn keep_file_path() -> PathBuf {
     let keep_file = "topgrade_keep";
     data_dir().join(keep_file)
+}
+
+/// If environment variable `TOPGRADE_SKIP_BRKC_NOTIFY` is set to `true`, then
+/// we won't notify the user of the breaking changes.
+pub(crate) fn should_skip() -> bool {
+    if let Ok(var) = var("TOPGRADE_SKIP_BRKC_NOTIFY") {
+        return var.as_str() == "true";
+    }
+
+    false
 }
 
 /// True if this is the first execution of a major release.

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use std::process::exit;
 use std::time::Duration;
 
-use crate::breaking_changes::{first_run_of_major_release, print_breaking_changes, write_keep_file};
+use crate::breaking_changes::{first_run_of_major_release, print_breaking_changes, should_skip, write_keep_file};
 use clap::CommandFactory;
 use clap::{crate_version, Parser};
 use color_eyre::eyre::Context;
@@ -135,9 +135,13 @@ fn run() -> Result<()> {
     let ctx = execution_context::ExecutionContext::new(run_type, sudo, &git, &config);
     let mut runner = runner::Runner::new(&ctx);
 
-    // If this is the first execution of a major release, inform user of breaking
-    // changes
-    if first_run_of_major_release()? {
+    // If
+    //
+    // 1. the breaking changes notification shouldnot be skipped
+    // 2. this is the first execution of a major release
+    //
+    // inform user of breaking changes
+    if !should_skip() && first_run_of_major_release()? {
         print_breaking_changes();
 
         if prompt_yesno("Confirmed?")? {


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
 
## For new steps
- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

-----

This PR adds a new feature that makes our breaking changes notification skippable, to do this, set `TOPGRADE_SKIP_BRKC_NOTIFY=true` when executing Topgrade:

```sh
$ TOPGRADE_SKIP_BRKC_NOTIFY=true topgrade
```
