### PR TITLE
Fix conflict between hx (hexdump alternative) and Helix

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -1025,15 +1025,15 @@ impl Hx {
 fn get_hx(ctx: &ExecutionContext) -> Result<Hx> {
     let hx = require("hx")?;
 
-    // Check if `hx --help` mentions "hexdump". hx (hexdump alternative) does, Helix doesn't.
+    // Check if `hx --help` mentions "helix". Helix does, hx (hexdump alternative) doesn't.
     let output = ctx.run_type().execute(&hx).arg("--help").output_checked()?;
 
-    if String::from_utf8(output.stdout)?.contains("hexdump") {
-        debug!("Detected `hx` as hx (hexdump alternative)");
-        Ok(Hx::HxHexdump)
-    } else {
+    if String::from_utf8(output.stdout)?.contains("helix") {
         debug!("Detected `hx` as Helix");
         Ok(Hx::Helix(hx))
+    } else {
+        debug!("Detected `hx` as hx (hexdump alternative)");
+        Ok(Hx::HxHexdump)
     }
 }
 

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -1008,14 +1008,14 @@ pub fn run_dotnet_upgrade(ctx: &ExecutionContext) -> Result<()> {
 
 enum Hx {
     Helix(PathBuf),
-    HxHexdump(()),
+    HxHexdump,
 }
 
 impl Hx {
     fn helix(self) -> Result<PathBuf> {
         match self {
             Hx::Helix(hx) => Ok(hx),
-            Hx::HxHexdump(_) => {
+            Hx::HxHexdump => {
                 Err(SkipStep("Command `hx` probably points to hx (hexdump alternative)".to_string()).into())
             }
         }
@@ -1030,7 +1030,7 @@ fn get_hx(ctx: &ExecutionContext) -> Result<Hx> {
 
     if String::from_utf8(output.stdout)?.contains("hexdump") {
         debug!("Detected `hx` as hx (hexdump alternative)");
-        Ok(Hx::HxHexdump(()))
+        Ok(Hx::HxHexdump)
     } else {
         debug!("Detected `hx` as Helix");
         Ok(Hx::Helix(hx))

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -1006,8 +1006,39 @@ pub fn run_dotnet_upgrade(ctx: &ExecutionContext) -> Result<()> {
     Ok(())
 }
 
+enum Hx {
+    Helix(PathBuf),
+    HxHexdump(()),
+}
+
+impl Hx {
+    fn helix(self) -> Result<PathBuf> {
+        match self {
+            Hx::Helix(hx) => Ok(hx),
+            Hx::HxHexdump(_) => {
+                Err(SkipStep("Command `hx` probably points to hx (hexdump alternative)".to_string()).into())
+            }
+        }
+    }
+}
+
+fn get_hx(ctx: &ExecutionContext) -> Result<Hx> {
+    let hx = require("hx")?;
+
+    // Check if `hx --help` mentions "hexdump". hx (hexdump alternative) does, Helix doesn't.
+    let output = ctx.run_type().execute(&hx).arg("--help").output_checked()?;
+
+    if String::from_utf8(output.stdout)?.contains("hexdump") {
+        debug!("Detected `hx` as hx (hexdump alternative)");
+        Ok(Hx::HxHexdump(()))
+    } else {
+        debug!("Detected `hx` as Helix");
+        Ok(Hx::Helix(hx))
+    }
+}
+
 pub fn run_helix_grammars(ctx: &ExecutionContext) -> Result<()> {
-    let helix = require("helix").or(require("hx"))?;
+    let helix = require("helix").or(get_hx(ctx)?.helix())?;
 
     print_separator("Helix");
 


### PR DESCRIPTION
## What does this PR do
Like #1092, fix the conflict by inspecting the output of `hx --help`.
Closes #848

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated
 