### PR TITLE
Add zigup step

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -297,10 +297,11 @@
 # (default: false)
 # set_default = false
 
-# Specifies the version string passed to zigup.
-# This may be a pinned version such as "0.13.0" or a branch such as "master".
-# (default: "master")
-# target_version = "master"
+# Version strings passed to zigup.
+# These may be pinned versions such as "0.13.0" or branches such as "master".
+# Each one will be updated in its own zigup invocation.
+# (default: ["master"])
+# target_versions = ["master", "0.13.0"]
 
 # Specifies the directory that the zig files will be installed to.
 # If defined, passed with the --install-dir command line flag.
@@ -315,6 +316,7 @@
 # (default: not defined)
 # path_link = "/home/user/.bin/zig"
 
-# If enabled, run `zigup clean` after updating the version.
+# If enabled, run `zigup clean` after updating all versions.
+# If enabled, each updated version above will be marked with `zigup keep`.
 # (default: false)
 # cleanup = false

--- a/config.example.toml
+++ b/config.example.toml
@@ -290,3 +290,27 @@
 # in the startup file, which might cause the update run to fail.
 # (default: true)
 # startup_file = true
+
+[zigup]
+# If disabled, Topgrade invokes zigup with `zigup fetch`.
+# This will prevent it from overriding the default zig version.
+# (default: false)
+# set_default = false
+
+# Specifies the version string passed to zigup.
+# This may be a pinned version such as "0.13.0" or a branch such as "master".
+# (default: "master")
+# target_version = "master"
+
+# Specifies the directory that the zig files will be installed to.
+# If defined, passed with the --install-dir command line flag.
+# If not defined, zigup will use its default behaviour.
+# (default: not defined)
+# install_dir = "/home/user/.zig"
+
+# Specifies the path of the symlink which will be set to point at the default compiler version.
+# If defined, passed with the --path-link command line flag.
+# If not defined, zigup will use its default behaviour.
+# This is not meaningful if set_default is not enabled.
+# (default: not defined)
+# path_link = "/home/user/.bin/zig"

--- a/config.example.toml
+++ b/config.example.toml
@@ -302,14 +302,14 @@
 # If defined, passed with the --install-dir command line flag.
 # If not defined, zigup will use its default behaviour.
 # (default: not defined)
-# install_dir = "/home/user/.zig"
+# install_dir = "~/.zig"
 
 # Specifies the path of the symlink which will be set to point at the default compiler version.
 # If defined, passed with the --path-link command line flag.
 # If not defined, zigup will use its default behaviour.
 # This is not meaningful if set_default is not enabled.
 # (default: not defined)
-# path_link = "/home/user/.bin/zig"
+# path_link = "~/.bin/zig"
 
 # If enabled, run `zigup clean` after updating all versions.
 # If enabled, each updated version above will be marked with `zigup keep`.

--- a/config.example.toml
+++ b/config.example.toml
@@ -292,11 +292,6 @@
 # startup_file = true
 
 [zigup]
-# If disabled, Topgrade invokes zigup with `zigup fetch`.
-# This will prevent it from overriding the default zig version.
-# (default: false)
-# set_default = false
-
 # Version strings passed to zigup.
 # These may be pinned versions such as "0.13.0" or branches such as "master".
 # Each one will be updated in its own zigup invocation.

--- a/config.example.toml
+++ b/config.example.toml
@@ -314,3 +314,7 @@
 # This is not meaningful if set_default is not enabled.
 # (default: not defined)
 # path_link = "/home/user/.bin/zig"
+
+# If enabled, run `zigup clean` after updating the version.
+# (default: false)
+# cleanup = false

--- a/src/config.rs
+++ b/src/config.rs
@@ -469,6 +469,7 @@ pub struct Zigup {
     target_version: Option<String>,
     install_dir: Option<PathBuf>,
     path_link: Option<PathBuf>,
+    cleanup: Option<bool>,
 }
 
 #[derive(Deserialize, Default, Debug, Merge)]
