### PR TITLE
Handle format change in asdf version

### DIFF
--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -642,9 +642,14 @@ pub fn run_asdf(ctx: &ExecutionContext) -> Result<()> {
     // v0.15.0-31e8c93
     //
     // ```
+    // ```
+    // $ asdf version
+    // v0.16.7
+    // ```
     let version_stdout = version_output.stdout.trim();
     // trim the starting 'v'
     let mut remaining = version_stdout.trim_start_matches('v');
+    // remove the hash part if present
     if let Some(idx) = remaining.find('-') {
         remaining = &remaining[..idx];
     }

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -645,11 +645,9 @@ pub fn run_asdf(ctx: &ExecutionContext) -> Result<()> {
     let version_stdout = version_output.stdout.trim();
     // trim the starting 'v'
     let mut remaining = version_stdout.trim_start_matches('v');
-    let idx = remaining
-        .find('-')
-        .ok_or_else(|| eyre!(output_changed_message!("asdf version", "no dash (-) found")))?;
-    // remove the hash part
-    remaining = &remaining[..idx];
+    if let Some(idx) = remaining.find('-') {
+        remaining = &remaining[..idx];
+    }
     let version =
         Version::parse(remaining).wrap_err_with(|| output_changed_message!("asdf version", "invalid version"))?;
     if version < Version::new(0, 15, 0) {


### PR DESCRIPTION
## What does this PR do

As of the latest version of asdf, the version has the format 0.16.7 - i.e. without the hash part.  This commit makes it so that both formats work.

Fixes #1096

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
