### PR TITLE
refactor(uv step): check self update result if self-update feat is available

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -1129,8 +1129,7 @@ pub fn run_uv(ctx: &ExecutionContext) -> Result<()> {
         ctx.run_type()
             .execute(&uv_exec)
             .args(["self", "update"])
-            .status_checked()
-            .ok();
+            .status_checked()?;
     }
 
     ctx.run_type()


### PR DESCRIPTION
## What does this PR do

For the `uv` step, if the self-update feature is available, we should do the update and **check** its result.

cc @lucaspar 


## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
