### PR TITLE
feat: clean scoop cache if cleanup is enabled

### DIFF
--- a/src/steps/os/windows.rs
+++ b/src/steps/os/windows.rs
@@ -57,6 +57,10 @@ pub fn run_scoop(ctx: &ExecutionContext) -> Result<()> {
 
     if ctx.config().cleanup() {
         ctx.run_type().execute(&scoop).args(["cleanup", "*"]).status_checked()?;
+        ctx.run_type()
+            .execute(&scoop)
+            .args(["cache", "rm", "-a"])
+            .status_checked()?
     }
 
     Ok(())


### PR DESCRIPTION
## What does this PR do

As described in issue #891, for the Scoop step, we should clean the cache if cleanup is enabled.

## Standards checklist

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
