### PR TITLE
feat: allow self renamer to work if tempdir is on a different device

### DIFF
--- a/src/self_renamer.rs
+++ b/src/self_renamer.rs
@@ -2,7 +2,7 @@
 
 use color_eyre::eyre::Result;
 use std::{env::current_exe, fs, path::PathBuf};
-use tracing::{debug, error};
+use tracing::{debug, error, warn};
 
 pub struct SelfRenamer {
     exe_path: PathBuf,
@@ -12,12 +12,40 @@ pub struct SelfRenamer {
 impl SelfRenamer {
     pub fn create() -> Result<Self> {
         let tempdir = tempfile::tempdir()?;
-        let temp_path = tempdir.path().join("topgrade.exe");
+        let mut temp_path = tempdir.path().join("topgrade.exe");
         let exe_path = current_exe()?;
 
-        debug!("Current exe in {:?}. Moving it to {:?}", exe_path, temp_path);
+        debug!(
+            "Current exe in {:?}. Attempting to move it to {:?}",
+            exe_path, temp_path
+        );
 
-        fs::rename(&exe_path, &temp_path)?;
+        match fs::rename(&exe_path, &temp_path) {
+            // cross-device error
+            Err(e) if e.raw_os_error() == Some(17) => {
+                debug!("Temporary directory is on a different device. Using the binary parent directory instead");
+
+                let Some(parent_dir) = exe_path.parent() else {
+                    return Err(color_eyre::eyre::Report::msg(
+                        "Could not get parent directory of the current binary",
+                    ));
+                };
+
+                let mut builder = tempfile::Builder::new();
+                builder.prefix("topgrade").suffix(".exe");
+                let temp_file = builder.tempfile_in(parent_dir)?;
+                temp_path = temp_file.path().to_path_buf();
+
+                // Delete the temporary file immediately to free up the name
+                if let Err(e) = temp_file.close() {
+                    warn!("Could not close temporary file: {}", e);
+                }
+
+                debug!("Moving current exe in {:?} to {:?}", exe_path, temp_path);
+                fs::rename(&exe_path, &temp_path)
+            }
+            other => other,
+        }?;
 
         Ok(SelfRenamer { exe_path, temp_path })
     }


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
 
## For new steps
- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

Currently, the self renamer fails with the following error if the tempdir is on a different device from the system temporary directory:
```
Error:
   0: The system cannot move the file to a different disk drive. (os error 17)
```
This PR works around this by using a temporary file in the binary directory instead in that case.

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
