### PR TITLE
feat(pixi): add support for `pixi global`

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -529,7 +529,16 @@ pub fn run_pixi_update(ctx: &ExecutionContext) -> Result<()> {
     let pixi = require("pixi")?;
     print_separator("Pixi");
 
-    ctx.run_type().execute(pixi).args(["self-update"]).status_checked()
+    ctx.run_type()
+        .execute(&pixi)
+        .args(["self-update"])
+        .status_checked()
+        .ok();
+
+    ctx.run_type()
+        .execute(&pixi)
+        .args(["global", "update"])
+        .status_checked()
 }
 
 pub fn run_mamba_update(ctx: &ExecutionContext) -> Result<()> {


### PR DESCRIPTION
## What does this PR do

This adds `pixi global update`, which updates the global binaries installed through `pixi`, to the `pixi` step. The implementation follows #890 where the same was added for `uv`.


## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [x] If this PR introduces new user-facing messages they are translated
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
