### PR TITLE
Add rye support

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -133,6 +133,7 @@ pub enum Step {
     Rtcl,
     RubyGems,
     Rustup,
+    Rye,
     Scoop,
     Sdkman,
     SelfUpdate,

--- a/src/main.rs
+++ b/src/main.rs
@@ -344,6 +344,7 @@ fn run() -> Result<()> {
     // The following update function should be executed on all OSes.
     runner.execute(Step::Fossil, "fossil", || generic::run_fossil(&ctx))?;
     runner.execute(Step::Elan, "elan", || generic::run_elan(&ctx))?;
+    runner.execute(Step::Rye, "rye", || generic::run_rye(&ctx))?;
     runner.execute(Step::Rustup, "rustup", || generic::run_rustup(&ctx))?;
     runner.execute(Step::Juliaup, "juliaup", || generic::run_juliaup(&ctx))?;
     runner.execute(Step::Dotnet, ".NET", || generic::run_dotnet_upgrade(&ctx))?;

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -227,6 +227,13 @@ pub fn run_rustup(ctx: &ExecutionContext) -> Result<()> {
     ctx.run_type().execute(rustup).arg("update").status_checked()
 }
 
+pub fn run_rye(ctx: &ExecutionContext) -> Result<()> {
+    let rye = require("rye")?;
+
+    print_separator("Rye");
+    ctx.run_type().execute(rye).args(["self", "update"]).status_checked()
+}
+
 pub fn run_elan(ctx: &ExecutionContext) -> Result<()> {
     let elan = require("elan")?;
 


### PR DESCRIPTION
Rye is a new cargo-like package manager for python by @mitsuhiko.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
