### PR TITLE
docs: don't call execute("bin_name_str")

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ To add a new `step` to `topgrade`:
 
        // Invoke the new step to get things updated!
        ctx.run_type()
-          .execute("xxx")
+          .execute(xxx)
           .arg(/* args required by this step */)
           .status_checked()
    }


### PR DESCRIPTION
## What does this PR do

We should never directly invoke `ctx.run_type().execute("binary_name_str")` as this can lead to issues on Windows due to 
the weird behavior of binary lookup in Rust std, always let `require()` do the binary lookup job. For example, here is an issue that we have encountered: https://github.com/topgrade-rs/topgrade/issues/725

## Standards checklist

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
