### PR TITLE
Helix fetches grammar as a regular user

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -796,20 +796,19 @@ pub fn run_dotnet_upgrade(ctx: &ExecutionContext) -> Result<()> {
 }
 
 pub fn run_helix_grammars(ctx: &ExecutionContext) -> Result<()> {
-    require("helix")?;
+    let helix = require("helix")?;
 
     print_separator("Helix");
 
-    let sudo = require_option(ctx.sudo().as_ref(), REQUIRE_SUDO.to_string())?;
     ctx.run_type()
-        .execute(sudo)
-        .args(["helix", "--grammar", "fetch"])
+        .execute(&helix)
+        .args(["--grammar", "fetch"])
         .status_checked()
         .with_context(|| "Failed to download helix grammars!")?;
 
     ctx.run_type()
-        .execute(sudo)
-        .args(["helix", "--grammar", "build"])
+        .execute(&helix)
+        .args(["--grammar", "build"])
         .status_checked()
         .with_context(|| "Failed to build helix grammars!")?;
 


### PR DESCRIPTION
Prior to this commit, helix grammars were fetched with sudo privileges. There is no need for this, and it was also a bug. Closes #697 .

## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
 
## For new steps
- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
