### PR TITLE
Fix typo in exit_status

### DIFF
--- a/locales/app.yml
+++ b/locales/app.yml
@@ -249,10 +249,10 @@ _version: 2
   en: "The Ultimate vimrc"
 "vim binary might be actually nvim":
   en: "vim binary might be actually nvim"
-"`{process}` failed: {exit_satus}":
-  en: "`%{process}` failed: %{exit_satus}"
-"`{process}` failed: {exit_satus} with {output}":
-  en: "`%{process}` failed: %{exit_satus} with %{output}"
+"`{process}` failed: {exit_status}":
+  en: "`%{process}` failed: %{exit_status}"
+"`{process}` failed: {exit_status} with {output}":
+  en: "`%{process}` failed: %{exit_status} with %{output}"
 "Unknown Linux Distribution":
   en: "Unknown Linux Distribution"
 'File "/etc/os-release" does not exist or is empty':

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,7 +27,7 @@ impl Display for TopgradeError {
                     f,
                     "{}",
                     t!(
-                        "`{process}` failed: {exit_satus}",
+                        "`{process}` failed: {exit_status}",
                         process = process,
                         exit_status = exit_status
                     )
@@ -38,7 +38,7 @@ impl Display for TopgradeError {
                     f,
                     "{}",
                     t!(
-                        "`{process}` failed: {exit_satus} with {output}",
+                        "`{process}` failed: {exit_status} with {output}",
                         process = process,
                         exit_status = exit_status,
                         output = output


### PR DESCRIPTION
## What does this PR do

Fix a typo in `exit_status`.

Maybe fixes issue #930

## Standards checklist

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself

Output of failing step before patch:

```console
── 21:46:00 - Brew ─────────────────────────────────────────────────────────────
Brew failed: 
   0: Command failed: `brew update`
   1: `brew` failed: %{exit_satus}

Location:
   src/steps/os/unix.rs:335
Retry? (y)es/(N)o/(s)hell/(q)uit
```

After patch:

```console
── 21:44:47 - Brew ─────────────────────────────────────────────────────────────
Brew failed: 
   0: Command failed: `brew update`
   1: `brew` failed: exit status: 1

Location:
   src/steps/os/unix.rs:335
Retry? (y)es/(N)o/(s)hell/(q)uit
```
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
