### PR TITLE
feat: add Ollama support

### DIFF
--- a/locales/app.yml
+++ b/locales/app.yml
@@ -793,3 +793,8 @@ _version: 2
   es: "No se pueden actualizar las aplicaciones de Microsoft Store, se requiere intervención manual"
   fr: "Impossible de mettre à jour les applications du Microsoft Store, une intervention manuelle est nécessaire"
   zh_TW: "無法更新 Microsoft Store 應用，需手動幹預"
+"Pulling model '{model_name}'":
+  en: "Pulling model '%{model_name}'"
+  es: "Extrayendo el modelo '%{model_name}'"
+  fr: "Récupération du modèle '%{model_name}'"
+  zh_TW: "正在拉取模型 '%{model_name}'"

--- a/src/config.rs
+++ b/src/config.rs
@@ -116,6 +116,7 @@ pub enum Step {
     Myrepos,
     Nix,
     Node,
+    Ollama,
     Opam,
     Pacdef,
     Pacstall,

--- a/src/main.rs
+++ b/src/main.rs
@@ -435,6 +435,7 @@ fn run() -> Result<()> {
     runner.execute(Step::Zvm, "ZVM", || generic::run_zvm(&ctx))?;
     runner.execute(Step::Aqua, "aqua", || generic::run_aqua(&ctx))?;
     runner.execute(Step::Bun, "bun", || generic::run_bun(&ctx))?;
+    runner.execute(Step::Ollama, "Ollama", || generic::run_ollama_pull(&ctx))?;
 
     if should_run_powershell {
         runner.execute(Step::Powershell, "Powershell Modules Update", || {


### PR DESCRIPTION
## What does this PR do

Add an `Ollama` step that would pull all the installed LLMs, closes #988.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [x] If this PR introduces new user-facing messages they are translated
 
## For new steps

- [x] *Optional:* Topgrade skips this step where needed
- [x] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command
  This step does not support the `--yes` option

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
