### PR TITLE
Add `output_changed_message!`, replace some `.expect`s

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -22,12 +22,12 @@ use crate::execution_context::ExecutionContext;
 use crate::executor::ExecutorOutput;
 use crate::terminal::{print_separator, shell};
 use crate::utils::{self, check_is_python_2_or_shim, get_require_sudo_string, require, require_option, which, PathExt};
-use crate::Step;
 use crate::HOME_DIR;
 use crate::{
     error::{SkipStep, StepFailed, TopgradeError},
     terminal::print_warning,
 };
+use crate::{output_changed_message, Step};
 
 #[cfg(target_os = "linux")]
 pub fn is_wsl() -> Result<bool> {
@@ -647,9 +647,10 @@ pub fn run_pip3_update(ctx: &ExecutionContext) -> Result<()> {
     {
         Ok(output) => {
             let stdout = output.stdout.trim();
-            stdout
-                .parse::<bool>()
-                .expect("unexpected output that is not `true` or `false`")
+            stdout.parse::<bool>().wrap_err(output_changed_message!(
+                "pip config get global.break-system-packages",
+                "unexpected output that is not `true` or `false`"
+            ))?
         }
         // it can fail because this key may not be set
         //

--- a/src/steps/os/archlinux.rs
+++ b/src/steps/os/archlinux.rs
@@ -3,7 +3,7 @@ use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
 use color_eyre::eyre;
-use color_eyre::eyre::Result;
+use color_eyre::eyre::{Context, Result};
 use rust_i18n::t;
 use walkdir::WalkDir;
 
@@ -12,7 +12,7 @@ use crate::error::TopgradeError;
 use crate::execution_context::ExecutionContext;
 use crate::utils::require_option;
 use crate::utils::which;
-use crate::{config, Step};
+use crate::{config, output_changed_message, Step};
 
 fn get_execution_path() -> OsString {
     let mut path = OsString::from("/usr/bin:");
@@ -285,7 +285,8 @@ impl ArchPackageManager for Aura {
         // Output will be something like: "aura x.x.x\n"
         let version_cmd_stdout = version_cmd_output.stdout;
         let version_str = version_cmd_stdout.trim_start_matches("aura ").trim_end();
-        let version = Version::parse(version_str).expect("invalid version");
+        let version =
+            Version::parse(version_str).wrap_err(output_changed_message!("aura --version", "invalid version"))?;
 
         // Aura, since version 4.0.6, no longer needs sudo.
         //

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -282,3 +282,13 @@ pub fn install_color_eyre() -> Result<()> {
         .display_location_section(true)
         .install()
 }
+
+#[macro_export]
+macro_rules! output_changed_message {
+    ($command:expr, $message:expr) => {
+        concat!(
+            "The output of `", $command, "` changed: ", $message,
+            ". This is not your fault, this is an issue in Topgrade. Please open an issue at: https://github.com/topgrade-rs/topgrade/issues/new?template=bug_report.md"
+        )
+    };
+}


### PR DESCRIPTION
## What does this PR do
* Adds `output_changed_message!` to replace duplicated "please file an issue to Topgrade" string
* Replaces some `.expect`s and other error raisers with `.wrap_err`
  * I haven't replaced all of them, but these are some obvious ones

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated

## Questions
Some questions:
1. Is the text of `output_changed_message!` okay like this?
2. Apparently I'm supposed to use `.context` instead of `.wrap_err`? At least in the `Option` case at `NIX_VERSION_REGEX.captures`?