### PR TITLE
feat: certbot renew

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -61,6 +61,7 @@ pub enum Step {
     Bun,
     BunPackages,
     Cargo,
+    Certbot,
     Chezmoi,
     Chocolatey,
     Choosenim,

--- a/src/main.rs
+++ b/src/main.rs
@@ -400,6 +400,7 @@ fn run() -> Result<()> {
         generic::run_ghcli_extensions_upgrade(&ctx)
     })?;
     runner.execute(Step::Bob, "Bob", || generic::run_bob(&ctx))?;
+    runner.execute(Step::Certbot, "Certbot", || generic::run_certbot(&ctx))?;
 
     if config.use_predefined_git_repos() {
         if config.should_run(Step::Emacs) {

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -538,6 +538,7 @@ pub fn run_pip_review_update(ctx: &ExecutionContext) -> Result<()> {
 
     Ok(())
 }
+
 pub fn run_pip_review_local_update(ctx: &ExecutionContext) -> Result<()> {
     let pip_review = require("pip-review")?;
 
@@ -557,6 +558,7 @@ pub fn run_pip_review_local_update(ctx: &ExecutionContext) -> Result<()> {
 
     Ok(())
 }
+
 pub fn run_pipupgrade_update(ctx: &ExecutionContext) -> Result<()> {
     let pipupgrade = require("pipupgrade")?;
 
@@ -574,6 +576,7 @@ pub fn run_pipupgrade_update(ctx: &ExecutionContext) -> Result<()> {
 
     Ok(())
 }
+
 pub fn run_stack_update(ctx: &ExecutionContext) -> Result<()> {
     if require("ghcup").is_ok() {
         // `ghcup` is present and probably(?) being used to install `stack`.
@@ -755,7 +758,7 @@ pub fn run_dotnet_upgrade(ctx: &ExecutionContext) -> Result<()> {
             return Err(SkipStep(String::from(
                 "Error running `dotnet tool list`. This is expected when a dotnet runtime is installed but no SDK.",
             ))
-            .into())
+            .into());
         }
     };
 
@@ -904,4 +907,17 @@ pub fn run_bob(ctx: &ExecutionContext) -> Result<()> {
     print_separator("Bob");
 
     ctx.run_type().execute(bob).args(["update", "--all"]).status_checked()
+}
+
+pub fn run_certbot(ctx: &ExecutionContext) -> Result<()> {
+    let sudo = require_option(ctx.sudo().as_ref(), REQUIRE_SUDO.to_string())?;
+    let certbot = require("certbot")?;
+
+    print_separator("Certbot");
+
+    let mut cmd = ctx.run_type().execute(sudo);
+    cmd.arg(certbot);
+    cmd.arg("renew");
+
+    cmd.status_checked()
 }


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
 
## For new steps
- [x] *Optional:* Topgrade skips this step where needed
- [x] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

   The `certbot` command does not seem to support this feature, right @bw1faeh0?

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
