### PR TITLE
fix: dont ignore rpm-ostree when bootc is found

### DIFF
--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -230,7 +230,9 @@ fn upgrade_redhat(ctx: &ExecutionContext) -> Result<()> {
             let sudo = require_option(ctx.sudo().as_ref(), get_require_sudo_string())?;
             return ctx.run_type().execute(sudo).arg(&bootc).arg("upgrade").status_checked();
         }
-    } else if let Some(ostree) = which("rpm-ostree") {
+    }
+
+    if let Some(ostree) = which("rpm-ostree") {
         if ctx.config().rpm_ostree() {
             let mut command = ctx.run_type().execute(ostree);
             command.arg("upgrade");


### PR DESCRIPTION
## What does this PR do
This PR should fix https://github.com/topgrade-rs/topgrade/issues/997 where it wouldn't take the rpm-ostree flow when bootc was found on the system, even if it was disabled via the config.

Tested with `rpm-ostree=false` & `bootc=false` it used `dnf`
Tested with `rpm-ostree=true` & `bootc=false` it used `rpm-ostree`
Tested with `rpm-ostree=false` & `bootc=true` it used `bootc`

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

This was introducued in PR https://github.com/topgrade-rs/topgrade/pull/986
@tulilirockz maybe you can verify this also works for you.
