### PR TITLE
refactor: disable julia startup file for julia package update

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -272,9 +272,9 @@
 # use_sudo = false
 
 [julia]
-# If enabled, Topgrade invokes julia with the --startup-file=yes CLI option.
+# If disabled, Topgrade invokes julia with the --startup-file=no CLI option.
 #
 # This may be desirable to avoid loading outdated packages with "using" directives
-# in the startup file which would cause the update run to fail.
+# in the startup file, which might cause the update run to fail.
 # (default: true)
 # startup_file = true

--- a/config.example.toml
+++ b/config.example.toml
@@ -270,3 +270,11 @@
 # and the update will be installed system-wide, i.e., available to all users.
 # (default: false)
 # use_sudo = false
+
+[julia]
+# If enabled, Topgrade invokes julia with the --startup-file=yes CLI option.
+#
+# This may be desirable to avoid loading outdated packages with "using" directives
+# in the startup file which would cause the update run to fail.
+# (default: true)
+# startup_file = true

--- a/src/config.rs
+++ b/src/config.rs
@@ -453,6 +453,7 @@ pub struct Lensfun {
 }
 
 #[derive(Deserialize, Default, Debug, Merge)]
+#[serde(deny_unknown_fields)]
 pub struct JuliaConfig {
     startup_file: Option<bool>,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -453,6 +453,11 @@ pub struct Lensfun {
 }
 
 #[derive(Deserialize, Default, Debug, Merge)]
+pub struct JuliaConfig {
+    startup_file: Option<bool>,
+}
+
+#[derive(Deserialize, Default, Debug, Merge)]
 #[serde(deny_unknown_fields)]
 /// Configuration file
 pub struct ConfigFile {
@@ -518,6 +523,9 @@ pub struct ConfigFile {
 
     #[merge(strategy = crate::utils::merge_strategies::inner_merge_opt)]
     lensfun: Option<Lensfun>,
+
+    #[merge(strategy = crate::utils::merge_strategies::inner_merge_opt)]
+    julia: Option<JuliaConfig>,
 }
 
 fn config_directory() -> PathBuf {
@@ -1631,6 +1639,14 @@ impl Config {
             .as_ref()
             .and_then(|lensfun| lensfun.use_sudo)
             .unwrap_or(false)
+    }
+
+    pub fn julia_use_startup_file(&self) -> bool {
+        self.config_file
+            .julia
+            .as_ref()
+            .and_then(|julia| julia.startup_file)
+            .unwrap_or(true)
     }
 }
 

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -910,7 +910,7 @@ pub fn update_julia_packages(ctx: &ExecutionContext) -> Result<()> {
 
     ctx.run_type()
         .execute(julia)
-        .args(["-e", "using Pkg; Pkg.update()"])
+        .args(["--startup-file=no", "-e", "using Pkg; Pkg.update()"])
         .status_checked()
 }
 

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -908,10 +908,15 @@ pub fn update_julia_packages(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator(t!("Julia Packages"));
 
-    ctx.run_type()
-        .execute(julia)
-        .args(["--startup-file=no", "-e", "using Pkg; Pkg.update()"])
-        .status_checked()
+    let mut executor = ctx.run_type().execute(julia);
+
+    executor.arg(if ctx.config().julia_use_startup_file() {
+        "--startup-file=yes"
+    } else {
+        "--startup-file=no"
+    });
+
+    executor.args(["-e", "using Pkg; Pkg.update()"]).status_checked()
 }
 
 pub fn run_helm_repo_update(ctx: &ExecutionContext) -> Result<()> {


### PR DESCRIPTION
## What does this PR do

This PR adds the `--startup-file=no` argument to the `julia` invocation for updating Julia packages. See [the upstream doc](https://docs.julialang.org/en/v1/manual/command-line-interface/#command-line-interface).

This is useful because if Julia has been recently updated (eg. with the `juliaup` step), then old versions of packages configured with `using` directives in `~/.julia/config/startup.jl` may fail to precompile or load with the new version, in turn causing the package update step to fail unnecessarily. By skipping the startup file load, broken or outdated packages will not attempt to be loaded.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- ~~[ ] If this PR introduces new user-facing messages they are translated~~
