### PR TITLE
fix: better `dotnet tool list` header parsing

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -773,6 +773,7 @@ pub fn run_dotnet_upgrade(ctx: &ExecutionContext) -> Result<()> {
         }
     };
 
+    let mut in_header = true;
     let mut packages = output
         .stdout
         .lines()
@@ -780,11 +781,17 @@ pub fn run_dotnet_upgrade(ctx: &ExecutionContext) -> Result<()> {
         //
         // Package Id      Version      Commands
         // -------------------------------------
-        //
-        // One thing to note is that .NET SDK respect locale, which means this
-        // header can be printed in languages other than English, do NOT use it
-        // to do any check.
-        .skip(2)
+        .skip_while(|line| {
+            // The .NET SDK respects locale, so the header can be printed
+            // in languages other than English. The separator should hopefully
+            // always be at least 10 -'s long.
+            if in_header && line.starts_with("----------") {
+                in_header = false;
+                true
+            } else {
+                in_header
+            }
+        })
         .filter(|line| !line.is_empty())
         .peekable();
 


### PR DESCRIPTION
I've just run into the same error as #572, in the same scenario (right after updating .NET). I'm also fairly sure I've had it happen before.

If I remove the `.dotnet` folder in my home directory, I get this output from `dotnet tool list`:
```
> mv .dotnet .dotnet2
> DOTNET_NOLOGO=true dotnet tool list --global 2> /dev/null
An issue was encountered verifying workloads. For more information, run "dotnet workload update".
Package Id      Version      Commands
-------------------------------------
<list of packages>
```
I think this is the the cause of the error, although I'm not 100% sure. Either way, topgrade should parse out the header in a more reliable way than just skipping the first two lines of output. 

## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself.
  Well, it no longer fails after removing the `~/.dotnet` folder. Hopefully this means it should no longer error right after a .NET update.