### PR TITLE
Detect Elan self update disabled (e.g. installed from distro repos)

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -265,8 +265,8 @@ pub fn run_elan(ctx: &ExecutionContext) -> Result<()> {
         ExecutorOutput::Wet(command_output) => {
             if command_output.status.success() {
                 // Flush the captured output
-                std::io::stdout().lock().write(&command_output.stdout).unwrap();
-                std::io::stderr().lock().write(&command_output.stderr).unwrap();
+                std::io::stdout().lock().write_all(&command_output.stdout).unwrap();
+                std::io::stderr().lock().write_all(&command_output.stderr).unwrap();
             } else {
                 let stderr_as_str = std::str::from_utf8(&command_output.stderr).unwrap();
                 if stderr_as_str.contains(disabled_error_msg) {
@@ -277,8 +277,8 @@ pub fn run_elan(ctx: &ExecutionContext) -> Result<()> {
                     // `elan` is NOT externally managed, `elan self update` can
                     // be performed, but the invocation failed, so we report the
                     // error to the user and error out.
-                    std::io::stdout().lock().write(&command_output.stdout).unwrap();
-                    std::io::stderr().lock().write(&command_output.stderr).unwrap();
+                    std::io::stdout().lock().write_all(&command_output.stdout).unwrap();
+                    std::io::stderr().lock().write_all(&command_output.stderr).unwrap();
 
                     return Err(StepFailed.into());
                 }


### PR DESCRIPTION
## What does this PR do
Adds a config option to disable elan self-update (for people like me, who installed elan from distro repos).

## Standards checklist

- [X] The PR title is descriptive
- [X] I have read `CONTRIBUTING.md`
- [X] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
