### PR TITLE
refactor: flip order of mise upgrade and mise plugins update

### DIFF
--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -653,12 +653,12 @@ pub fn run_mise(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("mise");
 
-    ctx.run_type().execute(&mise).arg("upgrade").status_checked()?;
-
     ctx.run_type()
         .execute(&mise)
         .args(["plugins", "update"])
-        .status_checked()
+        .status_checked()?;
+
+    ctx.run_type().execute(&mise).arg("upgrade").status_checked()
 }
 
 pub fn run_home_manager(ctx: &ExecutionContext) -> Result<()> {


### PR DESCRIPTION
## What does this PR do

Attempts to address issue previously encountered: https://github.com/topgrade-rs/topgrade/pull/757#issuecomment-2438658887

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
@returntrip
