### PR TITLE
Downgrade `create_release_assets.yml` workflow

### DIFF
--- a/.github/workflows/create_release_assets.yml
+++ b/.github/workflows/create_release_assets.yml
@@ -13,14 +13,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ ubuntu-latest, macos-latest, macos-13, windows-latest ]
+        platform: [ ubuntu-22.04, macos-latest, macos-13, windows-latest ]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v4
 
       - name: Install cargo-deb
         run: cargo install cargo-deb
-        if: ${{ matrix.platform == 'ubuntu-latest' }}
+        if: ${{ startsWith(matrix.platform, 'ubuntu-') }}
         shell: bash
 
       - name: Check format
@@ -59,14 +59,14 @@ jobs:
           rm -rf target/release
           cargo build --release
           cargo deb --no-build --no-strip
-        if: ${{ matrix.platform == 'ubuntu-latest' }}
+        if: ${{ startsWith(matrix.platform, 'ubuntu-') }}
         shell: bash
 
       - name: Move Debian-based system package
         run: |
           mkdir -p assets
           mv target/debian/*.deb assets
-        if: ${{ matrix.platform == 'ubuntu-latest' }}
+        if: ${{ startsWith(matrix.platform, 'ubuntu-') }}
         shell: bash
 
       - name: Rename Release (Windows)


### PR DESCRIPTION
Closes #1095

## What does this PR do
Downgrade `create_release_assets.yml` workflow Ubuntu version to `22.04` from `24.04` / `ubuntu-latest`
This downgrades the `glibc` version it is built against, making it work on Debian 12 and Ubuntu 22.04 again. A new Rust version broke this.
I unfortunately cannot easily test if this actually work, but I would assume so. Could we release a new version ASAP for the affected people?
@SteveLauC are you familiar with this `glibc` version stuff? Do you agree this is the best course of action, or is there something else we should do?

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated
