### PR TITLE
feat: support ZVM

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -159,6 +159,7 @@ pub enum Step {
     Xcodes,
     Yadm,
     Yarn,
+    Zvm,
 }
 
 #[derive(Deserialize, Default, Debug, Merge)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -410,6 +410,7 @@ fn run() -> Result<()> {
     runner.execute(Step::PlatformioCore, "PlatformIO Core", || {
         generic::run_platform_io(&ctx)
     })?;
+    runner.execute(Step::Zvm, "ZVM", || generic::run_zvm(&ctx))?;
 
     if should_run_powershell {
         runner.execute(Step::Powershell, "Powershell Modules Update", || {

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -967,3 +967,12 @@ pub fn run_platform_io(ctx: &ExecutionContext) -> Result<()> {
 
     ctx.run_type().execute(bin_path).arg("upgrade").status_checked()
 }
+
+/// Involve `zvm upgrade` to update ZVM
+pub fn run_zvm(ctx: &ExecutionContext) -> Result<()> {
+    let zvm = require("zvm")?;
+
+    print_separator("ZVM");
+
+    ctx.run_type().execute(zvm).arg("upgrade").status_checked()
+}


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
 
## For new steps
- [x] *Optional:* Topgrade skips this step where needed
- [x] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

   cc @tristan-nsg, does `zvm` have a `--yes` option?

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
