### PR TITLE
Run `conda clean` after `conda update` if `cleanup = true`

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -517,12 +517,23 @@ pub fn run_conda_update(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("Conda");
 
-    let mut command = ctx.run_type().execute(conda);
+    let mut command = ctx.run_type().execute(&conda);
     command.args(["update", "--all", "-n", "base"]);
     if ctx.config().yes(Step::Conda) {
         command.arg("--yes");
     }
-    command.status_checked()
+    command.status_checked()?;
+
+    if ctx.config().cleanup() {
+        let mut command = ctx.run_type().execute(conda);
+        command.args(["clean", "--all"]);
+        if ctx.config().yes(Step::Conda) {
+            command.arg("--yes");
+        }
+        command.status_checked()?;
+    }
+
+    Ok(())
 }
 
 pub fn run_pixi_update(ctx: &ExecutionContext) -> Result<()> {

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -548,12 +548,23 @@ pub fn run_mamba_update(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("Mamba");
 
-    let mut command = ctx.run_type().execute(mamba);
+    let mut command = ctx.run_type().execute(&mamba);
     command.args(["update", "--all", "-n", "base"]);
     if ctx.config().yes(Step::Mamba) {
         command.arg("--yes");
     }
-    command.status_checked()
+    command.status_checked()?;
+
+    if ctx.config().cleanup() {
+        let mut command = ctx.run_type().execute(&mamba);
+        command.args(["clean", "--all"]);
+        if ctx.config().yes(Step::Mamba) {
+            command.arg("--yes");
+        }
+        command.status_checked()?;
+    }
+
+    Ok(())
 }
 
 pub fn run_miktex_packages_update(ctx: &ExecutionContext) -> Result<()> {


### PR DESCRIPTION
## What does this PR do

Conda provides a `conda clean` subcommand, sort of like `apt autoremove`, that automatically removes used unused packages, tarballs, and so on:

https://docs.conda.io/projects/conda/en/latest/commands/clean.html

This PR updates the Conda topgrade step to run `conda clean --all` if `cleanup = true` is set in the topgrade config. It adds `--yes` if topgrade is run with `-y`.

The same change is applied to the Mamba upgrade step, too (note that mamba and conda are nearly identical CLIs for working with conda environments).

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [x] (n/a) If this PR introduces new user-facing messages they are translated
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [x] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
