### PR TITLE
style: allow unused ExecutorChild

### DIFF
--- a/src/executor.rs
+++ b/src/executor.rs
@@ -227,6 +227,7 @@ impl DryCommand {
 
 /// The Result of spawn. Contains an actual `std::process::Child` if executed by a wet command.
 pub enum ExecutorChild {
+    #[allow(unused)] // this type has not been used
     Wet(Child),
     Dry,
 }

--- a/src/self_renamer.rs
+++ b/src/self_renamer.rs
@@ -1,5 +1,3 @@
-#![cfg(windows)]
-
 use color_eyre::eyre::Result;
 use std::{env::current_exe, fs, path::PathBuf};
 use tracing::{debug, error};


### PR DESCRIPTION
## What does this PR do

Clear the following clippy warning:

```
error: field `0` is never read
   --> src/executor.rs:230:9
    |
[230](https://github.com/topgrade-rs/topgrade/actions/runs/9573017990/job/26393598748?pr=827#step:7:231) |     Wet(Child),
    |     --- ^^^^^
    |     |
    |     field in this variant
    |
    = note: `-D dead-code` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(dead_code)]`
help: consider changing the field to be of unit type to suppress this warning while preserving the field numbering, or remove the field
    |
230 |     Wet(()),
    |         ~~
```

It is indeed unused, but we should not remove it.

## Standards checklist

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
