### PR TITLE
feat: allow to configure the apt upgrade method on debian

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -167,6 +167,8 @@
 # Extra Home Manager arguments
 # home_manager_arguments = ["--flake", "file"]
 
+# subcommand to use for apt variants != nala (dist-upgrade (default) or upgrade)
+# apt_command = "dist-upgrade"
 
 [git]
 # How many repos to pull at max in parallel

--- a/src/config.rs
+++ b/src/config.rs
@@ -313,6 +313,7 @@ pub struct Linux {
     nix_env_arguments: Option<String>,
 
     #[merge(strategy = crate::utils::merge_strategies::string_append_opt)]
+    apt_command: Option<String>,
     apt_arguments: Option<String>,
 
     enable_tlmgr: Option<bool>,
@@ -1226,6 +1227,15 @@ impl Config {
             .as_ref()
             .and_then(|s| s.aura_pacman_arguments.as_deref())
             .unwrap_or("")
+    }
+
+    /// apt command: upgrade or dist-upgrade
+    pub fn apt_command(&self) -> &str {
+        self.config_file
+            .linux
+            .as_ref()
+            .and_then(|linux| linux.apt_command.as_deref())
+            .unwrap_or("dist-upgrade")
     }
 
     /// Extra apt arguments

--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -518,7 +518,8 @@ fn upgrade_debian(ctx: &ExecutionContext) -> Result<()> {
     if is_nala {
         command.arg("upgrade");
     } else {
-        command.arg("dist-upgrade");
+        let apt_command = ctx.config().apt_command();
+        command.arg(apt_command);
     };
     if ctx.config().yes(Step::System) {
         command.arg("-y");


### PR DESCRIPTION
Closes #2294

dist-upgrade, which was the hard-coded option, is allowed to remove packages in order to resolve dependency conflicts. This might cause quite a mess ... it is left as the default, but can be modified by the option apt_command.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
 
## For new steps
- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
