### PR TITLE
Add aqua tool installer cli

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -53,6 +53,7 @@ pub enum Step {
     AppMan,
     Asdf,
     Atom,
+    Aqua,
     Audit,
     AutoCpufreq,
     Bin,

--- a/src/main.rs
+++ b/src/main.rs
@@ -300,7 +300,6 @@ fn run() -> Result<()> {
         runner.execute(Step::HomeManager, "home-manager", || unix::run_home_manager(&ctx))?;
         runner.execute(Step::Asdf, "asdf", || unix::run_asdf(&ctx))?;
         runner.execute(Step::Mise, "mise", || unix::run_mise(&ctx))?;
-        runner.execute(Step::Aqua, "aqua", || unix::run_aqua(&ctx))?;
         runner.execute(Step::Pkgin, "pkgin", || unix::run_pkgin(&ctx))?;
         runner.execute(Step::Bun, "bun", || unix::run_bun(&ctx))?;
         runner.execute(Step::BunPackages, "bun-packages", || unix::run_bun_packages(&ctx))?;
@@ -421,6 +420,7 @@ fn run() -> Result<()> {
     })?;
     runner.execute(Step::Poetry, "Poetry", || generic::run_poetry(&ctx))?;
     runner.execute(Step::Zvm, "ZVM", || generic::run_zvm(&ctx))?;
+    runner.execute(Step::Aqua, "aqua", || generic::run_aqua(&ctx))?;
 
     if should_run_powershell {
         runner.execute(Step::Powershell, "Powershell Modules Update", || {

--- a/src/main.rs
+++ b/src/main.rs
@@ -300,6 +300,7 @@ fn run() -> Result<()> {
         runner.execute(Step::HomeManager, "home-manager", || unix::run_home_manager(&ctx))?;
         runner.execute(Step::Asdf, "asdf", || unix::run_asdf(&ctx))?;
         runner.execute(Step::Mise, "mise", || unix::run_mise(&ctx))?;
+        runner.execute(Step::Aqua, "aqua", || unix::run_aqua(&ctx))?;
         runner.execute(Step::Pkgin, "pkgin", || unix::run_pkgin(&ctx))?;
         runner.execute(Step::Bun, "bun", || unix::run_bun(&ctx))?;
         runner.execute(Step::BunPackages, "bun-packages", || unix::run_bun_packages(&ctx))?;

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -229,9 +229,9 @@ pub fn run_aqua(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("Aqua");
     if ctx.run_type().dry() {
-            println!("Updating aqua ...");
-            println!("Updating aqua installed cli tools ...");
-            Ok(())
+        println!("Updating aqua ...");
+        println!("Updating aqua installed cli tools ...");
+        Ok(())
     } else {
         ctx.run_type().execute(&aqua).arg("update-aqua").status_checked()?;
         ctx.run_type().execute(&aqua).arg("update").status_checked()

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -224,6 +224,16 @@ pub fn run_apm(ctx: &ExecutionContext) -> Result<()> {
         .status_checked()
 }
 
+pub fn run_aqua(ctx: &ExecutionContext) -> Result<()> {
+    let aqua = require("aqua")?;
+
+    print_separator("Aqua");
+
+    ctx.run_type().execute(&aqua).arg("update-aqua").status_checked()?;
+
+    ctx.run_type().execute(&aqua).args(["update"]).status_checked()
+}
+
 pub fn run_rustup(ctx: &ExecutionContext) -> Result<()> {
     let rustup = require("rustup")?;
 

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -228,10 +228,14 @@ pub fn run_aqua(ctx: &ExecutionContext) -> Result<()> {
     let aqua = require("aqua")?;
 
     print_separator("Aqua");
-
-    ctx.run_type().execute(&aqua).arg("update-aqua").status_checked()?;
-
-    ctx.run_type().execute(&aqua).args(["update"]).status_checked()
+    if ctx.run_type().dry() {
+            println!("Updating aqua ...");
+            println!("Updating aqua installed cli tools ...");
+            Ok(())
+    } else {
+        ctx.run_type().execute(&aqua).arg("update-aqua").status_checked()?;
+        ctx.run_type().execute(&aqua).arg("update").status_checked()
+    }
 }
 
 pub fn run_rustup(ctx: &ExecutionContext) -> Result<()> {

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -749,16 +749,6 @@ pub fn run_maza(ctx: &ExecutionContext) -> Result<()> {
     ctx.run_type().execute(maza).arg("update").status_checked()
 }
 
-pub fn run_aqua(ctx: &ExecutionContext) -> Result<()> {
-    let aqua = require("aqua")?;
-
-    print_separator("Aqua");
-
-    ctx.run_type().execute(&aqua).arg("update-aqua").status_checked()?;
-
-    ctx.run_type().execute(&aqua).args(["update"]).status_checked()
-}
-
 pub fn reboot() -> Result<()> {
     print!("Rebooting...");
 

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -749,6 +749,16 @@ pub fn run_maza(ctx: &ExecutionContext) -> Result<()> {
     ctx.run_type().execute(maza).arg("update").status_checked()
 }
 
+pub fn run_aqua(ctx: &ExecutionContext) -> Result<()> {
+    let aqua = require("aqua")?;
+
+    print_separator("Aqua");
+
+    ctx.run_type().execute(&aqua).arg("update-aqua").status_checked()?;
+
+    ctx.run_type().execute(&aqua).args(["update"]).status_checked()
+}
+
 pub fn reboot() -> Result<()> {
     print!("Rebooting...");
 


### PR DESCRIPTION
## What does this PR do
It adds the Aqua cli installer. 
https://aquaproj.github.io/

## Standards checklist

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [x] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
