### PR TITLE
feat: support auto-cpufreq

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -54,6 +54,7 @@ pub enum Step {
     Asdf,
     Atom,
     Audit,
+    AutoCpufreq,
     Bin,
     Bob,
     BrewCask,

--- a/src/main.rs
+++ b/src/main.rs
@@ -235,6 +235,7 @@ fn run() -> Result<()> {
         })?;
         runner.execute(Step::Lure, "LURE", || linux::run_lure_update(&ctx))?;
         runner.execute(Step::Waydroid, "Waydroid", || linux::run_waydroid(&ctx))?;
+        runner.execute(Step::AutoCpufreq, "auto-cpufreq", || linux::run_auto_cpufreq(&ctx))?;
     }
 
     #[cfg(target_os = "macos")]

--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -1062,6 +1062,19 @@ pub fn run_waydroid(ctx: &ExecutionContext) -> Result<()> {
         .status_checked()
 }
 
+pub fn run_auto_cpufreq(ctx: &ExecutionContext) -> Result<()> {
+    let sudo = require_option(ctx.sudo().as_ref(), REQUIRE_SUDO.to_string())?;
+    let auto_cpu_freq = require("auto-cpufreq")?;
+
+    print_separator("auto-cpufreq");
+
+    ctx.run_type()
+        .execute(sudo)
+        .arg(auto_cpu_freq)
+        .arg("--update")
+        .status_checked()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [ ] *Optional:* I have tested the code myself
 
## For new steps
- [x] *Optional:* Topgrade skips this step where needed
- [x] *Optional:* The `--dry-run` option works with this step

It should work considering this step involves only 1 command.

- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

Does not seem to be supported: https://github.com/AdnanHodzic/auto-cpufreq?tab=readme-ov-file#update---auto-cpufreq-update

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.


Closes #793
