### PR TITLE
refactor: 2 clippy warnings

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -488,7 +488,7 @@ impl ConfigFile {
         for path in possible_config_paths.iter() {
             if path.exists() {
                 debug!("Configuration at {}", path.display());
-                res.0 = path.clone();
+                res.0.clone_from(path);
                 break;
             }
         }
@@ -497,7 +497,7 @@ impl ConfigFile {
 
         // If no config file exists, create a default one in the config directory
         if !res.0.exists() && res.1.is_empty() {
-            res.0 = possible_config_paths[0].clone();
+            res.0.clone_from(&possible_config_paths[0]);
             debug!("No configuration exists");
             write(&res.0, EXAMPLE_CONFIG).map_err(|e| {
                 debug!(


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
 
## For new steps
- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

-----

Fix 2 clippy wranings
