### PR TITLE
feat: allow version specification for deno

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -223,6 +223,11 @@
 # use_sudo = true
 
 
+[deno]
+# Upgrade deno executable to the given version.
+# version = stable
+
+
 [vim]
 # For `vim-plug`, execute `PlugUpdate!` instead of `PlugUpdate`
 # force_plug_update = true

--- a/config.example.toml
+++ b/config.example.toml
@@ -225,7 +225,7 @@
 
 [deno]
 # Upgrade deno executable to the given version.
-# version = stable
+# version = "stable"
 
 
 [vim]

--- a/src/config.rs
+++ b/src/config.rs
@@ -258,6 +258,13 @@ pub struct NPM {
 #[derive(Deserialize, Default, Debug, Merge)]
 #[serde(deny_unknown_fields)]
 #[allow(clippy::upper_case_acronyms)]
+pub struct Deno {
+    version: Option<String>,
+}
+
+#[derive(Deserialize, Default, Debug, Merge)]
+#[serde(deny_unknown_fields)]
+#[allow(clippy::upper_case_acronyms)]
 pub struct Firmware {
     upgrade: Option<bool>,
 }
@@ -490,6 +497,9 @@ pub struct ConfigFile {
 
     #[merge(strategy = crate::utils::merge_strategies::inner_merge_opt)]
     yarn: Option<Yarn>,
+
+    #[merge(strategy = crate::utils::merge_strategies::inner_merge_opt)]
+    deno: Option<Deno>,
 
     #[merge(strategy = crate::utils::merge_strategies::inner_merge_opt)]
     vim: Option<Vim>,
@@ -1524,6 +1534,10 @@ impl Config {
             .as_ref()
             .and_then(|yarn| yarn.use_sudo)
             .unwrap_or(false)
+    }
+
+    pub fn deno_version(&self) -> Option<&str> {
+        self.config_file.deno.as_ref().and_then(|deno| deno.version.as_deref())
     }
 
     #[cfg(target_os = "linux")]

--- a/src/steps/node.rs
+++ b/src/steps/node.rs
@@ -206,7 +206,10 @@ impl Deno {
                 match version {
                     "stable" => {}
                     "rc" => {
-                        return Err(SkipStep("Deno v1.x cannot be upgraded to a release candidate".to_string()).into());
+                        return Err(SkipStep(
+                            "Deno (1.6.0-2.0.0) cannot be upgraded to a release candidate".to_string(),
+                        )
+                        .into());
                     }
                     "canary" => args.push("--canary"),
                     _ => {
@@ -222,7 +225,9 @@ impl Deno {
                 match version {
                     "stable" | "rc" | "canary" => {
                         // Prior to v1.6.0, `deno upgrade` is not able fetch the latest tag version.
-                        return Err(SkipStep("Deno v1.x cannot be upgraded to a named channel".to_string()).into());
+                        return Err(
+                            SkipStep("Deno (1.0.0-1.6.0) cannot be upgraded to a named channel".to_string()).into(),
+                        );
                     }
                     _ => {
                         if Version::parse(version).is_err() {

--- a/src/steps/node.rs
+++ b/src/steps/node.rs
@@ -204,7 +204,7 @@ impl Deno {
                 args.push(version);
             } else if bin_version >= Version::new(1, 6, 0) {
                 match version {
-                    "stable" => {}
+                    "stable" => { /* do nothing, as stable is the default channel to upgrade */ }
                     "rc" => {
                         return Err(SkipStep(
                             "Deno (1.6.0-2.0.0) cannot be upgraded to a release candidate".to_string(),

--- a/src/steps/node.rs
+++ b/src/steps/node.rs
@@ -253,11 +253,19 @@ impl Deno {
         Ok(())
     }
 
+    /// Get the version of Deno.
+    ///
+    /// This function will return the version of Deno installed on the system.
+    /// The version is parsed from the output of `deno -V`.
+    ///
+    /// ```sh
+    /// deno -V # deno 1.6.0
+    /// ```
     fn version(&self) -> Result<Version> {
         let version_str = Command::new(&self.command)
             .args(["-V"])
             .output_checked_utf8()
-            .map(|s| s.stdout.trim().to_owned().split_off(5));
+            .map(|s| s.stdout.trim().to_owned().split_off(5)); // remove "deno " prefix
         Version::parse(&version_str?).map_err(|err| err.into())
     }
 }


### PR DESCRIPTION
## What does this PR do
Add config field for specifying deno version.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
