### PR TITLE
added a check to disable dnf upgrading when

### DIFF
--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -237,25 +237,26 @@ fn upgrade_redhat(ctx: &ExecutionContext) -> Result<()> {
         }
     };
 
-    let sudo = require_option(ctx.sudo().as_ref(), get_require_sudo_string())?;
-    let mut command = ctx.run_type().execute(sudo);
-    command
-        .arg(which("dnf").unwrap_or_else(|| Path::new("yum").to_path_buf()))
-        .arg(if ctx.config().redhat_distro_sync() {
-            "distro-sync"
-        } else {
-            "upgrade"
-        });
+    if !ctx.config().rpm_ostree(){
+        let sudo = require_option(ctx.sudo().as_ref(), get_require_sudo_string())?;
+        let mut command = ctx.run_type().execute(sudo);
+        command
+            .arg(which("dnf").unwrap_or_else(|| Path::new("yum").to_path_buf()))
+            .arg(if ctx.config().redhat_distro_sync() {
+                "distro-sync"
+            } else {
+                "upgrade"
+            });
 
-    if let Some(args) = ctx.config().dnf_arguments() {
-        command.args(args.split_whitespace());
+        if let Some(args) = ctx.config().dnf_arguments() {
+            command.args(args.split_whitespace());
+        }
+
+        if ctx.config().yes(Step::System) {
+            command.arg("-y");
+        }
+        command.status_checked()?;
     }
-
-    if ctx.config().yes(Step::System) {
-        command.arg("-y");
-    }
-
-    command.status_checked()?;
     Ok(())
 }
 


### PR DESCRIPTION
## What does this PR do
Adds a check that skips dnf upgrades if rpm-ostree is enabled.
The DNF upgrade command will always fail on universal blue based distros.
This check makes sure that it just doesn't run when rpm-ostree is the enabled upgrade mechanism.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [x] If this PR introduces new user-facing messages they are translated (N/A)
 
## For new steps

- [  ] *Optional:* Topgrade skips this step where needed
    - This hasn't been tested since I don't have a platform that would skip this, but I think the logic stands, its a pretty minimal change.
- [x] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

Did this for my AuroraOS system since its based on universal blue, it should fix an issue where the dnf upgrade step will be called even if rpm-ostree is enabled.
