### PR TITLE
Add linux mint support

### DIFF
--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -73,7 +73,7 @@ impl Distribution {
 
             Some("nobara") => Distribution::Nobara,
             Some("void") => Distribution::Void,
-            Some("debian") | Some("pureos") | Some("Deepin") => Distribution::Debian,
+            Some("debian") | Some("pureos") | Some("Deepin") | Some("linuxmint") => Distribution::Debian,
             Some("arch") | Some("manjaro-arm") | Some("garuda") | Some("artix") => Distribution::Arch,
             Some("solus") => Distribution::Solus,
             Some("gentoo") => Distribution::Gentoo,


### PR DESCRIPTION
Detect linuxmint distros and treat them as debian. 

Question: how does ubuntu work here? 
Mint is a Ubuntu fork and i have seen linuxmint strata getting the Ubuntu treatment in the upgrade_bedrock section, but i have not found any code that handles Ubuntu distros. But topgrade surely has support for the most popular distro of all, doesn't it? is it okay to treat ubuntu distros as debian?