### PR TITLE
Allow Nix unfree packages to be upgraded

### DIFF
--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -413,10 +413,10 @@ pub fn run_nix(ctx: &ExecutionContext) -> Result<()> {
 
     debug!("Nix version: {:?}", version);
 
-    let mut packages = "--all";
+    let mut packages: Vec<&str> = vec!["--all", "--impure"];
 
     if !matches!(version, Ok(version) if version >= Version::new(2, 21, 0)) {
-        packages = ".*";
+        packages = vec![".*"];
     }
 
     if Path::new(&manifest_json_path).exists() {
@@ -425,7 +425,7 @@ pub fn run_nix(ctx: &ExecutionContext) -> Result<()> {
             .args(nix_args())
             .arg("profile")
             .arg("upgrade")
-            .arg(packages)
+            .args(&packages)
             .arg("--verbose")
             .status_checked()
     } else {


### PR DESCRIPTION

## What does this PR do
Allow unfree packages to be upgraded

Fixes #611.

## Standards checklist

- [X] The PR title is descriptive.
- [X] I have read `CONTRIBUTING.md`
- [X] *Optional:* I have tested the code myself
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
