### PR TITLE
fix: consider TMUX_PLUGIN_MANAGER_PATH when searching tpm binary

### DIFF
--- a/src/steps/tmux.rs
+++ b/src/steps/tmux.rs
@@ -18,7 +18,15 @@ use crate::{
 use std::os::unix::process::CommandExt as _;
 
 pub fn run_tpm(ctx: &ExecutionContext) -> Result<()> {
-    let tpm = HOME_DIR.join(".tmux/plugins/tpm/bin/update_plugins").require()?;
+    // Path
+    //
+    // Check if `$TMUX_PLUGIN_MANAGER_PATH/plugins/tpm/bin/update_plugins`
+    // exists, if not, use the default path `$HOME/.tmux/plugins/tpm/bin/update_plugins`.
+    let tpm = env::var("TMUX_PLUGIN_MANAGER_PATH")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| HOME_DIR.join(".tmux"))
+        .join("plugins/tpm/bin/update_plugins")
+        .require()?;
 
     print_separator("tmux plugins");
 

--- a/src/steps/tmux.rs
+++ b/src/steps/tmux.rs
@@ -18,15 +18,14 @@ use crate::{
 use std::os::unix::process::CommandExt as _;
 
 pub fn run_tpm(ctx: &ExecutionContext) -> Result<()> {
-    // Path
-    //
-    // Check if `$TMUX_PLUGIN_MANAGER_PATH/plugins/tpm/bin/update_plugins`
-    // exists, if not, use the default path `$HOME/.tmux/plugins/tpm/bin/update_plugins`.
-    let tpm = env::var("TMUX_PLUGIN_MANAGER_PATH")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| HOME_DIR.join(".tmux"))
-        .join("plugins/tpm/bin/update_plugins")
-        .require()?;
+    let tpm = match env::var("TMUX_PLUGIN_MANAGER_PATH") {
+        // If `TMUX_PLUGIN_MANAGER_PATH` is set, search for
+        // `$TMUX_PLUGIN_MANAGER_PATH/bin/install_plugins/tpm/bin/update_plugins`
+        Ok(var) => PathBuf::from(var).join("bin/install_plugins/tpm/bin/update_plugins"),
+        // Otherwise, use the default location `~/.tmux/plugins/tpm/bin/update_plugins`
+        Err(_) => HOME_DIR.join(".tmux/plugins/tpm/bin/update_plugins"),
+    }
+    .require()?;
 
     print_separator("tmux plugins");
 


### PR DESCRIPTION
## What does this PR do

Before this PR, when updating tmux plugins, we only look for the update binary in its default location. The actual location can be altered via environment variable `TMUX_PLUGIN_MANAGER_PATH` so it should be considered as well.

fixes #832 

## Standards checklist

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself
 