### PR TITLE
update zi and zinit update to use parallel flag

### DIFF
--- a/src/steps/zsh.rs
+++ b/src/steps/zsh.rs
@@ -124,7 +124,7 @@ pub fn run_zinit(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("zinit");
 
-    let cmd = format!("source {} && zinit self-update && zinit update --all", zshrc.display());
+    let cmd = format!("source {} && zinit self-update && zinit update --all --parallel", zshrc.display());
     ctx.run_type()
         .execute(zsh)
         .args(["-i", "-c", cmd.as_str()])
@@ -139,7 +139,7 @@ pub fn run_zi(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("zi");
 
-    let cmd = format!("source {} && zi self-update && zi update --all", zshrc.display());
+    let cmd = format!("source {} && zi self-update && zi update --all --parallel", zshrc.display());
     ctx.run_type().execute(zsh).args(["-i", "-c", &cmd]).status_checked()
 }
 


### PR DESCRIPTION
## What does this PR do

Speeds up zi and zinit update commands by adding parallel flag

## Standards checklist

- [ ] The PR title is descriptive.
- [ ] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
