### PR TITLE
fix: softwareupdate under dry run

### DIFF
--- a/src/steps/os/macos.rs
+++ b/src/steps/os/macos.rs
@@ -41,7 +41,7 @@ pub fn run_mas(ctx: &ExecutionContext) -> Result<()> {
 pub fn upgrade_macos(ctx: &ExecutionContext) -> Result<()> {
     print_separator("macOS system update");
 
-    let should_ask = !(ctx.config().yes(Step::System)) || (ctx.config().dry_run());
+    let should_ask = !(ctx.config().yes(Step::System) || ctx.config().dry_run());
     if should_ask {
         println!("Finding available software");
         if system_update_available()? {


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself

This is just a simple fix on the macOS softwareupdate step, as the boolean `should_ask` wasn't conditional to dry runs prior.