### PR TITLE
fix: traverse symbolic links under `$CONIG_DIR/topgrade.d` (#852)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -533,7 +533,9 @@ impl ConfigFile {
         if dir_to_search.exists() {
             for entry in fs::read_dir(dir_to_search)? {
                 let entry = entry?;
-                if entry.file_type()?.is_file() {
+                // Use `Path::is_file()` here to traverse symbolic links.
+                // `DirEntry::file_type()` and `FileType::is_file()` will not traverse symbolic links.
+                if entry.path().is_file() {
                     debug!(
                         "Found additional (directory) configuration file at {}",
                         entry.path().display()


### PR DESCRIPTION
## What does this PR do

Change the conditions for including configuration files to traverse symbolic links (fixes #852)

## Standards checklist

- [X] The PR title is descriptive.
- [X] I have read `CONTRIBUTING.md`
- [X] *Optional:* I have tested the code myself
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
