### PR TITLE
🌐 i18n(app): add new translation strings for windows and .net features

### DIFF
--- a/locales/app.yml
+++ b/locales/app.yml
@@ -176,6 +176,30 @@ _version: 2
   zh_CN: "自我更新"
   zh_TW: "自行更新"
   de: "Selbstaktualisierung"
+"The installer will request to run as administrator, expect a prompt.":
+  en: "The installer will request to run as administrator, expect a prompt."
+  lt: "Diegimo programa paprašys administratoriaus teisių, laukite užklausos."
+  es: "El instalador solicitará ejecutarse como administrador, espere el aviso."
+  fr: "L'installateur demandera à s'exécuter en tant qu'administrateur, veuillez patienter."
+  zh_CN: "安装程序将请求以管理员身份运行，请等待提示。"
+  zh_TW: "安裝程式將請求以管理員身份執行，請等待提示。"
+  de: "Das Installationsprogramm fordert Administratorrechte an, bitte bestätigen."
+"Failed to update .NET package {package_name}":
+  en: "Failed to update .NET package %{package_name}"
+  lt: "Nepavyko atnaujinti .NET paketo %{package_name}"
+  es: "No se pudo actualizar el paquete .NET %{package_name}"
+  fr: "Échec de la mise à jour du package .NET %{package_name}"
+  zh_CN: "无法更新 .NET 包 %{package_name}"
+  zh_TW: "無法更新 .NET 套件 %{package_name}"
+  de: "Aktualisierung des .NET-Pakets %{package_name} fehlgeschlagen"
+"Failed to parse `tmux_arguments`: `{args}`":
+  en: "Failed to parse `tmux_arguments`: `{args}`"
+  lt: "Nepavyko interpretuoti `tmux_arguments`: `{args}`"
+  es: "No se pudo analizar `tmux_arguments`: `{args}`"
+  fr: "Échec de l'analyse de `tmux_arguments`: `{args}`"
+  zh_CN: "无法解析 `tmux_arguments`: `{args}`"
+  zh_TW: "無法解析 `tmux_arguments`: `{args}`"
+  de: "Fehler beim Parsen von `tmux_arguments`: `{args}`"
 
 # The following 2 strings are used in the same sentence
 # i.e. *Only* updated repositories will be shown...

--- a/locales/app.yml
+++ b/locales/app.yml
@@ -192,14 +192,14 @@ _version: 2
   zh_CN: "无法更新 .NET 包 %{package_name}"
   zh_TW: "無法更新 .NET 套件 %{package_name}"
   de: "Aktualisierung des .NET-Pakets %{package_name} fehlgeschlagen"
-"Failed to parse `tmux_arguments`: `{args}`":
-  en: "Failed to parse `tmux_arguments`: `{args}`"
-  lt: "Nepavyko interpretuoti `tmux_arguments`: `{args}`"
-  es: "No se pudo analizar `tmux_arguments`: `{args}`"
-  fr: "Échec de l'analyse de `tmux_arguments`: `{args}`"
-  zh_CN: "无法解析 `tmux_arguments`: `{args}`"
-  zh_TW: "無法解析 `tmux_arguments`: `{args}`"
-  de: "Fehler beim Parsen von `tmux_arguments`: `{args}`"
+"Failed to parse `tmux_arguments`: %{args}":
+  en: "Failed to parse `tmux_arguments`: %{args}"
+  lt: "Nepavyko interpretuoti `tmux_arguments`: %{args}"
+  es: "No se pudo analizar `tmux_arguments`: %{args}"
+  fr: "Échec de l'analyse de `tmux_arguments`: %{args}"
+  zh_CN: "无法解析 `tmux_arguments`: %{args}"
+  zh_TW: "無法解析 `tmux_arguments`: %{args}"
+  de: "Fehler beim Parsen von `tmux_arguments`: %{args}"
 
 # The following 2 strings are used in the same sentence
 # i.e. *Only* updated repositories will be shown...

--- a/src/config.rs
+++ b/src/config.rs
@@ -1130,7 +1130,7 @@ impl Config {
             //
             //     Caused by:
             //         missing closing quote
-            .with_context(|| format!("Failed to parse `tmux_arguments`: `{args}`"))
+            .with_context(|| format!("{}", t!("Failed to parse `tmux_arguments`: `{args}`", args = args)))
     }
 
     /// Prompt for a key before exiting

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -970,7 +970,7 @@ pub fn run_dotnet_upgrade(ctx: &ExecutionContext) -> Result<()> {
             .execute(&dotnet)
             .args(["tool", "update", package_name, "--global"])
             .status_checked()
-            .with_context(|| format!("Failed to update .NET package {package_name:?}"))?;
+            .with_context(|| format!("{}", t!("Failed to update .NET package {package_name}", package_name = package_name)))?;
     }
 
     Ok(())

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -970,7 +970,15 @@ pub fn run_dotnet_upgrade(ctx: &ExecutionContext) -> Result<()> {
             .execute(&dotnet)
             .args(["tool", "update", package_name, "--global"])
             .status_checked()
-            .with_context(|| format!("{}", t!("Failed to update .NET package {package_name}", package_name = package_name)))?;
+            .with_context(|| {
+                format!(
+                    "{}",
+                    t!(
+                        "Failed to update .NET package {package_name}",
+                        package_name = package_name
+                    )
+                )
+            })?;
     }
 
     Ok(())

--- a/src/steps/os/windows.rs
+++ b/src/steps/os/windows.rs
@@ -211,7 +211,10 @@ pub fn windows_update(ctx: &ExecutionContext) -> Result<()> {
     print_separator(t!("Windows Update"));
 
     if powershell.supports_windows_update() {
-        println!("{}", t!("The installer will request to run as administrator, expect a prompt."));
+        println!(
+            "{}",
+            t!("The installer will request to run as administrator, expect a prompt.")
+        );
 
         powershell.windows_update(ctx)
     } else {

--- a/src/steps/os/windows.rs
+++ b/src/steps/os/windows.rs
@@ -211,7 +211,7 @@ pub fn windows_update(ctx: &ExecutionContext) -> Result<()> {
     print_separator(t!("Windows Update"));
 
     if powershell.supports_windows_update() {
-        println!("The installer will request to run as administrator, expect a prompt.");
+        println!("{}", t!("The installer will request to run as administrator, expect a prompt."));
 
         powershell.windows_update(ctx)
     } else {


### PR DESCRIPTION
I tested the new release version 16.0.3 and found that some messages on screen were not translated.
So I went through the code and found that some messages were missing in the translation file `app.yaml` so I added. Maybe it is some automated way but I did it manually. 

- add translations for windows update admin prompt message
- add translations for .NET package update failure message
- add translations for tmux arguments parsing error

🐛 fix(config): use translated strings in error messages

- replace hardcoded error messages with translated versions in config parsing
- update .NET package update error message to use translations
- update windows update admin prompt to use translations

