### PR TITLE
feat(git): add support to only fetch repositories

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -196,6 +196,8 @@
 # Arguments to pass Git when pulling Repositories
 # arguments = "--rebase --autostash"
 
+# Whether to fetch only instead of pulling remote changes
+# fetch_only = false
 
 [windows]
 # Manually select Windows updates

--- a/src/config.rs
+++ b/src/config.rs
@@ -197,6 +197,8 @@ pub struct Git {
     repos: Option<Vec<String>>,
 
     pull_predefined: Option<bool>,
+
+    fetch_only: Option<bool>,
 }
 
 #[derive(Deserialize, Default, Debug, Merge)]
@@ -1048,6 +1050,11 @@ impl Config {
     /// Extra Git arguments
     pub fn git_arguments(&self) -> Option<&String> {
         self.config_file.git.as_ref().and_then(|git| git.arguments.as_ref())
+    }
+
+    /// Only fetch repo's instead of pulling
+    pub fn git_fetch_only(&self) -> Option<&bool> {
+        self.config_file.git.as_ref().and_then(|git| git.fetch_only.as_ref())
     }
 
     pub fn tmux_config(&self) -> Result<TmuxConfig> {


### PR DESCRIPTION
## What does this PR do
add `fetch_only` to config in case user wants to only fetch, not already pull changes

## Standards checklist

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
