### PR TITLE
ci: add OpenBSD vm-action for clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,3 +85,21 @@ jobs:
         # ONLY run test with cargo
         if: matrix.use_cross == false
         run: cargo test --locked --target ${{ matrix.target }} 
+
+  openbsd:
+    needs: fmt
+    name: OpenBSD (check, clippy)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Test in OpenBSD
+        uses: vmactions/openbsd-vm@v1
+        with:
+          usesh: true
+          prepare: |
+            pkg_add rust rust-clippy
+          run: |
+            cargo check --locked
+            cargo clippy --locked --all-features -- -D warnings


### PR DESCRIPTION
probably not an "ideal" way to do this, but as cross-rs doesn't support OpenBSD targets, this will have to do. These vm-action tools could likely be extended to produce release binaries and whatever else too.

## What does this PR do

Adds OpenBSD CI by way of OpenBSD VM-Actions https://github.com/vmactions/openbsd-vm

## Standards checklist

- [*] The PR title is descriptive.
- [*] I have read `CONTRIBUTING.md`
- [*] *Optional:* I have tested the code myself