### PR TITLE
ci: correct checker binary name

### DIFF
--- a/.github/workflows/check_i18n.yml
+++ b/.github/workflows/check_i18n.yml
@@ -19,4 +19,4 @@ jobs:
           cargo install --git https://github.com/topgrade-rs/topgrade_i18n_locale_checker --profile dev
 
       - name: Run the checker
-        run: topgrade_i18n_locale_checker --locale-file ./locales/app.yml --rust-src-to-check ../src
+        run: topgrade_i18n_locale_checker --locale-file ./locales/app.yml --rust-src-to-check ./src

--- a/.github/workflows/check_i18n.yml
+++ b/.github/workflows/check_i18n.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
 
-name: Check i18n locale file
+name: Check i18n
 
 jobs:
   check_locale:
@@ -16,7 +16,7 @@ jobs:
       - name: Install checker
         # Build it with the dev profile as this is faster and the checker still works
         run: |
-          cargo install --git https://github.com/topgrade-rs/topgrade_i18n_locale_file_checker --profile dev
+          cargo install --git https://github.com/topgrade-rs/topgrade_i18n_locale_checker --profile dev
 
       - name: Run the checker
-        run: topgrade_i18n_locale_file_checker ./locales/app.yml
+        run: topgrade_i18n_locale_checker --locale-file ./locales/app.yml --rust-src-to-check ../src


### PR DESCRIPTION
## What does this PR do

The locale file checker has been renamed, the binary name in CI should be updated as well.

## Standards checklist

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
