### PR TITLE
fix: correct typos in output

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -510,7 +510,7 @@ pub fn run_pip3_update(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("pip3");
     if env::var("VIRTUAL_ENV").is_ok() {
-        print_warning("This step is will be skipped when running inside a virtual environment");
+        print_warning("This step is skipped when running inside a virtual environment");
         return Err(SkipStep("Does not run inside a virtual environment".to_string()).into());
     }
 
@@ -693,7 +693,7 @@ pub fn run_composer_update(ctx: &ExecutionContext) -> Result<()> {
 
     if !composer_home.is_descendant_of(&HOME_DIR) {
         return Err(SkipStep(format!(
-            "Composer directory {} isn't a decandent of the user's home directory",
+            "Composer directory {} isn't a descendant of the user's home directory",
             composer_home.display()
         ))
         .into());


### PR DESCRIPTION
Corrects a grammatical issue and a typo in two of the step output messages.

## Standards checklist:

- [X] The PR title is descriptive.
- [X] I have read `CONTRIBUTING.md`
- [X] The code compiles (`cargo build`)
- [X] The code passes rustfmt (`cargo fmt`)
- [X] The code passes clippy (`cargo clippy`)
- [X] The code passes tests (`cargo test`)
- [X] *Optional:* I have tested the code myself
 
## For new steps
- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
