### PR TITLE
ci: add macOS aarch64 check

### DIFF
--- a/.github/workflows/check-and-lint.yaml
+++ b/.github/workflows/check-and-lint.yaml
@@ -54,11 +54,11 @@ jobs:
             os: ubuntu-20.04
 
           - target: x86_64-apple-darwin
-            target_name: macOS
+            target_name: macOS-x86_64
             os: macos-13
 
           - target: aarch64-apple-darwin
-            target_name: macOS
+            target_name: macOS-aarch64
             os: macos-14
 
           - target: x86_64-unknown-netbsd

--- a/.github/workflows/check-and-lint.yaml
+++ b/.github/workflows/check-and-lint.yaml
@@ -55,7 +55,11 @@ jobs:
 
           - target: x86_64-apple-darwin
             target_name: macOS
-            os: macos-11
+            os: macos-13
+
+          - target: aarch64-apple-darwin
+            target_name: macOS
+            os: macos-14
 
           - target: x86_64-unknown-netbsd
             target_name: NetBSD


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
 

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

-----

1. Run CI checks on `aarch64-apple-darwin`
2. Bump macOS amd64 image to macOS-13