### PR TITLE
feat: put step logs in a span

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -34,6 +34,14 @@ impl<'a> Runner<'a> {
         let key = key.into();
         debug!("Step {:?}", key);
 
+        // alter the `func` to put it in a span
+        let func = || {
+            let span =
+                tracing::span!(parent: tracing::Span::none(), tracing::Level::TRACE, "step", step = ?step, key = %key);
+            let _guard = span.enter();
+            func()
+        };
+
         loop {
             match func() {
                 Ok(()) => {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,7 +7,6 @@ use std::process::Command;
 use color_eyre::eyre::Result;
 
 use tracing::{debug, error};
-use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::reload::{Handle, Layer};
 use tracing_subscriber::util::SubscriberInitExt;
@@ -239,10 +238,7 @@ pub fn install_tracing(filter_directives: &str) -> Result<Handle<EnvFilter, Regi
         .or_else(|_| EnvFilter::try_from_default_env())
         .or_else(|_| EnvFilter::try_new(DEFAULT_LOG_LEVEL))?;
 
-    let fmt_layer = fmt::layer()
-        .with_target(false)
-        .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
-        .without_time();
+    let fmt_layer = fmt::layer().with_target(false).without_time();
 
     let (filter, reload_handle) = Layer::new(env_filter);
 


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
 
## For new steps
- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

## What does this PR do

1. Put step logs in a span so that we can clearly see which step a log entry belongs to.
 
Before:
```
DEBUG Cannot find "rpm-ostree"
DEBUG Detected "/usr/bin/dnf" as "dnf"
Dry running: /usr/bin/sudo /usr/bin/dnf upgrade -y
````

After:
```
DEBUG step{step=System key=System update}: Cannot find "rpm-ostree"
DEBUG step{step=System key=System update}: Detected "/usr/bin/dnf" as "dnf"
Dry running: /usr/bin/sudo /usr/bin/dnf upgrade -y
```
   
