### PR TITLE
added silent install option for winget

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -219,6 +219,10 @@
 
 # wsl_update_use_web_download = true
 
+# The default for winget_install_silently is true, 
+# this example turns off silent install.
+# winget_install_silently = false
+
 # Causes Topgrade to rename itself during the run to allow package managers
 # to upgrade it. Use this only if you installed Topgrade by using a package
 # manager such as Scoop or Cargo

--- a/src/config.rs
+++ b/src/config.rs
@@ -225,7 +225,7 @@ pub struct Windows {
     open_remotes_in_new_terminal: Option<bool>,
     wsl_update_pre_release: Option<bool>,
     wsl_update_use_web_download: Option<bool>,
-    winget_silent_install: Option<bool>
+    winget_silent_install: Option<bool>,
 }
 
 #[derive(Deserialize, Default, Debug, Merge)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -225,6 +225,7 @@ pub struct Windows {
     open_remotes_in_new_terminal: Option<bool>,
     wsl_update_pre_release: Option<bool>,
     wsl_update_use_web_download: Option<bool>,
+    winget_silent_install: Option<bool>
 }
 
 #[derive(Deserialize, Default, Debug, Merge)]
@@ -1548,6 +1549,14 @@ impl Config {
             .as_ref()
             .and_then(|windows| windows.open_remotes_in_new_terminal)
             .unwrap_or(false)
+    }
+
+    pub fn winget_silent_install(&self) -> bool {
+        self.config_file
+            .windows
+            .as_ref()
+            .and_then(|windows| windows.winget_silent_install)
+            .unwrap_or(true)
     }
 
     pub fn sudo_command(&self) -> Option<SudoKind> {

--- a/src/steps/os/windows.rs
+++ b/src/steps/os/windows.rs
@@ -42,20 +42,12 @@ pub fn run_winget(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("winget");
 
-    // check if silent install is enabled
+    let mut args = vec!["upgrade", "--all"];
     if ctx.config().winget_silent_install() {
-        // execute with silent command
-        ctx.run_type()
-            .execute(winget)
-            .args(["upgrade", "--all", "--silent"])
-            .status_checked()
-    } else {
-        // execute without silent command
-        ctx.run_type()
-            .execute(winget)
-            .args(["upgrade", "--all"])
-            .status_checked()
+        args.push("--silent");
     }
+
+    ctx.run_type().execute(winget).args(args).status_checked()
 }
 
 pub fn run_scoop(ctx: &ExecutionContext) -> Result<()> {

--- a/src/steps/os/windows.rs
+++ b/src/steps/os/windows.rs
@@ -42,10 +42,25 @@ pub fn run_winget(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("winget");
 
-    ctx.run_type()
+    // check if silent install is enabled
+    if ctx.config().winget_silent_install() {
+
+        // execute with silent command
+        ctx.run_type()
+        .execute(winget)
+        .args(["upgrade", "--all", "--silent"])
+        .status_checked()
+
+    } else {
+
+        // execute without silent command
+        ctx.run_type()
         .execute(winget)
         .args(["upgrade", "--all"])
         .status_checked()
+        
+    }
+
 }
 
 pub fn run_scoop(ctx: &ExecutionContext) -> Result<()> {

--- a/src/steps/os/windows.rs
+++ b/src/steps/os/windows.rs
@@ -44,23 +44,18 @@ pub fn run_winget(ctx: &ExecutionContext) -> Result<()> {
 
     // check if silent install is enabled
     if ctx.config().winget_silent_install() {
-
         // execute with silent command
         ctx.run_type()
-        .execute(winget)
-        .args(["upgrade", "--all", "--silent"])
-        .status_checked()
-
+            .execute(winget)
+            .args(["upgrade", "--all", "--silent"])
+            .status_checked()
     } else {
-
         // execute without silent command
         ctx.run_type()
-        .execute(winget)
-        .args(["upgrade", "--all"])
-        .status_checked()
-        
+            .execute(winget)
+            .args(["upgrade", "--all"])
+            .status_checked()
     }
-
 }
 
 pub fn run_scoop(ctx: &ExecutionContext) -> Result<()> {


### PR DESCRIPTION
This PR implements issue #1088 

## What does this PR do

Before I describe what this PR does, let me define "silent" in the Windows context. On Windows, historically, silent or quite when discussing installations means the installer does not present a GUI to the user and installs the software without interaction. **It does not mean suppressing command line output**. 

This PR makes Winget perform its upgrade silently, unless configured to not, by using the new `winget_install_silent` configuration option and setting it to `false` in the config file. Without this option set to `false`, Windows installers will launch an unattended installer window for the user. With this option set to `true` or left default, it will use the `--silent` command line argument tell Winget to attempt to run all application installers silently. 

**It should be noted:** Support for silent installations is highly dependent on the maintainer of the Windows Application. Software using the `.msi` installer standard from Microsoft all support silent installations. Packages using InstallShield, Inno Setup, or Nullsoft installers also support silent installations. Vendors packaging their applications with an alternative installer solution will have mixed support. So, with all that said, **this feature does not guarantee all packages will install without presenting a GUI**, only that **all packages that support silent GUI-less installs will do so by default.**

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated
