### PR TITLE
feat: support msupdate on macOS

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -104,6 +104,7 @@ pub enum Step {
     Mas,
     Maza,
     Micro,
+    Msupdate,
     Myrepos,
     Nix,
     Node,

--- a/src/main.rs
+++ b/src/main.rs
@@ -261,6 +261,7 @@ fn run() -> Result<()> {
         runner.execute(Step::Sparkle, "Sparkle", || macos::run_sparkle(&ctx))?;
         runner.execute(Step::Mas, "App Store", || macos::run_mas(&ctx))?;
         runner.execute(Step::System, "System upgrade", || macos::upgrade_macos(&ctx))?;
+        runner.execute(Step::Msupdate, "msupdate", || macos::run_msupdate(&ctx))?;
     }
 
     #[cfg(target_os = "dragonfly")]

--- a/src/steps/os/macos.rs
+++ b/src/steps/os/macos.rs
@@ -1,7 +1,7 @@
 use crate::command::CommandExt;
 use crate::execution_context::ExecutionContext;
 use crate::terminal::{print_separator, prompt_yesno};
-use crate::utils::{require_option, REQUIRE_SUDO};
+use crate::utils::{require_option, PathExt, REQUIRE_SUDO};
 use crate::{utils::require, Step};
 use color_eyre::eyre::Result;
 use std::fs;
@@ -92,4 +92,23 @@ pub fn run_sparkle(ctx: &ExecutionContext) -> Result<()> {
         }
     }
     Ok(())
+}
+
+pub fn run_msupdate(ctx: &ExecutionContext) -> Result<()> {
+    // Per the documentation
+    //
+    // https://learn.microsoft.com/en-us/deployoffice/mac/update-office-for-mac-using-msupdate
+    //
+    // The binary `msupate` is located at:
+    // `/Library/Application\ Support/Microsoft/MAU2.0/Microsoft\ AutoUpdate.app/Contents/MacOS/msupdate`
+    // and its parent directory is not in `$PATH`
+
+    let msupdate =
+        r#"/Library/Application\ Support/Microsoft/MAU2.0/Microsoft\ AutoUpdate.app/Contents/MacOS/msupdate"#
+            .require()?;
+
+    print_separator("msupdate");
+
+    // Download and install all available updates: ./msupdate --install
+    ctx.run_type().execute(msupdate).arg("--install").status_checked()
 }

--- a/src/steps/os/macos.rs
+++ b/src/steps/os/macos.rs
@@ -103,9 +103,8 @@ pub fn run_msupdate(ctx: &ExecutionContext) -> Result<()> {
     // `/Library/Application\ Support/Microsoft/MAU2.0/Microsoft\ AutoUpdate.app/Contents/MacOS/msupdate`
     // and its parent directory is not in `$PATH`
 
-    let msupdate =
-        r#"/Library/Application\ Support/Microsoft/MAU2.0/Microsoft\ AutoUpdate.app/Contents/MacOS/msupdate"#
-            .require()?;
+    let msupdate = r#"/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate"#
+        .require()?;
 
     print_separator("msupdate");
 


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
 
## For new steps
- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step

  This should work as it only executes one command
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

  `msupdate` does not support such an option

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
