### PR TITLE
Remove check for whether conda config contains auto_activate_base

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -450,14 +450,6 @@ pub fn run_conda_update(ctx: &ExecutionContext) -> Result<()> {
 pub fn run_mamba_update(ctx: &ExecutionContext) -> Result<()> {
     let mamba = require("mamba")?;
 
-    let output = Command::new(&mamba)
-        .args(["config", "--show", "auto_activate_base"])
-        .output_checked_utf8()?;
-    debug!("Mamba output: {}", output.stdout);
-    if output.stdout.contains("False") {
-        return Err(SkipStep("auto_activate_base is set to False".to_string()).into());
-    }
-
     print_separator("Mamba");
 
     let mut command = ctx.run_type().execute(mamba);


### PR DESCRIPTION
## What does this PR do

Removes redundant auto_activate_base check. 

`mamba update --all -n base` should work whether the base is activated or not.

## Standards checklist

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] I have tested the code myself


Fixes #731 
