### PR TITLE
feat: add support for mise

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -106,6 +106,7 @@ pub enum Step {
     Mas,
     Maza,
     Micro,
+    Mise,
     Myrepos,
     Nix,
     Node,

--- a/src/main.rs
+++ b/src/main.rs
@@ -298,6 +298,7 @@ fn run() -> Result<()> {
         runner.execute(Step::Guix, "guix", || unix::run_guix(&ctx))?;
         runner.execute(Step::HomeManager, "home-manager", || unix::run_home_manager(&ctx))?;
         runner.execute(Step::Asdf, "asdf", || unix::run_asdf(&ctx))?;
+        runner.execute(Step::Mise, "mise", || unix::run_mise(&ctx))?;
         runner.execute(Step::Pkgin, "pkgin", || unix::run_pkgin(&ctx))?;
         runner.execute(Step::Bun, "bun", || unix::run_bun(&ctx))?;
         runner.execute(Step::BunPackages, "bun-packages", || unix::run_bun_packages(&ctx))?;

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -551,6 +551,19 @@ pub fn run_asdf(ctx: &ExecutionContext) -> Result<()> {
         .status_checked()
 }
 
+pub fn run_mise(ctx: &ExecutionContext) -> Result<()> {
+    let mise = require("mise")?;
+
+    print_separator("mise");
+
+    ctx.run_type().execute(&mise).arg("upgrade").status_checked()?;
+
+    ctx.run_type()
+        .execute(&mise)
+        .args(["plugins", "update"])
+        .status_checked()
+}
+
 pub fn run_home_manager(ctx: &ExecutionContext) -> Result<()> {
     let home_manager = require("home-manager")?;
 


### PR DESCRIPTION
Add support for mise-en-place (or mise). Mise is a tool like asdf (already supported). https://mise.jdx.dev/

## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
 
## For new steps
- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
