### PR TITLE
Fix nix version output changed

### DIFF
--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -475,8 +475,19 @@ pub fn run_nix(ctx: &ExecutionContext) -> Result<()> {
         .ok_or_else(|| eyre!(output_changed_message!("nix --version", "regex did not match")))?;
     let raw_version = &captures[1];
 
+    debug!("Raw Nix version: {raw_version}");
+
+    // Nix 2.29.0 outputs "2.29" instead of "2.29.0", so we need to add that if necessary.
+    let corrected_raw_version = if raw_version.chars().filter(|&c| c == '.').count() == 1 {
+        &format!("{raw_version}.0")
+    } else {
+        raw_version
+    };
+
+    debug!("Corrected raw Nix version: {corrected_raw_version}");
+
     let version =
-        Version::parse(raw_version).wrap_err_with(|| format!("Unable to parse Nix version: {raw_version:?}"))?;
+        Version::parse(corrected_raw_version).wrap_err_with(|| output_changed_message!("nix --version", "Invalid version"))?;
 
     debug!("Nix version: {:?}", version);
 

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -486,8 +486,8 @@ pub fn run_nix(ctx: &ExecutionContext) -> Result<()> {
 
     debug!("Corrected raw Nix version: {corrected_raw_version}");
 
-    let version =
-        Version::parse(corrected_raw_version).wrap_err_with(|| output_changed_message!("nix --version", "Invalid version"))?;
+    let version = Version::parse(corrected_raw_version)
+        .wrap_err_with(|| output_changed_message!("nix --version", "Invalid version"))?;
 
     debug!("Nix version: {:?}", version);
 


### PR DESCRIPTION
Closes #1137
## What does this PR do
- If the `nix --version` output contains exactly one dot (`.`), append `.0` to it.
- Use `output_changed_message!` here as well

```console
[gideon@gideon-pc-lin ~/projects/topgrade] (main *=) 1 (14.9s)
$ sh <(curl -L https://nixos.org/nix/install) --no-daemon
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100  4267  100  4267    0     0  19253      0 --:--:-- --:--:-- --:--:-- 19253
downloading Nix 2.28.2 binary tarball for x86_64-linux from 'https://releases.nixos.org/nix/nix-2.28.2/nix-2.28.2-x86_64-linux.tar.xz' to '/tmp/nix-binary-tarball-unpack.xRC9TNmBRL'...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 22.8M  100 22.8M    0     0  6267k      0  0:00:03  0:00:03 --:--:-- 6266k
Note: a multi-user installation is possible. See https://nixos.org/manual/nix/stable/installation/installing-binary.html#multi-user-installation
performing a single-user installation of Nix...
copying Nix to /nix/store.............................................................
replacing old 'nix-2.29pre20250409_e76bbe41'
installing 'nix-2.28.2'
unpacking 1 channels...
placing /home/gideon/.config/fish/conf.d/nix.fish...

Installation finished!  To ensure that the necessary environment
variables are set, either log in again, or type

  . /home/gideon/.nix-profile/etc/profile.d/nix.fish

in your shell.
[gideon@gideon-pc-lin ~/projects/topgrade] (main *=) 0 (5.469s)
$ PATH=$PATH:~/.nix-profile/bin cargo run -- --only nix -v
<snip>
── 12:29:28 - Nix ──────────────────────────────────────────────────────────────
DEBUG Executing command `/home/gideon/.nix-profile/bin/nix-channel --update`
unpacking 1 channels...
DEBUG Executing command `/home/gideon/.nix-profile/bin/nix --version`
DEBUG `nix --version` output output=nix (Nix) 2.28.2
 is_lix=false
DEBUG Raw Nix version: 2.28.2
DEBUG Corrected raw Nix version: 2.28.2
DEBUG Nix version: Version { major: 2, minor: 28, patch: 2 }
DEBUG Executing command `/home/gideon/.nix-profile/bin/nix-env --upgrade`
evaluation warning: The package set `androidndkPkgs_23b` has been renamed to `androidndkPkgs_23`.
evaluation warning: CUDA versions older than 12.0 will be removed in Nixpkgs 25.05; see the 24.11 release notes for more information
evaluation warning: CUDA versions older than 12.0 will be removed in Nixpkgs 25.05; see the 24.11 release notes for more information
evaluation warning: CUDA versions older than 12.0 will be removed in Nixpkgs 25.05; see the 24.11 release notes for more information
evaluation warning: CUDA versions older than 12.0 will be removed in Nixpkgs 25.05; see the 24.11 release notes for more information
evaluation warning: CUDA versions older than 12.0 will be removed in Nixpkgs 25.05; see the 24.11 release notes for more information
evaluation warning: CUDA versions older than 12.0 will be removed in Nixpkgs 25.05; see the 24.11 release notes for more information
evaluation warning: CUDA versions older than 12.0 will be removed in Nixpkgs 25.05; see the 24.11 release notes for more information
evaluation warning: CUDA versions older than 12.0 will be removed in Nixpkgs 25.05; see the 24.11 release notes for more information
evaluation warning: CUDA versions older than 12.0 will be removed in Nixpkgs 25.05; see the 24.11 release notes for more information
upgrading 'nix-2.28.2' to 'nix-2.29pre20250409_e76bbe41'
DEBUG Step "nix upgrade-nix"
DEBUG Detected "/home/gideon/.nix-profile/bin/nix" as "nix"

── 12:29:52 - Summary ──────────────────────────────────────────────────────────
nix: OK
nix upgrade-nix: SKIPPED: `nix upgrade-nix` can only be used on macOS or non-NixOS Linux
DEBUG Desktop notification: Topgrade finished successfully
[gideon@gideon-pc-lin ~/projects/topgrade] (fix-nix *=) 0 (28.5s)
$ PATH=$PATH:~/.nix-profile/bin cargo run -- --only nix -v
<snip>
── 12:30:13 - Nix ──────────────────────────────────────────────────────────────
DEBUG Executing command `/home/gideon/.nix-profile/bin/nix-channel --update`
unpacking 1 channels...
DEBUG Executing command `/home/gideon/.nix-profile/bin/nix --version`
DEBUG `nix --version` output output=nix (Nix) 2.29pre20250409_e76bbe41
 is_lix=false
DEBUG Raw Nix version: 2.29
DEBUG Corrected raw Nix version: 2.29.0
DEBUG Nix version: Version { major: 2, minor: 29, patch: 0 }
DEBUG Executing command `/home/gideon/.nix-profile/bin/nix-env --upgrade`
evaluation warning: The package set `androidndkPkgs_23b` has been renamed to `androidndkPkgs_23`.
evaluation warning: CUDA versions older than 12.0 will be removed in Nixpkgs 25.05; see the 24.11 release notes for more information
evaluation warning: CUDA versions older than 12.0 will be removed in Nixpkgs 25.05; see the 24.11 release notes for more information
evaluation warning: CUDA versions older than 12.0 will be removed in Nixpkgs 25.05; see the 24.11 release notes for more information
evaluation warning: CUDA versions older than 12.0 will be removed in Nixpkgs 25.05; see the 24.11 release notes for more information
evaluation warning: CUDA versions older than 12.0 will be removed in Nixpkgs 25.05; see the 24.11 release notes for more information
evaluation warning: CUDA versions older than 12.0 will be removed in Nixpkgs 25.05; see the 24.11 release notes for more information
evaluation warning: CUDA versions older than 12.0 will be removed in Nixpkgs 25.05; see the 24.11 release notes for more information
evaluation warning: CUDA versions older than 12.0 will be removed in Nixpkgs 25.05; see the 24.11 release notes for more information
evaluation warning: CUDA versions older than 12.0 will be removed in Nixpkgs 25.05; see the 24.11 release notes for more information
DEBUG Step "nix upgrade-nix"
DEBUG Detected "/home/gideon/.nix-profile/bin/nix" as "nix"

── 12:30:36 - Summary ──────────────────────────────────────────────────────────
nix: OK
nix upgrade-nix: SKIPPED: `nix upgrade-nix` can only be used on macOS or non-NixOS Linux
DEBUG Desktop notification: Topgrade finished successfully
```

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated
 