### PR TITLE
chore: build binary for both macOS aarch64 and amd64

### DIFF
--- a/.github/workflows/check_security_vulnerability.yml
+++ b/.github/workflows/check_security_vulnerability.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   lint:
     name: DevSkim
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   fmt:
     name: Rustfmt
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -42,16 +42,16 @@ jobs:
           - target: x86_64-linux-android
             target_name: Android
             use_cross: true
-            os: ubuntu-20.04
+            os: ubuntu-latest
 
           - target: x86_64-unknown-freebsd
             target_name: FreeBSD
             use_cross: true
-            os: ubuntu-20.04
+            os: ubuntu-latest
 
           - target: x86_64-unknown-linux-gnu
             target_name: Linux
-            os: ubuntu-20.04
+            os: ubuntu-latest
 
           - target: x86_64-apple-darwin
             target_name: macOS-x86_64
@@ -59,16 +59,16 @@ jobs:
 
           - target: aarch64-apple-darwin
             target_name: macOS-aarch64
-            os: macos-14
+            os: macos-latest
 
           - target: x86_64-unknown-netbsd
             target_name: NetBSD
             use_cross: true
-            os: ubuntu-20.04
+            os: ubuntu-latest
 
           - target: x86_64-pc-windows-msvc
             target_name: Windows
-            os: windows-2019
+            os: windows-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/create_release_assets.yml
+++ b/.github/workflows/create_release_assets.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ ubuntu-latest, macos-latest, windows-latest ]
+        platform: [ ubuntu-latest, macos-latest, macos-13, windows-latest ]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## What does this PR do

1. Build macOS binary for both arm64 and amd64, closes #678.
  
    By the time of filing this PR, `macos-latest` is arm-only, and for public non-large runners, `macos-13` is the ONLY macOS runner that is still amd64.

3. Bump Linux runner to `ubunut-latest`.

## Standards checklist

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
