### PR TITLE
feat(microsoft_store): Add Microsoft Store step for Windows

### DIFF
--- a/locales/app.yml
+++ b/locales/app.yml
@@ -610,3 +610,19 @@ _version: 2
   en: "Windows Update"
   es: "Actualización de Windows"
   zh_TW: "Windows 更新"
+"Microsoft Store":
+  en: "Microsoft Store"
+  es: "Tienda de Microsoft"
+  zh_TW: "Microsoft 店鋪"
+"Scanning for updates...":
+  en: "Scanning for updates..."
+  es: "Buscando actualizaciones..."
+  zh_TW: "正在掃描更新..."
+"Success, Microsoft Store apps are being updated in the background":
+  en: "Success, Microsoft Store apps are being updated in the background"
+  es: "Éxito, las aplicaciones de Microsoft Store se están actualizando en segundo plano"
+  zh_TW: "成功，Microsoft Store 應用程式正在後台更新"
+"Unable to update Microsoft Store apps, manual intervention is required":
+  en: "Unable to update Microsoft Store apps, manual intervention is required"
+  es: "No se pueden actualizar las aplicaciones de Microsoft Store, se requiere intervención manual"
+  zh_TW: "無法更新 Microsoft Store 應用，需手動幹預"

--- a/src/config.rs
+++ b/src/config.rs
@@ -111,6 +111,7 @@ pub enum Step {
     Mas,
     Maza,
     Micro,
+    MicrosoftStore,
     Mise,
     Myrepos,
     Nix,

--- a/src/main.rs
+++ b/src/main.rs
@@ -206,6 +206,9 @@ fn run() -> Result<()> {
         runner.execute(Step::Scoop, "Scoop", || windows::run_scoop(&ctx))?;
         runner.execute(Step::Winget, "Winget", || windows::run_winget(&ctx))?;
         runner.execute(Step::System, "Windows update", || windows::windows_update(&ctx))?;
+        runner.execute(Step::MicrosoftStore, "Microsoft Store", || {
+            windows::microsoft_store(&ctx)
+        })?;
     }
 
     #[cfg(target_os = "linux")]

--- a/src/steps/os/windows.rs
+++ b/src/steps/os/windows.rs
@@ -221,6 +221,14 @@ pub fn windows_update(ctx: &ExecutionContext) -> Result<()> {
     }
 }
 
+pub fn microsoft_store(ctx: &ExecutionContext) -> Result<()> {
+    let powershell = powershell::Powershell::windows_powershell();
+
+    print_separator(t!("Microsoft Store"));
+
+    powershell.microsoft_store(ctx)
+}
+
 pub fn reboot() -> Result<()> {
     // If this works, it won't return, but if it doesn't work, it may return a useful error
     // message.


### PR DESCRIPTION
Add Microsoft Store Apps update step for Windows as Winget cannot update all Microsoft Store apps yet.

Closes #912.

## What does this PR do
Adds a Microsoft Store Apps update step for Windows.

## Standards checklist

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
 
## For new steps

- [x] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

@Rikiub, could you verify the Spanish translations?
@olivertzeng, could you verify the Taiwanese translations?
