### PR TITLE
fix: use single quotes for locale keys with new line char

### DIFF
--- a/locales/app.yml
+++ b/locales/app.yml
@@ -20,9 +20,8 @@ _version: 2
   en: "Dropping you to shell. Fix what you need and then exit the shell."
 "Topgrade launched in a new tmux session":
   en: "Topgrade launched in a new tmux session"
-#TODO: See if the \n breaks anything
-"Topgrade upgraded to {version}:\n":
-  en: "Topgrade upgraded to %{version}:\n"
+'Topgrade upgraded to {version}:\n':
+  en: 'Topgrade upgraded to %{version}:\n'
 "Topgrade is up-to-date":
   en: "Topgrade is up-to-date"
 "Updating modules...":
@@ -284,8 +283,8 @@ _version: 2
 "Retry? (y)es/(N)o/(s)hell/(q)uit":
   en: "Retry? (y)es/(N)o/(s)hell/(q)uit"
 # 'R', 'S', 'Q'  have to stay the same throughout all translations. Eg German would look like "\n(R) Neustarten\n(S) Konsole\n(Q) Beenden"
-"\n(R)eboot\n(S)hell\n(Q)uit":
-  en: "\n(R)eboot\n(S)hell\n(Q)uit"
+'\n(R)eboot\n(S)hell\n(Q)uit':
+  en: '\n(R)eboot\n(S)hell\n(Q)uit'
 "Require sudo or counterpart but not found, skip":
   en: "Require sudo or counterpart but not found, skip"
 "sudo as user '{user}'":
@@ -300,4 +299,9 @@ _version: 2
   en: "No packages installed with Volta"
 "pyenv-update plugin is not installed":
   en: "pyenv-update plugin is not installed"
-  
+"Respawning...":
+  en:  "Respawning..."
+"Could not find Topgrade in any WSL disribution":
+  en: "Could not find Topgrade in any WSL disribution"
+"Windows Update":
+  en: "Windows Update"


### PR DESCRIPTION
## What does this PR do

This PR fixes some errors found by our checker:

```sh
$ ./topgrade_i18n_locale_file_checker --locale-file ../topgrade/locales/app.yml --rust-src-to-check ../topgrade/src
Errors Found:
  UseOfKeysDoNotExist
    file '../topgrade/src/self_update.rs' / line '52' / column '27' / key 'Respawning...'
    file '../topgrade/src/steps/os/windows.rs' / line '202' / column '21' / key 'Could not find Topgrade in any WSL disribution'
    file '../topgrade/src/steps/os/windows.rs' / line '209' / column '20' / key 'Windows Update'
    file '../topgrade/src/main.rs' / line '488' / column '19' / key '\n(R)eboot\n(S)hell\n(Q)uit'
```

For the first 3 errors, they are keys that have not been added to our locale file. The last one is interesting, we already have it in the locale file:

```yaml
"\n(R)eboot\n(S)hell\n(Q)uit":
  en: "\n(R)eboot\n(S)hell\n(Q)uit"
```

But it was enclosed with double quotes, which treated the `\n` as a new line rather than a string literal, using single quotes fixes the issue.


## Standards checklist

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
