### PR TITLE
Fix aqua CLI and JetBrains Aqua conflict

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -226,6 +226,13 @@ pub fn run_apm(ctx: &ExecutionContext) -> Result<()> {
 pub fn run_aqua(ctx: &ExecutionContext) -> Result<()> {
     let aqua = require("aqua")?;
 
+    // Check if `aqua --help` mentions "aqua". JetBrains aqua does not, aqua CLI does.
+    let output = ctx.run_type().execute(&aqua).arg("--help").output_checked()?;
+
+    if !String::from_utf8(output.stdout)?.contains("aqua") {
+        return Err(SkipStep("Command aqua probably points to JetBrains Aqua".to_string()).into());
+    }
+
     print_separator("Aqua");
     if ctx.run_type().dry() {
         println!("{}", t!("Updating aqua ..."));


### PR DESCRIPTION
closes #1024

## What does this PR do
Check which of the two it is using `aqua --help`, checking for the string `aqua`.

JetBrains Aqua `aqua --help` output:
```
Some of the common commands and options (sorry, the full list is not yet supported):
  --help      prints a short list of commands and options
  --version   shows version information
  /project/dir
    opens a project from the given directory
  [/project/dir|--temp-project] [--wait] [--line <line>] [--column <column>] file
    opens the file, either in a context of the given project or as a temporary single-file project,
    optionally waiting until the editor tab is closed
  diff <left> <right>
    opens a diff window between <left> and <right> files/directories
  merge <local> <remote> [base] <merged>
    opens a merge window between <local> and <remote> files (with optional common <base>), saving the result to <merged>
```
This is the same with all JetBrains IDE's, so it will probably not print `aqua` anytime soon. If it ever does, it will think it is the Aqua CLI and thus open it (very user-noticable); making it easier to fix than the other way around.

Aqua CLI `aqua --help` output:
```
NAME:
   aqua - Version Manager of CLI. https://aquaproj.github.io/

USAGE:
   aqua [global options] command [command options]

VERSION:
   2.46.0 (3e32082fae4f04e092860a00e11b1b13636c2829)

COMMANDS:
   init                   Create a configuration file if it doesn't exist
   install, i             Install tools
   generate, g            Search packages in registries and output the configuration interactively
   update-aqua, upa       Update aqua
   update-checksum, upc   Create or Update aqua-checksums.json
   update, up             Update registries and packages
   completion             Output shell completion script for bash, zsh, or fish
   which                  Output the absolute file path of the given command
   info                   Show information
   remove, rm             Uninstall packages
   vacuum                 Remove unused installed packages
   cp                     Copy executable files in a directory
   policy                 Manage Policy
   init-policy            [Deprecated] Create a policy file if it doesn't exist
   exec                   Execute tool
   list                   List packages in Registries
   generate-registry, gr  Generate a registry's package configuration
   version                Show version
   root-dir               Output the aqua root directory (AQUA_ROOT_DIR)
   help, h                Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --log-level value                      log level [$AQUA_LOG_LEVEL]
   --config value, -c value               configuration file path [$AQUA_CONFIG]
   --disable-cosign                       Disable Cosign verification (default: false) [$AQUA_DISABLE_COSIGN]
   --disable-slsa                         Disable SLSA verification (default: false) [$AQUA_DISABLE_SLSA]
   --disable-github-artifact-attestation  Disable GitHub Artifact Attestations verification (default: false) [$AQUA_DISABLE_GITHUB_ARTIFACT_ATTESTATION]
   --trace value                          trace output file path
   --cpu-profile value                    cpu profile output file path
   --help, -h                             show help
   --version, -v                          print the version
```
Mentions `aqua` multiple times. This is assumed to never change.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated
