### PR TITLE
fix(sudo): fix sudo detection & pre-sudo for GSudo

### DIFF
--- a/src/sudo.rs
+++ b/src/sudo.rs
@@ -24,7 +24,7 @@ pub struct Sudo {
 impl Sudo {
     /// Get the `sudo` binary or the `gsudo` binary in the case of `gsudo`
     /// masquerading as the `sudo` binary.
-    fn detect_gsudo_as_sudo(sudo_p: PathBuf) -> (PathBuf, SudoKind) {
+    fn determine_sudo_variant(sudo_p: PathBuf) -> (PathBuf, SudoKind) {
         match which("gsudo") {
             Some(gsudo_p) => {
                 match std::fs::canonicalize(&gsudo_p).unwrap() == std::fs::canonicalize(&sudo_p).unwrap() {
@@ -40,7 +40,7 @@ impl Sudo {
     pub fn detect() -> Option<Self> {
         which("doas")
             .map(|p| (p, SudoKind::Doas))
-            .or_else(|| which("sudo").map(|p| Self::detect_gsudo_as_sudo(p)))
+            .or_else(|| which("sudo").map(Self::determine_sudo_variant))
             .or_else(|| which("gsudo").map(|p| (p, SudoKind::Gsudo)))
             .or_else(|| which("pkexec").map(|p| (p, SudoKind::Pkexec)))
             .or_else(|| which("please").map(|p| (p, SudoKind::Please)))

--- a/src/sudo.rs
+++ b/src/sudo.rs
@@ -26,8 +26,8 @@ impl Sudo {
     pub fn detect() -> Option<Self> {
         which("doas")
             .map(|p| (p, SudoKind::Doas))
-            .or_else(|| which("sudo").map(|p| (p, SudoKind::Sudo)))
             .or_else(|| which("gsudo").map(|p| (p, SudoKind::Gsudo)))
+            .or_else(|| which("sudo").map(|p| (p, SudoKind::Sudo)))
             .or_else(|| which("pkexec").map(|p| (p, SudoKind::Pkexec)))
             .or_else(|| which("please").map(|p| (p, SudoKind::Please)))
             .map(|(path, kind)| Self { path, kind })


### PR DESCRIPTION
## What does this PR do
When the `sudo` binary is detected, an additional check is added to see whether it's actually `GSudo` masquerading as the `sudo` binary and the right `SudoKind` will be applied.
GSudo does this by making a `sudo.exe` that's symlinked to the `gsudo.exe` binary. We check if the canonical path of `sudo.exe` is equal to the canonical path of `gsudo.exe`, and apply `SudoKind::Gsudo` when true.

Additionally, during testing I've found that `gsudo status` doesn't cache credentials (it only shows whether credentials are currently cached and doesn't elevate), so `pre_sudo` likely never worked with `gsudo` in the first place. I've changed this to run `gsudo echo` instead, which does elevate and caches the credentials (if the credential cache has been enabled beforehand, of course).

Fixes issue #1057.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
