### PR TITLE
feat: support VSCodium

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -163,6 +163,7 @@ pub enum Step {
     Vim,
     VoltaPackages,
     Vscode,
+    Vscodium,
     Waydroid,
     Winget,
     Wsl,

--- a/src/main.rs
+++ b/src/main.rs
@@ -372,6 +372,9 @@ fn run() -> Result<()> {
     runner.execute(Step::Vscode, "Visual Studio Code extensions", || {
         generic::run_vscode_extensions_update(&ctx)
     })?;
+    runner.execute(Step::Vscodium, "VSCodium extensions", || {
+        generic::run_vscodium_extensions_update(&ctx)
+    })?;
     runner.execute(Step::Conda, "conda", || generic::run_conda_update(&ctx))?;
     runner.execute(Step::Mamba, "mamba", || generic::run_mamba_update(&ctx))?;
     runner.execute(Step::Pixi, "pixi", || generic::run_pixi_update(&ctx))?;

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -400,9 +400,9 @@ pub fn run_vcpkg_update(ctx: &ExecutionContext) -> Result<()> {
     command.args(["upgrade", "--no-dry-run"]).status_checked()
 }
 
-/// Make VSCOdium a separate step because:
+/// Make VSCodium a separate step because:
 ///
-/// 1. Users could use VSCode and VSCoium both
+/// 1. Users could use both VSCode and VSCoium
 /// 2. Just in case, VSCodium could have incompatible changes with VSCode
 pub fn run_vscodium_extensions_update(ctx: &ExecutionContext) -> Result<()> {
     // Calling vscodoe in WSL may install a server instead of updating extensions (https://github.com/topgrade-rs/topgrade/issues/594#issuecomment-1782157367)


### PR DESCRIPTION
This PR adds the support of VSCodium to Topgrade, it is added as an individual step (not an alias of the VSCode step) because:

1. Users could use both VSCode and VSCoium
2. Just in case, VSCodium could have incompatible changes with VSCode


## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
 
## For new steps
- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

Closes #787
