### PR TITLE
feat: support step Bun on Windows

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -301,7 +301,6 @@ fn run() -> Result<()> {
         runner.execute(Step::Asdf, "asdf", || unix::run_asdf(&ctx))?;
         runner.execute(Step::Mise, "mise", || unix::run_mise(&ctx))?;
         runner.execute(Step::Pkgin, "pkgin", || unix::run_pkgin(&ctx))?;
-        runner.execute(Step::Bun, "bun", || unix::run_bun(&ctx))?;
         runner.execute(Step::BunPackages, "bun-packages", || unix::run_bun_packages(&ctx))?;
         runner.execute(Step::Shell, "zr", || zsh::run_zr(&ctx))?;
         runner.execute(Step::Shell, "antibody", || zsh::run_antibody(&ctx))?;
@@ -422,6 +421,7 @@ fn run() -> Result<()> {
     runner.execute(Step::Uv, "uv", || generic::run_uv(&ctx))?;
     runner.execute(Step::Zvm, "ZVM", || generic::run_zvm(&ctx))?;
     runner.execute(Step::Aqua, "aqua", || generic::run_aqua(&ctx))?;
+    runner.execute(Step::Bun, "bun", || generic::run_bun(&ctx))?;
 
     if should_run_powershell {
         runner.execute(Step::Powershell, "Powershell Modules Update", || {

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -1052,3 +1052,11 @@ pub fn run_zvm(ctx: &ExecutionContext) -> Result<()> {
 
     ctx.run_type().execute(zvm).arg("upgrade").status_checked()
 }
+
+pub fn run_bun(ctx: &ExecutionContext) -> Result<()> {
+    let bun = require("bun")?;
+
+    print_separator("Bun");
+
+    ctx.run_type().execute(bun).arg("upgrade").status_checked()
+}

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -706,14 +706,6 @@ pub fn run_sdkman(ctx: &ExecutionContext) -> Result<()> {
     Ok(())
 }
 
-pub fn run_bun(ctx: &ExecutionContext) -> Result<()> {
-    let bun = require("bun")?;
-
-    print_separator("Bun");
-
-    ctx.run_type().execute(bun).arg("upgrade").status_checked()
-}
-
 pub fn run_bun_packages(ctx: &ExecutionContext) -> Result<()> {
     let bun = require("bun")?;
 


### PR DESCRIPTION
## What does this PR do

From the [installaction page](https://bun.sh/docs/installation#windows), `bun` is available on Windows, so move it to `generic.rs`.


## Standards checklist

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
