### PR TITLE
Allow providing additional conda envs to update in `topgrade.toml`

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -111,6 +111,19 @@
 # poetry_force_self_update = true
 
 
+[conda]
+# Additional named conda environments to update (`conda env update -n env_name`)
+# env_names = [
+#     "Toolbox",
+#     "PyTorch"
+# ]
+# Additional conda environment paths to pull (`conda env update -p env_path`)
+# env_paths = [
+#     "~/webserver/.conda/",
+#     "~/experiments/.conda/"
+# ]
+
+
 [composer]
 # self_update = true
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -236,6 +236,16 @@ pub struct Python {
 
 #[derive(Deserialize, Default, Debug, Merge)]
 #[serde(deny_unknown_fields)]
+pub struct Conda {
+    #[merge(strategy = crate::utils::merge_strategies::vec_prepend_opt)]
+    env_names: Option<Vec<String>>,
+
+    #[merge(strategy = crate::utils::merge_strategies::vec_prepend_opt)]
+    env_paths: Option<Vec<String>>,
+}
+
+#[derive(Deserialize, Default, Debug, Merge)]
+#[serde(deny_unknown_fields)]
 #[allow(clippy::upper_case_acronyms)]
 pub struct Distrobox {
     use_root: Option<bool>,
@@ -495,6 +505,9 @@ pub struct ConfigFile {
 
     #[merge(strategy = crate::utils::merge_strategies::commands_merge_opt)]
     commands: Option<Commands>,
+
+    #[merge(strategy = crate::utils::merge_strategies::inner_merge_opt)]
+    conda: Option<Conda>,
 
     #[merge(strategy = crate::utils::merge_strategies::inner_merge_opt)]
     python: Option<Python>,
@@ -956,6 +969,22 @@ impl Config {
     /// The list of custom steps.
     pub fn commands(&self) -> &Option<Commands> {
         &self.config_file.commands
+    }
+
+    /// The list of additional named conda environments.
+    pub fn conda_env_names(&self) -> Option<&Vec<String>> {
+        self.config_file
+            .conda
+            .as_ref()
+            .and_then(|conda| conda.env_names.as_ref())
+    }
+
+    /// The list of additional git repositories to pull.
+    pub fn conda_env_paths(&self) -> Option<&Vec<String>> {
+        self.config_file
+            .conda
+            .as_ref()
+            .and_then(|conda| conda.env_paths.as_ref())
     }
 
     /// The list of additional git repositories to pull.

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -1,6 +1,7 @@
 #![allow(unused_imports)]
 
 use std::ffi::OsStr;
+use std::iter::once;
 use std::path::PathBuf;
 use std::process::Command;
 use std::{env, path::Path};
@@ -517,12 +518,33 @@ pub fn run_conda_update(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("Conda");
 
-    let mut command = ctx.run_type().execute(conda);
-    command.args(["update", "--all", "-n", "base"]);
-    if ctx.config().yes(Step::Conda) {
-        command.arg("--yes");
+    // Update named environments, starting with the always-present "base"
+    let base_env_name = "base".to_string();
+    let addl_env_names = ctx.config().conda_env_names().into_iter().flatten();
+    let env_names = once(&base_env_name).chain(addl_env_names);
+
+    for env_name in env_names {
+        let mut command = ctx.run_type().execute(&conda);
+        command.args(["update", "--all", "-n", env_name]);
+        if ctx.config().yes(Step::Conda) {
+            command.arg("--yes");
+        }
+        command.status_checked()?;
     }
-    command.status_checked()
+
+    // Update any environments given by path
+    if let Some(env_paths) = ctx.config().conda_env_paths() {
+        for env_path in env_paths.iter() {
+            let mut command = ctx.run_type().execute(&conda);
+            command.args(["update", "--all", "-p", env_path]);
+            if ctx.config().yes(Step::Conda) {
+                command.arg("--yes");
+            }
+            command.status_checked()?;
+        }
+    }
+
+    Ok(())
 }
 
 pub fn run_pixi_update(ctx: &ExecutionContext) -> Result<()> {


### PR DESCRIPTION
## What does this PR do

This PR adds a `[conda]` block to `topgrade.toml` with two optional lists `env_names` and `env_paths`. These lists specify additional conda environments whose packages are updated using `conda env update -n env_name` or `conda env update -p env_path`, respectively.

I modified `run_conda_update()` to update the `base` conda environment first, then additional named environments and environment paths.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [x] n/a: If this PR introduces new user-facing messages they are translated
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
