### PR TITLE
refactor: skip Bun update if it is not installed via official script

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -1056,7 +1056,23 @@ pub fn run_zvm(ctx: &ExecutionContext) -> Result<()> {
 pub fn run_bun(ctx: &ExecutionContext) -> Result<()> {
     let bun = require("bun")?;
 
-    print_separator("Bun");
+    // From the official install script (both install.sh and install.ps1), Bun uses
+    // the path set in this variable as the install root, and its defaults to
+    // `$HOME/.bun`
+    //
+    // UNIX: https://bun.sh/install.sh
+    // Windows:https://bun.sh/install.ps1
+    let bun_install_env = env::var("BUN_INSTALL")
+        .map(PathBuf::from)
+        .unwrap_or(HOME_DIR.join(".bun"));
 
-    ctx.run_type().execute(bun).arg("upgrade").status_checked()
+    // If `bun` is a descendant of `bun_install_env`, then Bun is installed
+    // through the official script
+    if bun.is_descendant_of(&bun_install_env) {
+        print_separator("Bun");
+
+        ctx.run_type().execute(bun).arg("upgrade").status_checked()
+    } else {
+        Err(SkipStep("Bun is not installed through the official script, skip the update".into()).into())
+    }
 }


### PR DESCRIPTION
## What does this PR do

After this PR, we only update `bun` if it is installed through the official script. We determine this by checking if the binary location is a descendant of `bun_install_env`, which will be set through the environment variable `$BUN_INSTALL`, and defaults to `$HOME/.bun`.

Closes #892

## Standards checklist

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
