### PR TITLE
Add Pixi to topgrade

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -122,6 +122,7 @@ pub enum Step {
     PipReviewLocal,
     Pipupgrade,
     Pipx,
+    Pixi,
     Pkg,
     Pkgin,
     PlatformioCore,

--- a/src/main.rs
+++ b/src/main.rs
@@ -362,6 +362,7 @@ fn run() -> Result<()> {
     })?;
     runner.execute(Step::Conda, "conda", || generic::run_conda_update(&ctx))?;
     runner.execute(Step::Mamba, "mamba", || generic::run_mamba_update(&ctx))?;
+    runner.execute(Step::Pixi, "pixi", || generic::run_pixi_update(&ctx))?;
     runner.execute(Step::Miktex, "miktex", || generic::run_miktex_packages_update(&ctx))?;
     runner.execute(Step::Pip3, "pip3", || generic::run_pip3_update(&ctx))?;
     runner.execute(Step::PipReview, "pip-review", || generic::run_pip_review_update(&ctx))?;

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -447,14 +447,11 @@ pub fn run_conda_update(ctx: &ExecutionContext) -> Result<()> {
     command.status_checked()
 }
 
-pub fn run_pixi_update(ctx:&ExecutionContext) -> Result<()> {
+pub fn run_pixi_update(ctx: &ExecutionContext) -> Result<()> {
     let pixi = require("pixi")?;
     print_separator("Pixi");
 
-    ctx.run_type()
-        .execute(pixi)
-        .args("self-update")
-        .status_checked()
+    ctx.run_type().execute(pixi).args("self-update").status_checked()
 }
 
 pub fn run_mamba_update(ctx: &ExecutionContext) -> Result<()> {

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -447,6 +447,16 @@ pub fn run_conda_update(ctx: &ExecutionContext) -> Result<()> {
     command.status_checked()
 }
 
+pub fn run_pixi_update(ctx:&ExecutionContext) -> Result<()> {
+    let pixi = require("pixi")?;
+    print_separator("Pixi");
+
+    ctx.run_type()
+        .execute(pixi)
+        .args("self-update")
+        .status_checked()
+}
+
 pub fn run_mamba_update(ctx: &ExecutionContext) -> Result<()> {
     let mamba = require("mamba")?;
 

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -451,7 +451,7 @@ pub fn run_pixi_update(ctx: &ExecutionContext) -> Result<()> {
     let pixi = require("pixi")?;
     print_separator("Pixi");
 
-    ctx.run_type().execute(pixi).args("self-update").status_checked()
+    ctx.run_type().execute(pixi).args(["self-update"]).status_checked()
 }
 
 pub fn run_mamba_update(ctx: &ExecutionContext) -> Result<()> {


### PR DESCRIPTION
## What does this PR do

Add Pixi upgrade to topgrade.

For reference:
https://github.com/prefix-dev/pixi/?tab=readme-ov-file#pixi-package-management-made-easy

## Standards checklist

- [ ] The PR title is descriptive.
- [ ] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
