### PR TITLE
Fix `uv` step

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -1326,7 +1326,7 @@ pub fn run_uv(ctx: &ExecutionContext) -> Result<()> {
     //  "uv 0.5.11 (c4d0caaee 2024-12-19)\n"
     //  "uv 0.5.11+1 (xxxd0cee 2024-12-20)\n"
     //  "uv 0.6.14\n"
-    
+
     let uv_version_output_stdout = uv_version_output.stdout;
 
     let version_str = {
@@ -1339,7 +1339,7 @@ pub fn run_uv(ctx: &ExecutionContext) -> Result<()> {
             None => start_trimmed.trim_end_matches('\n'), // Otherwise, just strip the newline
             Some(i) => &start_trimmed[..i],
         }
-        
+
         // After trimming, it should be a string in 2 possible formats, both can be handled by `Version::parse()`
         //
         // 1. "0.5.11"

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -1324,14 +1324,14 @@ pub fn run_uv(ctx: &ExecutionContext) -> Result<()> {
     let uv_version_output_stdout = uv_version_output.stdout;
 
     let version_str = {
-        // trim the starting "uv" and " " (whitespace)
+        // Trim the starting "uv" and " " (whitespace)
         let start_trimmed = uv_version_output_stdout
             .trim_start_matches("uv")
             .trim_start_matches(' ');
-        // remove the tailing part " (c4d0caaee 2024-12-19)\n", if it's there
+        // Remove the tailing part " (c4d0caaee 2024-12-19)\n", if it's there
         match start_trimmed.find(' ') {
-            None => start_trimmed.trim_end_matches('\n'),  // Otherwise, just strip the newline
-            Some(i) => &start_trimmed[..i]  // this should be our version str "0.5.11"
+            None => start_trimmed.trim_end_matches('\n'), // Otherwise, just strip the newline
+            Some(i) => &start_trimmed[..i],               // This should be our version str "0.5.11"
         }
     };
     let version =

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -1331,7 +1331,7 @@ pub fn run_uv(ctx: &ExecutionContext) -> Result<()> {
         // remove the tailing part " (c4d0caaee 2024-12-19)\n", if it's there
         match start_trimmed.find(' ') {
             None => start_trimmed.trim_end_matches('\n'),  // Otherwise, just strip the newline
-            Some(i) => &start_trimmed[..i]
+            Some(i) => &start_trimmed[..i]  // this should be our version str "0.5.11"
         }
     };
     let version =

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -1337,8 +1337,13 @@ pub fn run_uv(ctx: &ExecutionContext) -> Result<()> {
         // Remove the tailing part " (c4d0caaee 2024-12-19)\n", if it's there
         match start_trimmed.find(' ') {
             None => start_trimmed.trim_end_matches('\n'), // Otherwise, just strip the newline
-            Some(i) => &start_trimmed[..i],               // This should be our version str "0.5.11"
+            Some(i) => &start_trimmed[..i],
         }
+        
+        // After trimming, it should be a string in 2 possible formats, both can be handled by `Version::parse()`
+        //
+        // 1. "0.5.11"
+        // 2. "0.5.11+1"
     };
     let version =
         Version::parse(version_str).expect("the output of `uv --version` changed, please file an issue to Topgrade");

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -1318,9 +1318,15 @@ pub fn run_uv(ctx: &ExecutionContext) -> Result<()> {
         .execute(&uv_exec)
         .arg("--version")
         .output_checked_utf8()?;
-    // Multiple possible output formats are possible. For example:
+    // Multiple possible output formats are possible according to uv source code
+    //
+    // https://github.com/astral-sh/uv/blob/6b7f60c1eaa840c2e933a0fb056ab46f99c991a5/crates/uv-cli/src/version.rs#L28-L42
+    //
+    // For example:
     //  "uv 0.5.11 (c4d0caaee 2024-12-19)\n"
+    //  "uv 0.5.11+1 (xxxd0cee 2024-12-20)\n"
     //  "uv 0.6.14\n"
+    
     let uv_version_output_stdout = uv_version_output.stdout;
 
     let version_str = {


### PR DESCRIPTION
## What does this PR do
Allows the version format `"uv 0.6.14\n"` as well as `"uv 0.5.11 (c4d0caaee 2024-12-19)\n"`.
Closes #1120.
The problem #1105 solved should be unaffected.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated
