### PR TITLE
use sudo for pruning docker images

### DIFF
--- a/src/steps/containers.rs
+++ b/src/steps/containers.rs
@@ -177,10 +177,11 @@ pub fn run_containers(ctx: &ExecutionContext) -> Result<()> {
     if ctx.config().cleanup() {
         // Remove dangling images
         debug!("Removing dangling images");
+        let sudo = require_option(ctx.sudo().as_ref(), get_require_sudo_string())?;
         if let Err(e) = ctx
             .run_type()
-            .execute(&crt)
-            .args(["image", "prune", "-f"])
+            .execute(sudo)
+            .args([&crt, "image", "prune", "-f"])
             .status_checked()
         {
             error!("Removing dangling images failed: {}", e);


### PR DESCRIPTION
The last part of the Docker update step was giving me the following error:

```
permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Head "http://%2Fvar%2Frun%2Fdocker.sock/_ping": dial unix /var/run/docker.sock: connect: permission denied
ERROR Removing dangling images failed: Command failed: '/usr/local/bin/docker image prune -f'

```

Manually executing `/usr/local/bin/docker image prune -f` with sudo worked fine, so i'm assuming that this was really just a permissions thing. I have not tested this fix and i'm not sure if i implemented it correctly, so please check the code. It seems weird that this issue has not come up before, could it be OS or distribution specific? I'm running Bedrock Linux/Kubuntu.