### PR TITLE
Update jetbrains-toolbox-updater

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1449,9 +1449,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jetbrains-toolbox-updater"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a67ac56f02a72dc1d2a259e6dab5a66eeb2a2a91fd6bf90923f5ed125dd6adaf"
+checksum = "b9d86b38fee698b3f63c9772fe2832d03a84e0724e409d499517c8a102949717"
 dependencies = [
  "dirs 6.0.0",
  "json",


### PR DESCRIPTION
## What does this PR do
I've bumped `jetbrains-toolbox-updater`, because I added a feature that should be included in the next release. It avoids accidentally permanently modifying Toolbox configuration when an error occurs.