### PR TITLE
fix(poetry): skip if not installed with official script

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -103,6 +103,10 @@
 # enable_pipupgrade = true                         ###disabled by default
 # pipupgrade_arguments = "-y -u --pip-path pip"    ###disabled by default
 
+# Run `poetry self update` even if poetry was not installed with the official script
+# (default: false)
+# poetry_force_self_update = true
+
 
 [composer]
 # self_update = true

--- a/config.example.toml
+++ b/config.example.toml
@@ -103,7 +103,10 @@
 # enable_pipupgrade = true                         ###disabled by default
 # pipupgrade_arguments = "-y -u --pip-path pip"    ###disabled by default
 
-# Run `poetry self update` even if poetry was not installed with the official script
+# For the poetry step, by default, Topgrade skips its update if poetry is not 
+# installed with the official script. This configuration entry forces Topgrade 
+# to run the update in this case.
+#
 # (default: false)
 # poetry_force_self_update = true
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -229,6 +229,7 @@ pub struct Python {
     enable_pip_review_local: Option<bool>,
     enable_pipupgrade: Option<bool>,
     pipupgrade_arguments: Option<String>,
+    poetry_force_self_update: Option<bool>,
 }
 
 #[derive(Deserialize, Default, Debug, Merge)]
@@ -1625,6 +1626,13 @@ impl Config {
             .python
             .as_ref()
             .and_then(|python| python.enable_pip_review_local)
+            .unwrap_or(false)
+    }
+    pub fn poetry_force_self_update(&self) -> bool {
+        self.config_file
+            .python
+            .as_ref()
+            .and_then(|python| python.poetry_force_self_update)
             .unwrap_or(false)
     }
 


### PR DESCRIPTION
## What does this PR do

This skips the `poetry self update` step if poetry is not installed using the [official installer script](https://python-poetry.org/docs/#installing-with-the-official-installer), preventing externally-managed-environment errors if it was installed through e.g. a package manager.

I've also added a config option (`python.poetry_force_self_update`) that bypasses the check to always run `poetry self update` - this is useful for [manual installations](https://python-poetry.org/docs/#installing-manually). 

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself - tested on both Linux and Windows
- [x] If this PR introduces new user-facing messages they are translated

Fixes #979