### PR TITLE
feat(container): add optional ingored_prefixes to ignore multiple tags

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -230,3 +230,4 @@
 # containers = ["archlinux-latest"]
 [containers]
 # ignored_containers = ["ghcr.io/rancher-sandbox/rancher-desktop/rdx-proxy:latest"]
+# ingored_prefixes = ["rancher/"]

--- a/src/config.rs
+++ b/src/config.rs
@@ -165,6 +165,7 @@ pub struct Include {
 pub struct Containers {
     #[merge(strategy = crate::utils::merge_strategies::vec_prepend_opt)]
     ignored_containers: Option<Vec<String>>,
+    ignored_prefixes: Option<Vec<String>>,
 }
 
 #[derive(Deserialize, Default, Debug, Merge)]
@@ -853,6 +854,13 @@ impl Config {
         self.config_file.git.as_ref().and_then(|git| git.repos.as_ref())
     }
 
+    /// The list of docker/podman container prefixes to ignore.
+    pub fn containers_ignored_prefixes(&self) -> Option<&Vec<String>> {
+        self.config_file
+            .containers
+            .as_ref()
+            .and_then(|containers| containers.ignored_prefixes.as_ref())
+    }
     /// The list of docker/podman containers to ignore.
     pub fn containers_ignored_tags(&self) -> Option<&Vec<String>> {
         self.config_file


### PR DESCRIPTION
## Standards checklist:

- [X] The PR title is descriptive.
- [X] I have read `CONTRIBUTING.md`
- [X] The code compiles (`cargo build`)
- [X] The code passes rustfmt (`cargo fmt`)
- [X] The code passes clippy (`cargo clippy`)
- [X] The code passes tests (`cargo test`)
- [X] *Optional:* I have tested the code myself
 
## For new steps
- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

My use case - sorry for not creating an issue for that - is that I am using rancher desktop as k8s/docker solution. And I wanted to ignore multiple paths with a prefix.

I am not really sure if this is a huge impact, in my case it was 8-10 tags to ignore, but might be helpful for others. Tagging @JakobFels, since he did the previous container related one; what is your take here? Should we rather ignore things one by one or should we be able to skip with prefix?


At the same time the config options merging strategy might be totally incorrect, can anyone help me out with that part?