### PR TITLE
fix: don't use Command::new(bin_name) as it won't work on Windows

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -358,7 +358,7 @@ pub fn run_vscode_extensions_update(ctx: &ExecutionContext) -> Result<()> {
 
     // Vscode has update command only since 1.86 version ("january 2024" update), disable the update for prior versions
     // Use command `code --version` which returns 3 lines: version, git commit, instruction set. We parse only the first one
-    let version: Result<Version> = match Command::new("code")
+    let version: Result<Version> = match Command::new(&vscode)
         .arg("--version")
         .output_checked_utf8()?
         .stdout
@@ -389,7 +389,7 @@ pub fn run_pipx_update(ctx: &ExecutionContext) -> Result<()> {
 
     // pipx version 1.4.0 introduced a new command argument `pipx upgrade-all --quiet`
     // (see https://pipx.pypa.io/stable/docs/#pipx-upgrade-all)
-    let version_str = Command::new("pipx")
+    let version_str = Command::new(&pipx)
         .args(["--version"])
         .output_checked_utf8()
         .map(|s| s.stdout.trim().to_owned());
@@ -404,7 +404,7 @@ pub fn run_pipx_update(ctx: &ExecutionContext) -> Result<()> {
 pub fn run_conda_update(ctx: &ExecutionContext) -> Result<()> {
     let conda = require("conda")?;
 
-    let output = Command::new("conda")
+    let output = Command::new(&conda)
         .args(["config", "--show", "auto_activate_base"])
         .output_checked_utf8()?;
     debug!("Conda output: {}", output.stdout);
@@ -425,7 +425,7 @@ pub fn run_conda_update(ctx: &ExecutionContext) -> Result<()> {
 pub fn run_mamba_update(ctx: &ExecutionContext) -> Result<()> {
     let mamba = require("mamba")?;
 
-    let output = Command::new("mamba")
+    let output = Command::new(&mamba)
         .args(["config", "--show", "auto_activate_base"])
         .output_checked_utf8()?;
     debug!("Mamba output: {}", output.stdout);


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
 
## For new steps
- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

-----

#### What does this PR do

On Windows, involving a command using `Command::new("binary_name")` can fail with error `Command not found` even though the corresponding binary is installed and put somewhere under `$PATH`, for example, #720.

There is a Rust issue for it: https://github.com/rust-lang/rust/issues/37519

A workaround is to use the `which` crate, which works in a way closer to how PowerShell handles cmd resolution, Topgrade's helper function `require()` uses `which()` under the hood, so this PR replaces those `Command::new("binary-name-string")` with `Command::new(a_path_returned_from_which)`.


Closes #720