### PR TITLE
feat: don't run reboot with sudo on Linux with systemd

### DIFF
--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -720,5 +720,19 @@ pub fn run_maza(ctx: &ExecutionContext) -> Result<()> {
 
 pub fn reboot() -> Result<()> {
     print!("Rebooting...");
+
+    cfg_if::cfg_if! {
+        if #[cfg(target_os = "linux")] {
+            // Per this doc: https://www.freedesktop.org/software/systemd/man/latest/sd_booted.html
+            //
+            // If this directory exists, then this Linux uses systemd as the init program.
+            let systemd_dir = Path::new("/run/systemd/system");
+            if let Ok(true) = systemd_dir.try_exists() {
+                // On Linux with systemd, `reboot` can be invoded without `sudo`.
+                return Command::new("reboot").status_checked();
+            }
+        }
+    }
+
     Command::new("sudo").arg("reboot").status_checked()
 }


### PR DESCRIPTION
## What does this PR do

Based on the discussion in #861, on Linux with systemd, `reboot` can be invoked without `sudo`, this PR implements it.

Closes #861.

## Standards checklist

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
