### PR TITLE
Adds `pyenv` step

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -121,6 +121,7 @@ pub enum Step {
     Pnpm,
     Powershell,
     Protonup,
+    Pyenv,
     Raco,
     Rcm,
     Remotes,

--- a/src/main.rs
+++ b/src/main.rs
@@ -324,6 +324,7 @@ fn run() -> Result<()> {
         runner.execute(Step::GnomeShellExtensions, "Gnome Shell Extensions", || {
             unix::upgrade_gnome_extensions(&ctx)
         })?;
+        runner.execute(Step::Pyenv, "pyenv", || unix::run_pyenv(&ctx))?;
         runner.execute(Step::Sdkman, "SDKMAN!", || unix::run_sdkman(&ctx))?;
         runner.execute(Step::Rcm, "rcm", || unix::run_rcm(&ctx))?;
         runner.execute(Step::Maza, "maza", || unix::run_maza(&ctx))?;

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -580,6 +580,28 @@ pub fn run_pearl(ctx: &ExecutionContext) -> Result<()> {
     ctx.run_type().execute(pearl).arg("update").status_checked()
 }
 
+pub fn run_pyenv(ctx: &ExecutionContext) -> Result<()> {
+    let pyenv = require("pyenv")?;
+    print_separator("pyenv");
+
+    // get PYENV_ROOT
+    let pyenv_dir = var("PYENV_ROOT")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| HOME_DIR.join(".pyenv"));
+
+    // if pyenv_dir does not exist, return
+    if !pyenv_dir.exists() {
+        return Err(SkipStep("Pyenv is installed, but $PYENV_ROOT is not set correctly".to_string()).into());
+    }
+
+    // if pyenv_dir is not a git repo, return
+    if !pyenv_dir.join(".git").exists() {
+        return Err(SkipStep("pyenv is not a git repository".to_string()).into());
+    }
+
+    ctx.run_type().execute(pyenv).arg("update").status_checked()
+}
+
 pub fn run_sdkman(ctx: &ExecutionContext) -> Result<()> {
     let bash = require("bash")?;
 

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -584,17 +584,14 @@ pub fn run_pyenv(ctx: &ExecutionContext) -> Result<()> {
     let pyenv = require("pyenv")?;
     print_separator("pyenv");
 
-    // get PYENV_ROOT
     let pyenv_dir = var("PYENV_ROOT")
         .map(PathBuf::from)
         .unwrap_or_else(|_| HOME_DIR.join(".pyenv"));
 
-    // if pyenv_dir does not exist, return
     if !pyenv_dir.exists() {
         return Err(SkipStep("Pyenv is installed, but $PYENV_ROOT is not set correctly".to_string()).into());
     }
 
-    // if pyenv_dir is not a git repo, return
     if !pyenv_dir.join(".git").exists() {
         return Err(SkipStep("pyenv is not a git repository".to_string()).into());
     }


### PR DESCRIPTION
- Closes #626.

Runs `pyenv update` as the new `pyenv` step, given that all conditions are met:

+ OS is Unix (Windows not supported by Pyenv);
+ The `$PYENV_ROOT` env variable points to a valid location; and
+ `$PYENV_ROOT` points to a Git directory.
    + This last check might not be the case for other methods of installing `pyenv`, for which a `pyenv update` may not be available, or may fail.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - I ran `cargo run -- --verbose --only pyenv`, which works as expected for me, but I'm not sure where/how to add automated unit tests.
 
## For new steps
- [x] *Optional:* Topgrade skips this step where needed
- [x] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command
    - underlying command does not support `--yes`.

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
