### PR TITLE
ci: fix release_to_aur.yml

### DIFF
--- a/.github/workflows/release_to_aur.yml
+++ b/.github/workflows/release_to_aur.yml
@@ -14,8 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Publish AUR package
-        uses: ATiltedTree/create-aur-release@v1
+        uses: aksh1618/update-aur-package@v1.0.5
         with:
+          tag_version_prefix: v
           package_name: topgrade
           commit_username: "Thomas Schönauer"
           commit_email: t.schoenauer@hgs-wt.at


### PR DESCRIPTION
## What does this PR do
This PR change the action used to update AUR because the original one is not available on Github anymore.

## Standards checklist

- [X] The PR title is descriptive.
- [X] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself

I haven't been able to test myself as it's linked to topgrade CI.