### PR TITLE
fix: Executor::spawn()/output() should not use their _checked() variants

### DIFF
--- a/src/executor.rs
+++ b/src/executor.rs
@@ -152,7 +152,10 @@ impl Executor {
         let result = match self {
             Executor::Wet(c) => {
                 debug!("Running {:?}", c);
-                c.spawn_checked().map(ExecutorChild::Wet)?
+                // We should use `spawn()` here rather than `spawn_checked()` since
+                // their semantics and behaviors are different.
+                #[allow(clippy::disallowed_methods)]
+                c.spawn().map(ExecutorChild::Wet)?
             }
             Executor::Dry(c) => {
                 c.dry_run();
@@ -166,7 +169,12 @@ impl Executor {
     /// See `std::process::Command::output`
     pub fn output(&mut self) -> Result<ExecutorOutput> {
         match self {
-            Executor::Wet(c) => Ok(ExecutorOutput::Wet(c.output_checked()?)),
+            Executor::Wet(c) => {
+                // We should use `output()` here rather than `output_checked()` since
+                // their semantics and behaviors are different.
+                #[allow(clippy::disallowed_methods)]
+                Ok(ExecutorOutput::Wet(c.output()?))
+            }
             Executor::Dry(c) => {
                 c.dry_run();
                 Ok(ExecutorOutput::Dry)


### PR DESCRIPTION
## What does this PR do

`CommandExt::output_checked()` returns `Err()` if the command fails, using it in `Executor::output()` will make its behavior different from `std::process::Command::output()`.

The same applies to `spawn()` as well. `Executor` does not have a `status()` command.

These changes were made 2 years ago by @9999years, it would be great if we can have you here and take a look at this PR:)

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
