### PR TITLE
refactor: add missing i18n for OpenBSD steps

### DIFF
--- a/locales/app.yml
+++ b/locales/app.yml
@@ -610,3 +610,15 @@ _version: 2
   en: "Windows Update"
   es: "Actualización de Windows"
   zh_TW: "Windows 更新"
+"Would check if OpenBSD is -current":
+  en: "Would check if OpenBSD is -current"
+  es: "Comprobaría si OpenBSD está en -current"
+  zh_TW: "會檢查 OpenBSD 是否為 -current"
+"Would upgrade the OpenBSD system":
+  en: "Would upgrade the OpenBSD system"
+  es: "Actualizaría el sistema OpenBSD"
+  zh_TW: "會升級 OpenBSD 系統"
+"Would upgrade OpenBSD packages":
+  en: "Would upgrade OpenBSD packages"
+  es: "Actualizaría los paquetes de OpenBSD"
+  zh_TW: "會升級 OpenBSD 套件"

--- a/src/steps/os/openbsd.rs
+++ b/src/steps/os/openbsd.rs
@@ -10,7 +10,7 @@ fn is_openbsd_current(ctx: &ExecutionContext) -> Result<bool> {
     let motd_content = fs::read_to_string("/etc/motd")?;
     let is_current = motd_content.contains("-current");
     if ctx.config().dry_run() {
-        println!("Would check if OpenBSD is -current");
+        println!("{}", t!("Would check if OpenBSD is -current"));
         Ok(is_current)
     } else {
         Ok(is_current)
@@ -24,7 +24,7 @@ pub fn upgrade_openbsd(ctx: &ExecutionContext) -> Result<()> {
     let is_current = is_openbsd_current(ctx)?;
 
     if ctx.config().dry_run() {
-        println!("Would upgrade the OpenBSD system");
+        println!("{}", t!("Would upgrade the OpenBSD system"));
         return Ok(());
     }
 
@@ -43,7 +43,7 @@ pub fn upgrade_packages(ctx: &ExecutionContext) -> Result<()> {
     let is_current = is_openbsd_current(ctx)?;
 
     if ctx.config().dry_run() {
-        println!("Would upgrade OpenBSD packages");
+        println!("{}", t!("Would upgrade OpenBSD packages"));
         return Ok(());
     }
 


### PR DESCRIPTION
## What does this PR do

In #923 and #954, we added some new messages that need i18n support, this PR does it.

Translations are provided by ChatGPT.

## Standards checklist

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
