### PR TITLE
fix: use env BUN_INSTALL to locate package.json

### DIFF
--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -675,7 +675,12 @@ pub fn run_bun_packages(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("Bun Packages");
 
-    if !HOME_DIR.join(".bun/install/global/package.json").exists() {
+    let mut package_json: PathBuf = var("BUN_INSTALL")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| HOME_DIR.join(".bun"));
+    package_json.push("install/global/package.json");
+
+    if !package_json.exists() {
         println!("No global packages installed");
         return Ok(());
     }


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
 
## For new steps
- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

Closes #733
