### PR TITLE
Fix local host detection for remotes with user 

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1457,14 +1457,16 @@ impl Config {
     str_value!(linux, emerge_update_flags);
 
     pub fn should_execute_remote(&self, remote: &str) -> bool {
+        let remote_host = remote.split_once('@').map_or(remote, |(_,host)| host);
+
         if let Ok(hostname) = hostname() {
-            if remote == hostname {
+            if remote_host == hostname {
                 return false;
             }
         }
 
         if let Some(limit) = self.opt.remote_host_limit.as_ref() {
-            return limit.is_match(remote);
+            return limit.is_match(remote_host);
         }
 
         true

--- a/src/main.rs
+++ b/src/main.rs
@@ -182,9 +182,7 @@ fn run() -> Result<()> {
     }
 
     if let Some(topgrades) = config.remote_topgrades() {
-        let hostname_res = hostname();
-        let hostname: Option<&str> = hostname_res.as_ref().ok().map(|s| s.as_str());
-        for remote_topgrade in topgrades.iter().filter(|t| config.should_execute_remote(hostname, t)) {
+        for remote_topgrade in topgrades.iter().filter(|t| config.should_execute_remote(hostname(), t)) {
             runner.execute(Step::Remotes, format!("Remote ({remote_topgrade})"), || {
                 ssh::ssh_step(&ctx, remote_topgrade)
             })?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ use self::error::Upgraded;
 use self::steps::{remote::*, *};
 use self::terminal::*;
 
-use self::utils::{install_color_eyre, install_tracing, update_tracing};
+use self::utils::{hostname, install_color_eyre, install_tracing, update_tracing};
 
 mod breaking_changes;
 mod command;
@@ -182,7 +182,9 @@ fn run() -> Result<()> {
     }
 
     if let Some(topgrades) = config.remote_topgrades() {
-        for remote_topgrade in topgrades.iter().filter(|t| config.should_execute_remote(t)) {
+        let hostname_res = hostname();
+        let hostname: Option<&str> = hostname_res.as_ref().ok().map(|s| s.as_str());
+        for remote_topgrade in topgrades.iter().filter(|t| config.should_execute_remote(hostname, t)) {
             runner.execute(Step::Remotes, format!("Remote ({remote_topgrade})"), || {
                 ssh::ssh_step(&ctx, remote_topgrade)
             })?;


### PR DESCRIPTION
Strip the user when comparing the remote with the hostname of the local machine to prevent repeatedly running topgrade over SSH on localhost.

## Details of the issue

### Set-up

topgrade is run on a machine with a hostname equal to `host`, which has `user@host` present in the `remote_upgrades` list in `topgrade.toml`.

### Current behavior

topgrade will trigger remote execution for `user@host` over SSH connection to `host`. This will repeat indefinitely due to the host recursively connecting to itself during each remote execution.

### New behavior

`user@host` remote will be recognized as being local to `host` and skipped by topgrade.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
