### PR TITLE
fix(RubyGems): support no-sudo updating for rbenv and rvm

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -120,7 +120,10 @@ pub fn run_rubygems(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("RubyGems");
     let gem_path_str = gem.as_os_str();
-    if gem_path_str.to_str().unwrap().contains("asdf") {
+    if gem_path_str.to_str().unwrap().contains("asdf")
+        || gem_path_str.to_str().unwrap().contains(".rbenv")
+        || gem_path_str.to_str().unwrap().contains(".rvm")
+    {
         ctx.run_type()
             .execute(gem)
             .args(["update", "--system"])


### PR DESCRIPTION
## What does this PR do

Currently, when updating RubyGems, the code defaults to sudo-ing it, unless there is `asdf` in the path. I've added checks for `rbenv` and `rvm` Ruby version managers to avoid using sudo.

The idea behind that piece of code may be faulty in the first place, and we should probably check the location or the file permissions of installed RubyGems instead of the pathname, but for a quick fix, should do.

## Standards checklist

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
