### PR TITLE
chore: pin toolchain to MSRV(1.76)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ on:
 name: CI
 
 env:
-  RUST_VER: 'stable'
   CROSS_VER: '0.2.5'
   CARGO_NET_RETRY: 3
 
@@ -18,12 +17,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: '${{ env.RUST_VER }}'
-          components: rustfmt
 
       - name: Run cargo fmt
         env:
@@ -72,12 +65,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: '${{ env.RUST_VER }}'
-          components: clippy
 
       - name: Setup Rust Cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/create_release_assets.yml
+++ b/.github/workflows/create_release_assets.yml
@@ -18,11 +18,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: setup Rust
-        uses: dtolnay/rust-toolchain@stable
-        with: 
-          components: rustfmt, clippy
-
       - name: Install cargo-deb
         run: cargo install cargo-deb
         if: ${{ matrix.platform == 'ubuntu-latest' }}

--- a/.github/workflows/create_release_assets_cross.yml
+++ b/.github/workflows/create_release_assets_cross.yml
@@ -24,11 +24,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: setup Rust
-        uses: dtolnay/rust-toolchain@stable
-        with: 
-          components: rustfmt, clippy
-
       - name: Install cargo-deb cross compilation dependencies
         run: sudo apt-get install libc6-arm64-cross libgcc-s1-arm64-cross
         if: ${{ matrix.target == 'aarch64-unknown-linux-gnu' }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ categories = ["os"]
 keywords = ["upgrade", "update"]
 license = "GPL-3.0"
 repository = "https://github.com/topgrade-rs/topgrade"
+rust-version = "1.76.0"
 version = "15.0.0"
 authors = ["Roey Darwish Dror <roey.ghost@gmail.com>", "Thomas Schönauer <t.schoenauer@hgs-wt.at>"]
 exclude = ["doc/screenshot.gif", "BREAKINGCHANGES_dev.md"]

--- a/README.md
+++ b/README.md
@@ -39,9 +39,6 @@ To remedy this, **Topgrade** detects which tools you use and runs the appropriat
 Other systems users can either use `cargo install` or the compiled binaries from the release page.
 The compiled binaries contain a self-upgrading feature.
 
-> Currently, Topgrade requires Rust 1.65 or above. In general, Topgrade tracks 
-> the latest stable toolchain.
-
 ## Usage
 
 Just run `topgrade`.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.76.0"


### PR DESCRIPTION
## What does this PR do

1. Pin the toolchain to 1.76.0
2. For our CI, remove the `dtolnay/rust-toolchain` action as it is no longer needed:   
    1. GH CI provides `rustup` by default
    2. We have the toolchain specified in `rust-toolchain.toml`
    3. Thus, `cargo xxx` will download the toolchain automatically



## Standards checklist

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
