### PR TITLE
feat(cargo): remove dependence on install-update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2133,9 +2133,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
  "itoa",
  "ryu",
@@ -2610,6 +2610,7 @@ dependencies = [
  "self_update",
  "semver",
  "serde",
+ "serde_json",
  "shell-words",
  "shellexpand",
  "strum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ merge = "~0.1"
 regex-split = "~0.1"
 notify-rust = "~4.10"
 wildmatch = "2.3.0"
+serde_json = "1.0.117"
 
 [package.metadata.generate-rpm]
 assets = [{ source = "target/release/topgrade", dest = "/usr/bin/topgrade" }]

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -12,9 +12,7 @@ use color_eyre::eyre::Result;
 use semver::{Version, VersionReq};
 use serde_json::Value;
 use tempfile::tempfile_in;
-use tracing::instrument::WithSubscriber;
 use tracing::{debug, error};
-use tracing_subscriber::fmt::writer::MakeWriterExt;
 
 use crate::command::{CommandExt, Utf8Output};
 use crate::execution_context::ExecutionContext;

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -146,7 +146,6 @@ fn manual_cargo_updates(crates_json: PathBuf) -> Result<()> {
             return Err(SkipStep("Improper .crates2.json".to_string()).into());
         }
     }
-    println!("{feature_packages:?}");
 
     for (package, all_features, no_default, feature) in feature_packages {
         let feature: Vec<_> = feature.iter().map(|feat| feat.as_str().unwrap()).collect();


### PR DESCRIPTION
Fixes the dependency of cargo update on cargo-install-update binary and also fixes the issue where packages are installed without the relevant features. 

## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
 
## For new steps
- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
