### PR TITLE
Omit `deb-get clean` output

### DIFF
--- a/locales/app.yml
+++ b/locales/app.yml
@@ -1288,3 +1288,11 @@ _version: 2
   zh_CN: "jetbrains-toolbox-updater 在更新过程中遇到意外错误"
   zh_TW: "jetbrains-toolbox-updater 在更新過程中遇到意外錯誤："
   de: "jetbrains-toolbox-updater ist auf einen unerwarteten Fehler während der Aktualisierung gestoßen:"
+"<output from `deb-get clean` omitted>":
+  en: "<output from `deb-get clean` omitted>"
+  lt: "<išvestis iš `deb-get clean` praleista>"
+  es: "<salida de `deb-get clean` omitido>"
+  fr: "<sortie de `deb-get clean` omise>"
+  zh_CN: "<省略了 `deb-get clean` 的輸出>"
+  zh_TW: "<省略了 `deb-get clean` 的輸出>"
+  de: "<Ausgabe von `deb-get clean` ausgelassen>"

--- a/locales/app.yml
+++ b/locales/app.yml
@@ -1293,6 +1293,6 @@ _version: 2
   lt: "<išvestis iš `deb-get clean` praleista>"
   es: "<salida de `deb-get clean` omitido>"
   fr: "<sortie de `deb-get clean` omise>"
-  zh_CN: "<省略了 `deb-get clean` 的輸出>"
+  zh_CN: "<省略了 `deb-get clean` 的输出>"
   zh_TW: "<省略了 `deb-get clean` 的輸出>"
   de: "<Ausgabe von `deb-get clean` ausgelassen>"

--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -587,7 +587,11 @@ pub fn run_deb_get(ctx: &ExecutionContext) -> Result<()> {
     ctx.run_type().execute(&deb_get).arg("upgrade").status_checked()?;
 
     if ctx.config().cleanup() {
-        ctx.run_type().execute(&deb_get).arg("clean").status_checked()?;
+        let output = ctx.run_type().execute(&deb_get).arg("clean").output_checked()?;
+        // Swallow the output, as it's very noisy and not useful.
+        //  The output is automatically printed as part of `output_checked` when an error occurs.
+        println!("<output from `deb-get clean` omitted>");
+        debug!("`deb-get clean` output: {output:?}");
     }
 
     Ok(())

--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -590,7 +590,7 @@ pub fn run_deb_get(ctx: &ExecutionContext) -> Result<()> {
         let output = ctx.run_type().execute(&deb_get).arg("clean").output_checked()?;
         // Swallow the output, as it's very noisy and not useful.
         //  The output is automatically printed as part of `output_checked` when an error occurs.
-        println!("<output from `deb-get clean` omitted>");
+        println!("{}", t!("<output from `deb-get clean` omitted>"));
         debug!("`deb-get clean` output: {output:?}");
     }
 


### PR DESCRIPTION
## What does this PR do
Omits `deb-get clean` output, as it is very noisy and not useful.
Closes #1116

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [x] If this PR introduces new user-facing messages they are translated
