### PR TITLE
feat(os): support NI Linux Real-Time's opkg package manager

### DIFF
--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -30,6 +30,7 @@ pub enum Distribution {
     FedoraImmutable,
     Debian,
     Gentoo,
+    NILRT,
     OpenMandriva,
     OpenSuseTumbleweed,
     PCLinuxOS,
@@ -71,6 +72,7 @@ impl Distribution {
                 };
             }
 
+            Some("nilrt") => Distribution::NILRT,
             Some("nobara") => Distribution::Nobara,
             Some("void") => Distribution::Void,
             Some("debian") | Some("pureos") | Some("Deepin") | Some("linuxmint") => Distribution::Debian,
@@ -158,6 +160,7 @@ impl Distribution {
             Distribution::OpenMandriva => upgrade_openmandriva(ctx),
             Distribution::PCLinuxOS => upgrade_pclinuxos(ctx),
             Distribution::Nobara => upgrade_nobara(ctx),
+            Distribution::NILRT => upgrade_nilrt(ctx),
         }
     }
 
@@ -283,6 +286,14 @@ fn upgrade_nobara(ctx: &ExecutionContext) -> Result<()> {
 
     upgrade_command.status_checked()?;
     Ok(())
+}
+
+fn upgrade_nilrt(ctx: &ExecutionContext) -> Result<()> {
+    let sudo = require_option(ctx.sudo().as_ref(), REQUIRE_SUDO.to_string())?;
+    let opkg = require("opkg")?;
+
+    ctx.run_type().execute(sudo).arg(&opkg).arg("update").status_checked()?;
+    ctx.run_type().execute(sudo).arg(&opkg).arg("upgrade").status_checked()
 }
 
 fn upgrade_fedora_immutable(ctx: &ExecutionContext) -> Result<()> {
@@ -1253,5 +1264,10 @@ mod tests {
     #[test]
     fn test_nobara() {
         test_template(include_str!("os_release/nobara"), Distribution::Nobara);
+    }
+
+    #[test]
+    fn test_nilrt() {
+        test_template(include_str!("os_release/nilrt"), Distribution::NILRT);
     }
 }

--- a/src/steps/os/os_release/nilrt
+++ b/src/steps/os/os_release/nilrt
@@ -1,0 +1,8 @@
+ID=nilrt
+NAME="NI Linux Real-Time"
+VERSION="10.0 (kirkstone)"
+VERSION_ID=10.0
+PRETTY_NAME="NI Linux Real-Time 10.0 (kirkstone)"
+DISTRO_CODENAME="kirkstone"
+BUILD_ID="23.8.0f153-x64"
+VERSION_CODENAME="kirkstone"


### PR DESCRIPTION
## What does this PR do

Add support for the `opkg` package manager used by the NI Linux Real-Time distribution.

## Standards checklist

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
