### PR TITLE
Fix "Only one instance of <IDE> can be run at a a time." error

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -1499,21 +1499,22 @@ pub fn run_jetbrains_toolbox(_ctx: &ExecutionContext) -> Result<()> {
     }
 }
 
-fn run_jetbrains_ide(ctx: &ExecutionContext, bin: PathBuf, name: &str) -> Result<()> {
-    print_separator(format!("JetBrains {name} plugins"));
+fn run_jetbrains_ide_generic<const IS_JETBRAINS: bool>(ctx: &ExecutionContext, bin: PathBuf, name: &str) -> Result<()> {
+    let prefix = if IS_JETBRAINS { "JetBrains " } else { "" };
+    print_separator(format!("{prefix}{name} plugins"));
 
     // The `update` command is undocumented, but tested on all of the below.
     ctx.run_type().execute(bin).arg("update").status_checked()
 }
 
+fn run_jetbrains_ide(ctx: &ExecutionContext, bin: PathBuf, name: &str) -> Result<()> {
+    run_jetbrains_ide_generic::<true>(ctx, bin, name)
+}
+
 pub fn run_android_studio(ctx: &ExecutionContext) -> Result<()> {
     // We don't use `run_jetbrains_ide` here because that would print "JetBrains Android Studio",
     //  which is incorrect as Android Studio is made by Google. Just "Android Studio" is fine.
-    let bin = require("studio")?;
-
-    print_separator("Android Studio plugins");
-
-    ctx.run_type().execute(bin).arg("update").status_checked()
+    run_jetbrains_ide_generic::<false>(ctx, require("studio")?, "Android Studio")
 }
 
 pub fn run_jetbrains_aqua(ctx: &ExecutionContext) -> Result<()> {


### PR DESCRIPTION
## What does this PR do
* Deduplicates `run_android_studio`
* Records output of `<ide> update` command to check for "Only one instance of <IDE> can be run at a a time.", and skip it in that case

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated
 
