### PR TITLE
docs: fix `--log-filter` link in `--help`

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -849,7 +849,7 @@ pub struct CommandLineArgs {
 
     /// Tracing filter directives.
     ///
-    /// See: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/struct.EnvFilter.html
+    /// See: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives
     #[arg(long, default_value = DEFAULT_LOG_LEVEL)]
     pub log_filter: String,
 


### PR DESCRIPTION
## What does this PR do
Fixes the link in the `--log-filter`  description of when adding the `--help` option.

Issue: #1051 

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
