### PR TITLE
fix(pipx): adds `--include-injected` argument to `pipx`

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -374,7 +374,7 @@ pub fn run_pipx_update(ctx: &ExecutionContext) -> Result<()> {
     let pipx = require("pipx")?;
     print_separator("pipx");
 
-    let mut command_args = vec!["upgrade-all"];
+    let mut command_args = vec!["upgrade-all", "--include-injected"];
 
     // pipx version 1.4.0 introduced a new command argument `pipx upgrade-all --quiet`
     // (see https://pipx.pypa.io/stable/docs/#pipx-upgrade-all)


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
 
This pull request adds `--include-injected` argument when running `pipx upgrade-all`, otherwise packages injected into the main apps' environments will not be updated.
