### PR TITLE
Add "Cinnamon spices" step

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -69,6 +69,7 @@ pub enum Step {
     Chezmoi,
     Chocolatey,
     Choosenim,
+    CinnamonSpices,
     ClamAvDb,
     Composer,
     Conda,

--- a/src/main.rs
+++ b/src/main.rs
@@ -442,6 +442,7 @@ fn run() -> Result<()> {
     runner.execute(Step::Aqua, "aqua", || generic::run_aqua(&ctx))?;
     runner.execute(Step::Bun, "bun", || generic::run_bun(&ctx))?;
     runner.execute(Step::Zigup, "zigup", || generic::run_zigup(&ctx))?;
+    runner.execute(Step::CinnamonSpices, "Cinnamon spices", || generic::run_cinnamon_spices_updater(&ctx))?;
 
     if should_run_powershell {
         runner.execute(Step::Powershell, "Powershell Modules Update", || {

--- a/src/main.rs
+++ b/src/main.rs
@@ -442,7 +442,9 @@ fn run() -> Result<()> {
     runner.execute(Step::Aqua, "aqua", || generic::run_aqua(&ctx))?;
     runner.execute(Step::Bun, "bun", || generic::run_bun(&ctx))?;
     runner.execute(Step::Zigup, "zigup", || generic::run_zigup(&ctx))?;
-    runner.execute(Step::CinnamonSpices, "Cinnamon spices", || generic::run_cinnamon_spices_updater(&ctx))?;
+    runner.execute(Step::CinnamonSpices, "Cinnamon spices", || {
+        generic::run_cinnamon_spices_updater(&ctx)
+    })?;
 
     if should_run_powershell {
         runner.execute(Step::Powershell, "Powershell Modules Update", || {

--- a/src/main.rs
+++ b/src/main.rs
@@ -251,6 +251,9 @@ fn run() -> Result<()> {
         runner.execute(Step::Lure, "LURE", || linux::run_lure_update(&ctx))?;
         runner.execute(Step::Waydroid, "Waydroid", || linux::run_waydroid(&ctx))?;
         runner.execute(Step::AutoCpufreq, "auto-cpufreq", || linux::run_auto_cpufreq(&ctx))?;
+        runner.execute(Step::CinnamonSpices, "Cinnamon spices", || {
+            linux::run_cinnamon_spices_updater(&ctx)
+        })?;
     }
 
     #[cfg(target_os = "macos")]
@@ -442,9 +445,6 @@ fn run() -> Result<()> {
     runner.execute(Step::Aqua, "aqua", || generic::run_aqua(&ctx))?;
     runner.execute(Step::Bun, "bun", || generic::run_bun(&ctx))?;
     runner.execute(Step::Zigup, "zigup", || generic::run_zigup(&ctx))?;
-    runner.execute(Step::CinnamonSpices, "Cinnamon spices", || {
-        generic::run_cinnamon_spices_updater(&ctx)
-    })?;
 
     if should_run_powershell {
         runner.execute(Step::Powershell, "Powershell Modules Update", || {

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -1309,5 +1309,8 @@ pub fn run_cinnamon_spices_updater(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("Cinnamon spices");
 
-    ctx.run_type().execute(cinnamon_spice_updater).arg("--update-all").status_checked()
+    ctx.run_type()
+        .execute(cinnamon_spice_updater)
+        .arg("--update-all")
+        .status_checked()
 }

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -1303,3 +1303,11 @@ pub fn run_zigup(ctx: &ExecutionContext) -> Result<()> {
 
     Ok(())
 }
+
+pub fn run_cinnamon_spices_updater(ctx: &ExecutionContext) -> Result<()> {
+    let cinnamon_spice_updater = require("cinnamon-spice-updater")?;
+
+    print_separator("Cinnamon spices");
+
+    ctx.run_type().execute(cinnamon_spice_updater).arg("--update-all").status_checked()
+}

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -1303,14 +1303,3 @@ pub fn run_zigup(ctx: &ExecutionContext) -> Result<()> {
 
     Ok(())
 }
-
-pub fn run_cinnamon_spices_updater(ctx: &ExecutionContext) -> Result<()> {
-    let cinnamon_spice_updater = require("cinnamon-spice-updater")?;
-
-    print_separator("Cinnamon spices");
-
-    ctx.run_type()
-        .execute(cinnamon_spice_updater)
-        .arg("--update-all")
-        .status_checked()
-}

--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -1117,6 +1117,17 @@ pub fn run_auto_cpufreq(ctx: &ExecutionContext) -> Result<()> {
         .status_checked()
 }
 
+pub fn run_cinnamon_spices_updater(ctx: &ExecutionContext) -> Result<()> {
+    let cinnamon_spice_updater = require("cinnamon-spice-updater")?;
+
+    print_separator("Cinnamon spices");
+
+    ctx.run_type()
+        .execute(cinnamon_spice_updater)
+        .arg("--update-all")
+        .status_checked()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Closes #1054

## What does this PR do
Adds a "Cinnamon spices" step that uses "cinnamon-spice-updater"

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated
 
## For new steps

- [x] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

The step is currently guarded only for Linux and not for Linux Mint specifically. But I don't see why it would matter, since the command is only available on Linux Mint anyway. What do you think?