### PR TITLE
fix:(emacs): fix issue #1075

### DIFF
--- a/src/steps/emacs.el
+++ b/src/steps/emacs.el
@@ -1,9 +1,4 @@
-(when (fboundp 'paradox-upgrade-packages)
-    (progn
-      (unless (boundp 'paradox-github-token)
-        (setq paradox-github-token t))
-      (paradox-upgrade-packages)
-      (princ
-       (if (get-buffer "*Paradox Report*")
-           (with-current-buffer "*Paradox Report*" (buffer-string))
-         "\nNothing to upgrade\n"))))
+(when (featurep 'package)
+  (if (fboundp 'package-upgrade-all)
+    (package-upgrade-all nil)
+    (message "Your Emacs version doesn't support unattended packages upgrade")))


### PR DESCRIPTION
## What does this PR do

Fix issue #1075. We'll use Emacs' embedded package upgrade functionality if available.

I don't know if we can use the i18n system to translate the string inside `emacs.el`.

Tested with Emacs 29.3 on Linux and Emacs 30.1 on macOS.
