### PR TITLE
feat: add volta packages

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -155,6 +155,7 @@ pub enum Step {
     Vagrant,
     Vcpkg,
     Vim,
+    VoltaPackages,
     Vscode,
     Waydroid,
     Winget,

--- a/src/main.rs
+++ b/src/main.rs
@@ -385,6 +385,9 @@ fn run() -> Result<()> {
     runner.execute(Step::Node, "npm", || node::run_npm_upgrade(&ctx))?;
     runner.execute(Step::Yarn, "yarn", || node::run_yarn_upgrade(&ctx))?;
     runner.execute(Step::Pnpm, "pnpm", || node::run_pnpm_upgrade(&ctx))?;
+    runner.execute(Step::VoltaPackages, "volta packages", || {
+        node::run_volta_packages_upgrade(&ctx)
+    })?;
     runner.execute(Step::Containers, "Containers", || containers::run_containers(&ctx))?;
     runner.execute(Step::Deno, "deno", || node::deno_upgrade(&ctx))?;
     runner.execute(Step::Composer, "composer", || generic::run_composer_update(&ctx))?;


### PR DESCRIPTION
## What does this PR do

Currently there's no volta upgrade command, so this implementation has to list all installed packages first, and update them separately

Example output: 
![CleanShot 2024-08-01 at 09 51 27@2x](https://github.com/user-attachments/assets/998e259e-2c10-4ada-9c09-fc4ab4f5f60e)

## Standards checklist

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

