### PR TITLE
feat: tmux session attach mode

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -47,6 +47,12 @@
 # Run inside tmux (default: false)
 # run_in_tmux = true
 
+# Changes the way topgrade interacts with
+# the newly crated tmux session, creating the session
+# and only attaching to it if not inside tmux
+# (default: create, allowed values: "create", "create_and_switch_client")
+# tmux_session_attach_mode = "create"
+
 # Cleanup temporary or old files (default: false)
 # cleanup = true
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,7 +118,7 @@ fn run() -> Result<()> {
     if config.run_in_tmux() && env::var("TOPGRADE_INSIDE_TMUX").is_err() {
         #[cfg(unix)]
         {
-            tmux::run_in_tmux(config.tmux_arguments()?)?;
+            tmux::run_in_tmux(config.tmux_config()?)?;
             return Ok(());
         }
     }


### PR DESCRIPTION
## What does this PR do
This will allow the user to choose between just creating a session when in tmux, or switching the client to the newly created session. It's useful for my workflow revolving around tmux, where having forced a separate session with no quick way to attach to it created friction

## Standards checklist

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
