### PR TITLE
Adds `uv` step

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -153,6 +153,7 @@ pub enum Step {
     Tlmgr,
     Tmux,
     Toolbx,
+    Uv,
     Vagrant,
     Vcpkg,
     Vim,

--- a/src/main.rs
+++ b/src/main.rs
@@ -327,6 +327,7 @@ fn run() -> Result<()> {
             unix::upgrade_gnome_extensions(&ctx)
         })?;
         runner.execute(Step::Pyenv, "pyenv", || unix::run_pyenv(&ctx))?;
+        runner.execute(Step::Uv, "uv", || unix::run_uv(&ctx))?;
         runner.execute(Step::Sdkman, "SDKMAN!", || unix::run_sdkman(&ctx))?;
         runner.execute(Step::Rcm, "rcm", || unix::run_rcm(&ctx))?;
         runner.execute(Step::Maza, "maza", || unix::run_maza(&ctx))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -327,7 +327,6 @@ fn run() -> Result<()> {
             unix::upgrade_gnome_extensions(&ctx)
         })?;
         runner.execute(Step::Pyenv, "pyenv", || unix::run_pyenv(&ctx))?;
-        runner.execute(Step::Uv, "uv", || unix::run_uv(&ctx))?;
         runner.execute(Step::Sdkman, "SDKMAN!", || unix::run_sdkman(&ctx))?;
         runner.execute(Step::Rcm, "rcm", || unix::run_rcm(&ctx))?;
         runner.execute(Step::Maza, "maza", || unix::run_maza(&ctx))?;
@@ -420,6 +419,7 @@ fn run() -> Result<()> {
         generic::run_lensfun_update_data(&ctx)
     })?;
     runner.execute(Step::Poetry, "Poetry", || generic::run_poetry(&ctx))?;
+    runner.execute(Step::Uv, "uv", || generic::run_uv(&ctx))?;
     runner.execute(Step::Zvm, "ZVM", || generic::run_zvm(&ctx))?;
     runner.execute(Step::Aqua, "aqua", || generic::run_aqua(&ctx))?;
 

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -1024,6 +1024,26 @@ pub fn run_poetry(ctx: &ExecutionContext) -> Result<()> {
     ctx.run_type().execute(poetry).args(["self", "update"]).status_checked()
 }
 
+pub fn run_uv(ctx: &ExecutionContext) -> Result<()> {
+    let uv_exec = require("uv")?;
+    print_separator("uv");
+
+    ctx.run_type()
+        .execute(&uv_exec)
+        .args(["self", "update"])
+        .status_checked()
+        .ok();
+
+    // ignoring self-update errors, because they are likely due to uv's
+    // installation being managed by another package manager, in which
+    // case another step will handle the update.
+
+    ctx.run_type()
+        .execute(&uv_exec)
+        .args(["tool", "upgrade", "--all"])
+        .status_checked()
+}
+
 /// Involve `zvm upgrade` to update ZVM
 pub fn run_zvm(ctx: &ExecutionContext) -> Result<()> {
     let zvm = require("zvm")?;

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -643,6 +643,26 @@ pub fn run_pyenv(ctx: &ExecutionContext) -> Result<()> {
     ctx.run_type().execute(pyenv).arg("update").status_checked()
 }
 
+pub fn run_uv(ctx: &ExecutionContext) -> Result<()> {
+    let uv_exec = require("uv")?;
+    print_separator("uv");
+
+    ctx.run_type()
+        .execute(&uv_exec)
+        .args(["self", "update"])
+        .status_checked()
+        .ok();
+
+    // ignoring self-update errors, because they are likely due to uv's
+    // installation being managed by another package manager, in which
+    // case another step will handle the update.
+
+    ctx.run_type()
+        .execute(&uv_exec)
+        .args(["tool", "upgrade", "--all"])
+        .status_checked()
+}
+
 pub fn run_sdkman(ctx: &ExecutionContext) -> Result<()> {
     let bash = require("bash")?;
 

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -643,26 +643,6 @@ pub fn run_pyenv(ctx: &ExecutionContext) -> Result<()> {
     ctx.run_type().execute(pyenv).arg("update").status_checked()
 }
 
-pub fn run_uv(ctx: &ExecutionContext) -> Result<()> {
-    let uv_exec = require("uv")?;
-    print_separator("uv");
-
-    ctx.run_type()
-        .execute(&uv_exec)
-        .args(["self", "update"])
-        .status_checked()
-        .ok();
-
-    // ignoring self-update errors, because they are likely due to uv's
-    // installation being managed by another package manager, in which
-    // case another step will handle the update.
-
-    ctx.run_type()
-        .execute(&uv_exec)
-        .args(["tool", "upgrade", "--all"])
-        .status_checked()
-}
-
 pub fn run_sdkman(ctx: &ExecutionContext) -> Result<()> {
     let bash = require("bash")?;
 

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -609,6 +609,10 @@ pub fn run_pyenv(ctx: &ExecutionContext) -> Result<()> {
         return Err(SkipStep("pyenv is not a git repository".to_string()).into());
     }
 
+    if !pyenv_dir.join("plugins").join("pyenv-update").exists() {
+        return Err(SkipStep("pyenv-update plugin is not installed".to_string()).into());
+    }
+
     ctx.run_type().execute(pyenv).arg("update").status_checked()
 }
 


### PR DESCRIPTION
This `uv` step runs global update tasks for the relatively new [`uv`](https://github.com/astral-sh/uv) python package and project manager.

On update, two actions are executed:

1. `uv self update` [docs](https://docs.astral.sh/uv/getting-started/installation/#standalone-installer)
2. `uv tool upgrade --all` [docs](https://docs.astral.sh/uv/guides/tools/#installing-tools)

## Standards checklist:

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [x] The code passes clippy (`cargo clippy`)
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - `cargo run -- --verbose --only uv` works.
 
## For new steps

- [x] *Optional:* Topgrade skips this step where needed
- [x] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command
    - underlying command does not support `--yes`.
