### PR TITLE
FIXES #708: add config directive for pkg_* cleanup on OpenBSD

### DIFF
--- a/src/steps/os/openbsd.rs
+++ b/src/steps/os/openbsd.rs
@@ -16,8 +16,18 @@ pub fn upgrade_openbsd(ctx: &ExecutionContext) -> Result<()> {
 pub fn upgrade_packages(ctx: &ExecutionContext) -> Result<()> {
     let sudo = require_option(ctx.sudo().as_ref(), REQUIRE_SUDO.to_string())?;
     print_separator("OpenBSD Packages");
+
+    if ctx.config().cleanup() {
+        ctx.run_type()
+            .execute(sudo)
+            .args(["/usr/sbin/pkg_delete", "-ac"])
+            .status_checked()?;
+    }
+
     ctx.run_type()
         .execute(sudo)
         .args(["/usr/sbin/pkg_add", "-u"])
-        .status_checked()
+        .status_checked()?;
+
+    Ok(())
 }


### PR DESCRIPTION
## Standards checklist:

- [+] The PR title is descriptive.
- [+] I have read `CONTRIBUTING.md`
- [+] The code compiles (`cargo build`)
- [+] The code passes rustfmt (`cargo fmt`)
- [+] The code passes clippy (`cargo clippy`)
- [+] The code passes tests (`cargo test`)

fixes #708