### PR TITLE
docs: --only is no longer experimental

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -743,7 +743,7 @@ pub struct CommandLineArgs {
     #[arg(long = "disable", value_name = "STEP", value_enum, num_args = 1..)]
     disable: Vec<Step>,
 
-    /// Perform only the specified steps (experimental)
+    /// Perform only the specified steps
     #[arg(long = "only", value_name = "STEP", value_enum, num_args = 1..)]
     only: Vec<Step>,
 


### PR DESCRIPTION
## What does this PR do

I think `--only` is not experimental now, so update the doc.


## Standards checklist

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
