### PR TITLE
Run `juliaup gc` if cleanup is enabled

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -296,7 +296,13 @@ pub fn run_juliaup(ctx: &ExecutionContext) -> Result<()> {
             .status_checked()?;
     }
 
-    ctx.run_type().execute(&juliaup).arg("update").status_checked()
+    ctx.run_type().execute(&juliaup).arg("update").status_checked()?;
+
+    if ctx.config().cleanup() {
+        ctx.run_type().execute(&juliaup).arg("gc").status_checked()?;
+    }
+
+    Ok(())
 }
 
 pub fn run_choosenim(ctx: &ExecutionContext) -> Result<()> {


### PR DESCRIPTION
## What does this PR do

This PR runs `juliaup gc` to collect old julia versions if the `misc.cleanup` flag is set to true. 

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [x] If this PR introduces new user-facing messages they are translated