### PR TITLE
ci: replace deprecated gh actions with alternatives

### DIFF
--- a/.github/workflows/create_release_assets.yml
+++ b/.github/workflows/create_release_assets.yml
@@ -17,36 +17,27 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+
+      - name: setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with: 
           components: rustfmt, clippy
-      - uses: actions-rs/cargo@v1.0.1
-        name: Check format
-        with:
-          command: fmt
-          args: --all -- --check
-      - uses: actions-rs/cargo@v1.0.1
-        name: Run clippy
-        with:
-          command: clippy
-          args: --all-targets --locked -- -D warnings
-      - uses: actions-rs/cargo@v1.0.1
-        name: Run clippy (All features)
-        with:
-          command: clippy
-          args: --all-targets --locked --all-features -- -D warnings
-      - uses: actions-rs/cargo@v1.0.1
-        name: Run tests
-        with:
-          command: test
-      - uses: actions-rs/cargo@v1.0.1
-        name: Build
-        with:
-          command: build
-          args: --release --all-features
+
+      - name: Check format
+        run: cargo fmt --all -- --check
+
+      - name: Run clippy
+        run: cargo clippy --all-targets --locked -- -D warnings
+
+      - name: Run clippy (All features)
+        run: cargo clippy --all-targets --locked --all-features -- -D warnings
+
+      - name: Run tests
+        run: cargo test
+
+      - name: Build in Release profile with all features enabled
+        run: cargo build --release --all-features
+
       - name: Rename Release (Unix)
         run: |
           cargo install default-target
@@ -59,6 +50,7 @@ jobs:
           ls .
         if: ${{ matrix.platform != 'windows-latest' }}
         shell: bash
+
       - name: Rename Release (Windows)
         run: |
           cargo install default-target
@@ -71,6 +63,7 @@ jobs:
           ls .
         if: ${{ matrix.platform == 'windows-latest' }}
         shell: bash
+
       - name: Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/create_release_assets_cross.yml
+++ b/.github/workflows/create_release_assets_cross.yml
@@ -13,48 +13,45 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [ "aarch64-unknown-linux-gnu", "armv7-unknown-linux-gnueabihf", "x86_64-unknown-linux-musl", "aarch64-unknown-linux-musl", "x86_64-unknown-freebsd",  ]
+        target: [ 
+          "aarch64-unknown-linux-gnu", 
+          "armv7-unknown-linux-gnueabihf", 
+          "x86_64-unknown-linux-musl", 
+          "aarch64-unknown-linux-musl", 
+          "x86_64-unknown-freebsd",  
+        ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          default: true
-          override: true
-          target: ${{ matrix.target }}
+
+      - name: setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with: 
           components: rustfmt, clippy
-      - uses: actions-rs/cargo@v1.0.1
-        name: Check format
+
+      - name: install targets
+        run: rustup target add ${{ matrix.target }}
+
+      - name: install cross
+        uses: taiki-e/install-action@v2
         with:
-          use-cross: true
-          command: fmt
-          args: --all -- --check
-      - uses: actions-rs/cargo@v1.0.1
-        name: Run clippy
-        with:
-          command: clippy
-          use-cross: true
-          args: --all-targets --locked --target ${{matrix.target}} -- -D warnings
-      - uses: actions-rs/cargo@v1.0.1
-        name: Run clippy (All features)
-        with:
-          command: clippy
-          use-cross: true
-          args:  --locked --all-features --target ${{matrix.target}} -- -D warnings
-      - uses: actions-rs/cargo@v1.0.1
-        name: Run tests
-        with:
-          command: test
-          use-cross: true
-          args: --target ${{matrix.target}}
-      - uses: actions-rs/cargo@v1.0.1
-        name: Build
-        with:
-          command: build
-          use-cross: true
-          args: --release --all-features --target ${{matrix.target}}
+          tool: cross@0.2.5
+
+      - name: Check format
+        run: cross fmt --all -- --check
+
+      - name: Run clippy
+        run: cross clippy --all-targets --locked --target ${{matrix.target}} -- -D warnings
+
+      - name: Run clippy (All features)
+        run: cross clippy  --locked --all-features --target ${{matrix.target}} -- -D warnings
+
+      - name: Run tests
+        run: cross test --target ${{matrix.target}}
+
+      - name: Build in Release profile with all features enabled
+        run: cross build --release --all-features --target ${{matrix.target}}
+
       - name: Rename Release
         run: |
           mkdir assets
@@ -64,6 +61,7 @@ jobs:
           tar --format=ustar -czf $FILENAME.tar.gz topgrade
           rm topgrade
           ls .
+
       - name: Release
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
## What does this PR do

`actions-rs/toolchain` and `action-rs/cargo` are deprecated, replace them with actions that are still maintained.


Ref: https://github.com/topgrade-rs/topgrade/issues/664#issuecomment-2026541629


## Is this PR tested

No, since these 2 jobs will only be triggered in in a release.