### PR TITLE
docs: document that we need to translate user-facing texts

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,9 +3,10 @@
 
 ## Standards checklist
 
-- [ ] The PR title is descriptive.
+- [ ] The PR title is descriptive
 - [ ] I have read `CONTRIBUTING.md`
 - [ ] *Optional:* I have tested the code myself
+- [ ] If this PR introduces new user-facing messages they are translated
  
 ## For new steps
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,6 +129,24 @@ $ cargo test
 
 Don't worry about other platforms, we have most of them covered in our CI.
 
+## I18n 
+
+If your PR introduces user-facing messages, we need to ensure they are translated. 
+Please add the translations to [`locales/app.yml`][app_yml]. For simple messages 
+without arguments (e.g., "hello world"), we can simply translate them according 
+(Tip: ChatGPT or similar LLMs is good at translation). If a message contains 
+arguments, e.g., "hello <NAME>", please follow this convention:
+
+```yml
+"hello {name}":        # key
+  en: "hello %{name}"  # translation
+```
+
+Arguments in the key should be in format `{argument_name}`, and they will have
+a preceeding `%` when used in translations.
+
+[app_yml]: https://github.com/topgrade-rs/topgrade/blob/main/locales/app.yml
+
 ## Some tips
 
 1. Locale


### PR DESCRIPTION
## What does this PR do

1. Document that newly-added user facing texts need to be translated.
2. Add a check list item for it.

## Standards checklist

- [x] The PR title is descriptive.
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
