### PR TITLE
feat(sudo): add run0 as a sudo variant

### DIFF
--- a/src/sudo.rs
+++ b/src/sudo.rs
@@ -43,6 +43,7 @@ impl Sudo {
             .or_else(|| which("sudo").map(Self::determine_sudo_variant))
             .or_else(|| which("gsudo").map(|p| (p, SudoKind::Gsudo)))
             .or_else(|| which("pkexec").map(|p| (p, SudoKind::Pkexec)))
+            .or_else(|| which("run0").map(|p| (p, SudoKind::Run0)))
             .or_else(|| which("please").map(|p| (p, SudoKind::Please)))
             .map(|(path, kind)| Self { path, kind })
     }
@@ -95,6 +96,13 @@ impl Sudo {
                 // See: https://linux.die.net/man/1/pkexec
                 cmd.arg("echo");
             }
+            SudoKind::Run0 => {
+                // `run0` uses polkit for authentication
+                // and thus has the same issues as `pkexec`.
+                //
+                // See: https://www.freedesktop.org/software/systemd/man/devel/run0.html
+                cmd.arg("echo");
+            }
             SudoKind::Please => {
                 // From `man please`
                 //   -w, --warm
@@ -131,6 +139,7 @@ pub enum SudoKind {
     Sudo,
     Gsudo,
     Pkexec,
+    Run0,
     Please,
 }
 


### PR DESCRIPTION
## What does this PR do

Add `run0` (shipped by systemd since version 256) as a `sudo` variant.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [ ] ~~If this PR introduces new user-facing messages they are translated~~
 
## ~~For new steps~~

- [ ] ~~*Optional:* Topgrade skips this step where needed~~
- [ ] ~~*Optional:* The `--dry-run` option works with this step~~
- [ ] ~~*Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command~~

~~If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.~~
