### PR TITLE
feat(brew): Add `greedy-auto-updates` option to Brew

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -120,6 +120,12 @@
 # both of them, they won't clash with each other.
 # greedy_latest = true
 
+# For the BrewCask step
+# If `Repo Cask Upgrade` does not exist, then use the `--greedy_auto_updates` option.
+# NOTE: the above entry `greedy_cask` contains this entry, though you can enable
+# both of them, they won't clash with each other.
+# greedy_auto_updates = true
+
 # For the BrewFormula step
 # Execute `brew autoremove` after the step.
 # autoremove = true
@@ -254,7 +260,7 @@
 # runtime = "podman"
 
 [lensfun]
-# If disabled, Topgrade invokes `lensfun‑update‑data` without root priviledge, 
+# If disabled, Topgrade invokes `lensfun‑update‑data` without root priviledge,
 # then the update will be only available to you. Otherwise, `sudo` is required,
 # and the update will be installed system-wide, i.e., available to all users.
 # (default: false)

--- a/src/config.rs
+++ b/src/config.rs
@@ -270,6 +270,7 @@ pub struct Flatpak {
 pub struct Brew {
     greedy_cask: Option<bool>,
     greedy_latest: Option<bool>,
+    greedy_auto_updates: Option<bool>,
     autoremove: Option<bool>,
     fetch_head: Option<bool>,
 }
@@ -1175,6 +1176,15 @@ impl Config {
             .brew
             .as_ref()
             .and_then(|c| c.greedy_latest)
+            .unwrap_or(false)
+    }
+
+    /// Whether Brew cask should be auto_updates
+    pub fn brew_greedy_auto_updates(&self) -> bool {
+        self.config_file
+            .brew
+            .as_ref()
+            .and_then(|c| c.greedy_auto_updates)
             .unwrap_or(false)
     }
 

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -380,6 +380,9 @@ pub fn run_brew_cask(ctx: &ExecutionContext, variant: BrewVariant) -> Result<()>
         if ctx.config().brew_greedy_latest() {
             brew_args.push("--greedy-latest");
         }
+        if ctx.config().brew_greedy_auto_updates() {
+            brew_args.push("--greedy-auto-updates");
+        }
     }
 
     variant.execute(run_type).args(&brew_args).status_checked()?;


### PR DESCRIPTION
## What does this PR do

Adds the ability to call Homebrew's `--greedy-auto-updates`, which upgrades casks with `auto_updates true` without including casks with `version :latest`.

This is useful to avoid upgrading packages marked with `:latest`, like fonts.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] Compiles with `cargo build`
- [x] Passes `cargo fmt`
- [x] Passes `cargo clippy`
- [x] Passes `cargo test`
- [x] *Optional:* I have tested the code myself
 
## Related

https://github.com/topgrade-rs/topgrade/pull/636