### PR TITLE
Add config flag to toggle verbose Git repository output.

### DIFF
--- a/BREAKINGCHANGES_dev.md
+++ b/BREAKINGCHANGES_dev.md
@@ -1,4 +1,9 @@
-# Configutation
+# Git: Pull Repos
+
+1. The output of "Pulling <repository path>" has been moved behind the
+--verbose flag / [misc] configuration block.
+
+# Configuration
 
 1. The `enable_winget` configuration entry in the `windows` section has been
 removed because it will not cause any issues and will be enabled by default.

--- a/config.example.toml
+++ b/config.example.toml
@@ -181,9 +181,6 @@
 # Don't pull the predefined git repos
 # pull_predefined = false
 
-# Don't show up to date repositories or pulling output. Only updated or errors will be shown.
-# verbose_output = true
-
 # Arguments to pass Git when pulling Repositories
 # arguments = "--rebase --autostash"
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -109,7 +109,7 @@
 # greedy_cask = true
 
 # For the BrewCask step
-# If `Repo Cask Upgrade` does not exist, then use the `--greedy_latest` optoin.
+# If `Repo Cask Upgrade` does not exist, then use the `--greedy_latest` option.
 # NOTE: the above entry `greedy_cask` contains this entry, though you can enable
 # both of them, they won't clash with each other.
 # greedy_latest = true
@@ -180,6 +180,9 @@
 
 # Don't pull the predefined git repos
 # pull_predefined = false
+
+# Don't show up to date repositories or pulling output. Only updated or errors will be shown.
+# verbose_output = true
 
 # Arguments to pass Git when pulling Repositories
 # arguments = "--rebase --autostash"

--- a/src/config.rs
+++ b/src/config.rs
@@ -186,9 +186,6 @@ pub struct Git {
     repos: Option<Vec<String>>,
 
     pull_predefined: Option<bool>,
-
-    // Don't show up to date repositories or pulling output. Only updated or errors will be shown.
-    verbose_output: Option<bool>,
 }
 
 #[derive(Deserialize, Default, Debug, Merge)]
@@ -1366,14 +1363,6 @@ impl Config {
                 .as_ref()
                 .and_then(|git| git.pull_predefined)
                 .unwrap_or(true)
-    }
-
-    pub fn verbose_repos(&self) -> bool {
-        self.config_file
-            .git
-            .as_ref()
-            .and_then(|git| git.verbose_output)
-            .unwrap_or(true)
     }
 
     pub fn verbose(&self) -> bool {

--- a/src/config.rs
+++ b/src/config.rs
@@ -186,6 +186,9 @@ pub struct Git {
     repos: Option<Vec<String>>,
 
     pull_predefined: Option<bool>,
+
+    // Don't show up to date repositories or pulling output. Only updated or errors will be shown.
+    verbose_output: Option<bool>,
 }
 
 #[derive(Deserialize, Default, Debug, Merge)]
@@ -1363,6 +1366,14 @@ impl Config {
                 .as_ref()
                 .and_then(|git| git.pull_predefined)
                 .unwrap_or(true)
+    }
+
+    pub fn verbose_repos(&self) -> bool {
+        self.config_file
+            .git
+            .as_ref()
+            .and_then(|git| git.verbose_output)
+            .unwrap_or(true)
     }
 
     pub fn verbose(&self) -> bool {

--- a/src/steps/git.rs
+++ b/src/steps/git.rs
@@ -368,10 +368,10 @@ impl RepoStep {
             return Ok(());
         }
 
-        let verbose = ctx.config().verbose_repos();
+        let verbose = ctx.config().verbose();
 
         if !verbose {
-            println!("{} updated repositories will be shown...", style("Only").green().bold());
+            println!("\n{} updated repositories will be shown...\n", style("Only").green().bold());
         }
 
         let futures_iterator = self


### PR DESCRIPTION
If `true`: the default, no change.

If `false`: Only show repositories that have been updated or have an error.

Minor tweak to output (removed colon) so that copy and paste for 'cd' is nicer.

## Standards checklist:

- [X] The PR title is descriptive.
- [X] I have read `CONTRIBUTING.md`
- [X] The code compiles (`cargo build`)
- [X] The code passes rustfmt (`cargo fmt`)
- [X] The code passes clippy (`cargo clippy`)
- [X] The code passes tests (`cargo test`)
- [X] *Optional:* I have tested the code myself
 
## For new steps
- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
