### PR TITLE
Fix `pyenv: no such command 'update'` 

### DIFF
--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -609,6 +609,10 @@ pub fn run_pyenv(ctx: &ExecutionContext) -> Result<()> {
         return Err(SkipStep("pyenv is not a git repository".to_string()).into());
     }
 
+    if !pyenv_dir.join("plugins").join("pyenv-update").exists() {
+        return Err(SkipStep("pyenv-update plugin is not installed".to_string()).into());
+    }
+
     ctx.run_type().execute(pyenv).arg("update").status_checked()
 }
 


### PR DESCRIPTION
## What does this PR do

Additional check before `pyenv update` is called. Fixes #849 when `pyenv` is managed by Homebrew or installed by cloning the repo without the required update plugin.

## Standards checklist

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself

Try it by running

`cargo run -- --verbose --only pyenv`