@@ -1709,6 +1710,14 @@ impl Config {
             .zigup
             .as_ref()
             .and_then(|zigup| zigup.path_link.as_deref())
+    }
+
+    pub fn zigup_cleanup(&self) -> bool {
+        self.config_file
+            .zigup
+            .as_ref()
+            .and_then(|zigup| zigup.cleanup)
+            .unwrap_or(false)
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -464,6 +464,15 @@ pub struct JuliaConfig {
 
 #[derive(Deserialize, Default, Debug, Merge)]
 #[serde(deny_unknown_fields)]
+pub struct Zigup {
+    set_default: Option<bool>,
+    target_version: Option<String>,
+    install_dir: Option<PathBuf>,
+    path_link: Option<PathBuf>,
+}
+
+#[derive(Deserialize, Default, Debug, Merge)]
+#[serde(deny_unknown_fields)]
 /// Configuration file
 pub struct ConfigFile {
     #[merge(strategy = crate::utils::merge_strategies::inner_merge_opt)]
@@ -531,6 +540,9 @@ pub struct ConfigFile {
 
     #[merge(strategy = crate::utils::merge_strategies::inner_merge_opt)]
     julia: Option<JuliaConfig>,
+
+    #[merge(strategy = crate::utils::merge_strategies::inner_merge_opt)]
+    zigup: Option<Zigup>,
 }
 
 fn config_directory() -> PathBuf {
@@ -1667,6 +1679,36 @@ impl Config {
             .as_ref()
             .and_then(|julia| julia.startup_file)
             .unwrap_or(true)
+    }
+
+    pub fn zigup_set_default(&self) -> bool {
+        self.config_file
+            .zigup
+            .as_ref()
+            .and_then(|zigup| zigup.set_default)
+            .unwrap_or(false)
+    }
+
+    pub fn zigup_target_version(&self) -> &str {
+        self.config_file
+            .zigup
+            .as_ref()
+            .and_then(|zigup| zigup.target_version.as_deref())
+            .unwrap_or("master")
+    }
+
+    pub fn zigup_install_dir(&self) -> Option<&Path> {
+        self.config_file
+            .zigup
+            .as_ref()
+            .and_then(|zigup| zigup.install_dir.as_deref())
+    }
+
+    pub fn zigup_path_link(&self) -> Option<&Path> {
+        self.config_file
+            .zigup
+            .as_ref()
+            .and_then(|zigup| zigup.path_link.as_deref())
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -465,7 +465,6 @@ pub struct JuliaConfig {
 #[derive(Deserialize, Default, Debug, Merge)]
 #[serde(deny_unknown_fields)]
 pub struct Zigup {
-    set_default: Option<bool>,
     target_versions: Option<Vec<String>>,
     install_dir: Option<PathBuf>,
     path_link: Option<PathBuf>,
@@ -1680,14 +1679,6 @@ impl Config {
             .as_ref()
             .and_then(|julia| julia.startup_file)
             .unwrap_or(true)
-    }
-
-    pub fn zigup_set_default(&self) -> bool {
-        self.config_file
-            .zigup
-            .as_ref()
-            .and_then(|zigup| zigup.set_default)
-            .unwrap_or(false)
     }
 
     pub fn zigup_target_versions(&self) -> Vec<String> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -466,8 +466,8 @@ pub struct JuliaConfig {
 #[serde(deny_unknown_fields)]
 pub struct Zigup {
     target_versions: Option<Vec<String>>,
-    install_dir: Option<PathBuf>,
-    path_link: Option<PathBuf>,
+    install_dir: Option<String>,
+    path_link: Option<String>,
     cleanup: Option<bool>,
 }
 
@@ -1689,14 +1689,14 @@ impl Config {
             .unwrap_or(vec!["master".to_owned()])
     }
 
-    pub fn zigup_install_dir(&self) -> Option<&Path> {
+    pub fn zigup_install_dir(&self) -> Option<&str> {
         self.config_file
             .zigup
             .as_ref()
             .and_then(|zigup| zigup.install_dir.as_deref())
     }
 
-    pub fn zigup_path_link(&self) -> Option<&Path> {
+    pub fn zigup_path_link(&self) -> Option<&str> {
         self.config_file
             .zigup
             .as_ref()

--- a/src/config.rs
+++ b/src/config.rs
@@ -466,7 +466,7 @@ pub struct JuliaConfig {
 #[serde(deny_unknown_fields)]
 pub struct Zigup {
     set_default: Option<bool>,
-    target_version: Option<String>,
+    target_versions: Option<Vec<String>>,
     install_dir: Option<PathBuf>,
     path_link: Option<PathBuf>,
     cleanup: Option<bool>,
@@ -1690,12 +1690,12 @@ impl Config {
             .unwrap_or(false)
     }
 
-    pub fn zigup_target_version(&self) -> &str {
+    pub fn zigup_target_versions(&self) -> Vec<String> {
         self.config_file
             .zigup
             .as_ref()
-            .and_then(|zigup| zigup.target_version.as_deref())
-            .unwrap_or("master")
+            .and_then(|zigup| zigup.target_versions.clone())
+            .unwrap_or(vec!["master".to_owned()])
     }
 
     pub fn zigup_install_dir(&self) -> Option<&Path> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -171,6 +171,7 @@ pub enum Step {
     Xcodes,
     Yadm,
     Yarn,
+    Zigup,
     Zvm,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -441,6 +441,7 @@ fn run() -> Result<()> {
     runner.execute(Step::Zvm, "ZVM", || generic::run_zvm(&ctx))?;
     runner.execute(Step::Aqua, "aqua", || generic::run_aqua(&ctx))?;
     runner.execute(Step::Bun, "bun", || generic::run_bun(&ctx))?;
+    runner.execute(Step::Zigup, "zigup", || generic::run_zigup(&ctx))?;
 
     if should_run_powershell {
         runner.execute(Step::Powershell, "Powershell Modules Update", || {

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -1233,14 +1233,12 @@ pub fn run_zigup(ctx: &ExecutionContext) -> Result<()> {
             args.push(path.as_os_str());
         }
 
-        let mut cmd = ctx.run_type().execute(&zigup);
-
-        if config.zigup_set_default() {
-            cmd.args(&args).arg(&zig_version)
-        } else {
-            cmd.args(&args).arg("fetch").arg(&zig_version)
-        }
-        .status_checked()?;
+        ctx.run_type()
+            .execute(&zigup)
+            .args(args)
+            .arg("fetch")
+            .arg(&zig_version)
+            .status_checked()?;
 
         if config.zigup_cleanup() {
             ctx.run_type()

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -1222,14 +1222,14 @@ pub fn run_zigup(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("zigup");
 
-    let mut path_args: Vec<&OsStr> = Vec::new();
+    let mut path_args = Vec::new();
     if let Some(path) = config.zigup_path_link() {
-        path_args.push("--path-link".as_ref());
-        path_args.push(path.as_os_str());
+        path_args.push("--path-link".to_owned());
+        path_args.push(shellexpand::tilde(path).into_owned());
     }
     if let Some(path) = config.zigup_install_dir() {
-        path_args.push("--install-dir".as_ref());
-        path_args.push(path.as_os_str());
+        path_args.push("--install-dir".to_owned());
+        path_args.push(shellexpand::tilde(path).into_owned());
     }
 
     for zig_version in config.zigup_target_versions() {

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -1221,5 +1221,23 @@ pub fn run_zigup(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("zigup");
 
-    ctx.run_type().execute(zigup).arg("master").status_checked()
+    let mut runner = ctx.run_type().execute(zigup);
+
+    let mut runner = if !ctx.config().zigup_set_default() {
+        runner.arg("fetch")
+    } else {
+        &mut runner
+    };
+    runner = if let Some(path) = ctx.config().zigup_path_link() {
+        runner.arg("--path-link").arg(path)
+    } else {
+        runner
+    };
+    runner = if let Some(path) = ctx.config().zigup_install_dir() {
+        runner.arg("--install-dir").arg(path)
+    } else {
+        runner
+    };
+
+    runner.arg(ctx.config().zigup_target_version()).status_checked()
 }

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -1222,20 +1222,20 @@ pub fn run_zigup(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("zigup");
 
-    for zig_version in config.zigup_target_versions() {
-        let mut args: Vec<&OsStr> = Vec::new();
-        if let Some(path) = config.zigup_path_link() {
-            args.push("--path-link".as_ref());
-            args.push(path.as_os_str());
-        }
-        if let Some(path) = config.zigup_install_dir() {
-            args.push("--install-dir".as_ref());
-            args.push(path.as_os_str());
-        }
+    let mut path_args: Vec<&OsStr> = Vec::new();
+    if let Some(path) = config.zigup_path_link() {
+        path_args.push("--path-link".as_ref());
+        path_args.push(path.as_os_str());
+    }
+    if let Some(path) = config.zigup_install_dir() {
+        path_args.push("--install-dir".as_ref());
+        path_args.push(path.as_os_str());
+    }
 
+    for zig_version in config.zigup_target_versions() {
         ctx.run_type()
             .execute(&zigup)
-            .args(args)
+            .args(&path_args)
             .arg("fetch")
             .arg(&zig_version)
             .status_checked()?;
@@ -1243,6 +1243,7 @@ pub fn run_zigup(ctx: &ExecutionContext) -> Result<()> {
         if config.zigup_cleanup() {
             ctx.run_type()
                 .execute(&zigup)
+                .args(&path_args)
                 .arg("keep")
                 .arg(&zig_version)
                 .status_checked()?;
@@ -1250,7 +1251,11 @@ pub fn run_zigup(ctx: &ExecutionContext) -> Result<()> {
     }
 
     if config.zigup_cleanup() {
-        ctx.run_type().execute(zigup).arg("clean").status_checked()?;
+        ctx.run_type()
+            .execute(zigup)
+            .args(&path_args)
+            .arg("clean")
+            .status_checked()?;
     }
 
     Ok(())

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -1215,3 +1215,11 @@ pub fn run_bun(ctx: &ExecutionContext) -> Result<()> {
 
     ctx.run_type().execute(bun).arg("upgrade").status_checked()
 }
+
+pub fn run_zigup(ctx: &ExecutionContext) -> Result<()> {
+    let zigup = require("zigup")?;
+
+    print_separator("zigup");
+
+    ctx.run_type().execute(zigup).arg("master").status_checked()
+}

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -1221,7 +1221,7 @@ pub fn run_zigup(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("zigup");
 
-    let mut runner = ctx.run_type().execute(zigup);
+    let mut runner = ctx.run_type().execute(&zigup);
 
     let mut runner = if !ctx.config().zigup_set_default() {
         runner.arg("fetch")
@@ -1239,5 +1239,11 @@ pub fn run_zigup(ctx: &ExecutionContext) -> Result<()> {
         runner
     };
 
-    runner.arg(ctx.config().zigup_target_version()).status_checked()
+    runner.arg(ctx.config().zigup_target_version()).status_checked()?;
+
+    if ctx.config().zigup_cleanup() {
+        ctx.run_type().execute(zigup).arg("clean").status_checked()
+    } else {
+        Ok(())
+    }
 }


### PR DESCRIPTION
## What does this PR do

This PR adds a step to run [`zigup`](https://github.com/marler8997/zigup), a zig version manager comparable to the already-supported ZVM. The step can be configured to update multiple version tracking strings, mark them for keeping/clean up old versions, and change the directory they're installed into as well as the symlink path that they're "installed with".

By default, the step updates the `master` branch, which is currently considered the recommended version of zig (see "Tagged release or nightly build?" [here](https://ziglang.org/learn/getting-started/)), falling back to the default behaviour of `zigup` with paths, and not deleting any files.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [x] If this PR introduces new user-facing messages they are translated
 
## For new steps

- [x] *Optional:* Topgrade skips this step where needed
- [x] *Optional:* The `--dry-run` option works with this step - **I believe this should work as the step doesn't perform anything outside of the `command` API**
- [ ] ~~*Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command~~ **N/A**
