### PR TITLE
feat: new step Lensfun's database update

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -244,3 +244,10 @@
 [containers]
 # Specify the containers to ignore while updating (Wildcard supported)
 # ignored_containers = ["ghcr.io/rancher-sandbox/rancher-desktop/rdx-proxy:latest", "docker.io*"]
+
+[lensfun]
+# If disabled, Topgrade invokes `lensfun‑update‑data` without root priviledge, 
+# then the update will be only available to you. Otherwise, `sudo` is required,
+# and the update will be installed system-wide, i.e., available to all users.
+# (default: false)
+# use_sudo = false

--- a/src/config.rs
+++ b/src/config.rs
@@ -101,6 +101,7 @@ pub enum Step {
     Helix,
     Krew,
     Lure,
+    Lensfun,
     Macports,
     Mamba,
     Miktex,
@@ -398,6 +399,12 @@ pub struct Misc {
 
 #[derive(Deserialize, Default, Debug, Merge)]
 #[serde(deny_unknown_fields)]
+pub struct Lensfun {
+    use_sudo: Option<bool>,
+}
+
+#[derive(Deserialize, Default, Debug, Merge)]
+#[serde(deny_unknown_fields)]
 /// Configuration file
 pub struct ConfigFile {
     #[merge(strategy = crate::utils::merge_strategies::inner_merge_opt)]
@@ -456,6 +463,9 @@ pub struct ConfigFile {
 
     #[merge(strategy = crate::utils::merge_strategies::inner_merge_opt)]
     distrobox: Option<Distrobox>,
+
+    #[merge(strategy = crate::utils::merge_strategies::inner_merge_opt)]
+    lensfun: Option<Lensfun>,
 }
 
 fn config_directory() -> PathBuf {
@@ -1522,6 +1532,14 @@ impl Config {
         }
 
         self.opt.custom_commands.iter().any(|s| s == name)
+    }
+
+    pub fn lensfun_use_sudo(&self) -> bool {
+        self.config_file
+            .lensfun
+            .as_ref()
+            .and_then(|lensfun| lensfun.use_sudo)
+            .unwrap_or(false)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -412,6 +412,9 @@ fn run() -> Result<()> {
     runner.execute(Step::PlatformioCore, "PlatformIO Core", || {
         generic::run_platform_io(&ctx)
     })?;
+    runner.execute(Step::Lensfun, "Lensfun's database update", || {
+        generic::run_lensfun_update_data(&ctx)
+    })?;
 
     if should_run_powershell {
         runner.execute(Step::Powershell, "Powershell Modules Update", || {

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -977,3 +977,20 @@ pub fn run_platform_io(ctx: &ExecutionContext) -> Result<()> {
 
     ctx.run_type().execute(bin_path).arg("upgrade").status_checked()
 }
+
+/// Run `lensfun-update-data` to update lensfun database.
+///
+/// `sudo` will be used if `use_sudo` configuration entry is set to true.
+pub fn run_lensfun_update_data(ctx: &ExecutionContext) -> Result<()> {
+    const SEPARATOR: &str = "Lensfun's database update";
+    let lensfun_update_data = require("lensfun-update-data")?;
+
+    if ctx.config().lensfun_use_sudo() {
+        let sudo = require_option(ctx.sudo().as_ref(), REQUIRE_SUDO.to_string())?;
+        print_separator(SEPARATOR);
+        ctx.run_type().execute(sudo).arg(lensfun_update_data).status_checked()
+    } else {
+        print_separator(SEPARATOR);
+        ctx.run_type().execute(lensfun_update_data).status_checked()
+    }
+}

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -984,13 +984,21 @@ pub fn run_platform_io(ctx: &ExecutionContext) -> Result<()> {
 pub fn run_lensfun_update_data(ctx: &ExecutionContext) -> Result<()> {
     const SEPARATOR: &str = "Lensfun's database update";
     let lensfun_update_data = require("lensfun-update-data")?;
+    const EXIT_CODE_WHEN_NO_UPDATE: i32 = 1;
 
     if ctx.config().lensfun_use_sudo() {
         let sudo = require_option(ctx.sudo().as_ref(), REQUIRE_SUDO.to_string())?;
         print_separator(SEPARATOR);
-        ctx.run_type().execute(sudo).arg(lensfun_update_data).status_checked()
+        ctx.run_type()
+            .execute(sudo)
+            .arg(lensfun_update_data)
+            // `lensfun-update-data` returns 1 when there is no update available
+            // which should be considered success
+            .status_checked_with_codes(&[EXIT_CODE_WHEN_NO_UPDATE])
     } else {
         print_separator(SEPARATOR);
-        ctx.run_type().execute(lensfun_update_data).status_checked()
+        ctx.run_type()
+            .execute(lensfun_update_data)
+            .status_checked_with_codes(&[EXIT_CODE_WHEN_NO_UPDATE])
     }
 }


### PR DESCRIPTION
## What does this PR do

This PR adds support for updating [Lensfun](https://github.com/lensfun/lensfun)'s lenses database via its cli tool `lensfun-update-data`. 

Per the [documentation](https://lensfun.github.io/manual/v0.3.2/lensfun-update-data.html), this update command can be invoked with or without `sudo` so that one can decide where to install the update. If `sudo` is used, then the update will be installed system-wide, available to all users. Otherwise, update will be install under user's home directory and thus exclusive to the user.

This option is controlled through the following configuration entry in Topgrade:

```toml
[lensfun]
# If disabled, Topgrade invokes `lensfun‑update‑data` without root priviledge, 
# then the update will be only available to you. Otherwise, `sudo` is required,
# and the update will be installed system-wide, i.e., available to all users.
# (default: false)
# use_sudo = false
```
 

## Standards checklist

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself
 
## For new steps

- [x] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step

It should work as this is a one command step.

- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

The `lensfun-update-data` command does not accept options.

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
