### PR TITLE
improve fedora immutable detection

### DIFF
--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -59,7 +59,9 @@ impl Distribution {
             Some("centos") | Some("rhel") | Some("ol") => Distribution::CentOS,
             Some("clear-linux-os") => Distribution::ClearLinux,
             Some("fedora") => {
-                return if let Some(variant) = variant {
+                return if section.get("OSTREE_VERSION").is_some() {
+                    Ok(Distribution::FedoraImmutable)
+                } else if let Some(variant) = variant {
                     match variant {
                         "Silverblue" | "Kinoite" | "Sericea" | "Onyx" | "IoT Edition" | "Sway Atomic" => {
                             Ok(Distribution::FedoraImmutable)


### PR DESCRIPTION
## What does this PR do
Improves the detection for rpm-ostree based fedora versions by checking for the OSTREE_VERSION section in os-release
This allows detection of systems built by [blue-build](https://blue-build.org) that do not contain a VARIANT section
e.g: my [os-release](https://github.com/user-attachments/files/16117705/os-release.txt)

I have kept the old detection method as some older rpm-ostree based distributions do not include the OSTREE_VERSION
section (see [fedoraonyx](https://github.com/user-attachments/files/16117714/fedoraonyx.txt) in src/steps/os/os_release)

## Standards checklist

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
