### PR TITLE
revert: revert 614 to remove the -p option

### DIFF
--- a/src/steps/zsh.rs
+++ b/src/steps/zsh.rs
@@ -124,10 +124,7 @@ pub fn run_zinit(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("zinit");
 
-    let cmd = format!(
-        "source {} && zinit self-update && zinit update --all -p",
-        zshrc.display(),
-    );
+    let cmd = format!("source {} && zinit self-update && zinit update --all", zshrc.display());
     ctx.run_type()
         .execute(zsh)
         .args(["-i", "-c", cmd.as_str()])
@@ -142,7 +139,7 @@ pub fn run_zi(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("zi");
 
-    let cmd = format!("source {} && zi self-update && zi update --all -p", zshrc.display(),);
+    let cmd = format!("source {} && zi self-update && zi update --all", zshrc.display());
     ctx.run_type().execute(zsh).args(["-i", "-c", &cmd]).status_checked()
 }
 


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
 
## For new steps
- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

Revert PR #614 as the `-p` option does not work properly.

Closes #709 
