### PR TITLE
feat: also detect Helix step with bin name hx

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -796,7 +796,7 @@ pub fn run_dotnet_upgrade(ctx: &ExecutionContext) -> Result<()> {
 }
 
 pub fn run_helix_grammars(ctx: &ExecutionContext) -> Result<()> {
-    let helix = require("helix")?;
+    let helix = require("helix").or(require("hx"))?;
 
     print_separator("Helix");
 


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
 
The binary name of Helix varies from systems, on my host (Fedora, installed with `dnf`), it is called `hx` rather than helix, this PR enables Topgrade to search it with the binary name `hx`.