### PR TITLE
feat: support update PlatformIO Core

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -121,6 +121,7 @@ pub enum Step {
     Pipx,
     Pkg,
     Pkgin,
+    PlatformioCore,
     Pnpm,
     Powershell,
     Protonup,

--- a/src/main.rs
+++ b/src/main.rs
@@ -407,6 +407,9 @@ fn run() -> Result<()> {
     runner.execute(Step::Certbot, "Certbot", || generic::run_certbot(&ctx))?;
     runner.execute(Step::GitRepos, "Git Repositories", || git::run_git_pull(&ctx))?;
     runner.execute(Step::ClamAvDb, "ClamAV Databases", || generic::run_freshclam(&ctx))?;
+    runner.execute(Step::PlatformioCore, "PlatformIO Core", || {
+        generic::run_platform_io(&ctx)
+    })?;
 
     if should_run_powershell {
         runner.execute(Step::Powershell, "Powershell Modules Update", || {

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -940,3 +940,23 @@ pub fn run_freshclam(ctx: &ExecutionContext) -> Result<()> {
     print_separator("Update ClamAV Database(FreshClam)");
     ctx.run_type().execute(freshclam).status_checked()
 }
+
+/// Involve `pio upgrade` to update PlatformIO core.
+pub fn run_platform_io(ctx: &ExecutionContext) -> Result<()> {
+    // We use the full path because by default the binary is not in `PATH`:
+    // https://github.com/topgrade-rs/topgrade/issues/754#issuecomment-2020537559
+    #[cfg(unix)]
+    fn bin_path() -> PathBuf {
+        HOME_DIR.join(".platformio/penv/bin/pio")
+    }
+    #[cfg(windows)]
+    fn bin_path() -> PathBuf {
+        HOME_DIR.join(".platformio/penv/Scripts/pio.exe")
+    }
+
+    let bin_path = require(bin_path())?;
+
+    print_separator("PlatformIO Core");
+
+    ctx.run_type().execute(bin_path).arg("upgrade").status_checked()
+}


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
 
## For new steps
- [x] *Optional:* Topgrade skips this step where needed
  Should work
- [x] *Optional:* The `--dry-run` option works with this step
  Should work as there is only 1 command to execute
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command
  This does not seem to be supported

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

Closes #754