### PR TITLE
Fix `pixi self-update` running when `pixi` is not installed with the …

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -553,11 +553,21 @@ pub fn run_pixi_update(ctx: &ExecutionContext) -> Result<()> {
     let pixi = require("pixi")?;
     print_separator("Pixi");
 
-    ctx.run_type()
+    // Check if `pixi --help` mentions self-update, if yes, self-update must be enabled.
+    // pixi self-update --help works regardless of whether the feature is enabled.
+    let output = ctx
+        .run_type()
         .execute(&pixi)
-        .args(["self-update"])
-        .status_checked()
-        .ok();
+        .arg("--help")
+        .output_checked()?;
+
+    if String::from_utf8(output.stdout)?.contains("self-update") {
+        ctx.run_type()
+            .execute(&pixi)
+            .args(["self-update"])
+            .status_checked()
+            .ok();
+    }
 
     ctx.run_type()
         .execute(&pixi)

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -555,11 +555,7 @@ pub fn run_pixi_update(ctx: &ExecutionContext) -> Result<()> {
 
     // Check if `pixi --help` mentions self-update, if yes, self-update must be enabled.
     // pixi self-update --help works regardless of whether the feature is enabled.
-    let output = ctx
-        .run_type()
-        .execute(&pixi)
-        .arg("--help")
-        .output_checked()?;
+    let output = ctx.run_type().execute(&pixi).arg("--help").output_checked()?;
 
     if String::from_utf8(output.stdout)?.contains("self-update") {
         ctx.run_type()


### PR DESCRIPTION
…`self-update` feature

Closes #1086

## What does this PR do
In the `pixi` step, call `pixi --help` to check for the availability of the `self-update` command. If it is not available, skip the `pixi self-update` part of the step.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated
 

Pixi installed via `brew install pixi` or `cargo install --locked --git https://github.com/prefix-dev/pixi.git pixi`:
```
── 08:30:45 - Pixi ─────────────────────────────────────────────────────────────
DEBUG Executing command `/home/linuxbrew/.linuxbrew/bin/pixi --help`
DEBUG Executing command `/home/linuxbrew/.linuxbrew/bin/pixi global update`
```
Pixi installed via standalone installer:
```
── 08:33:07 - Pixi ─────────────────────────────────────────────────────────────
DEBUG Executing command `/home/gideon/.pixi/bin/pixi --help`
DEBUG Executing command `/home/gideon/.pixi/bin/pixi self-update`
✔ pixi is already up-to-date (version 0.43.3)
DEBUG Executing command `/home/gideon/.pixi/bin/pixi global update`
```