### PR TITLE
windows update, use explicit reboot policy

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -213,6 +213,8 @@
 # Manually select Windows updates
 # accept_all_updates = false
 
+# updates_auto_reboot = true
+
 # open_remotes_in_new_terminal = true
 
 # wsl_update_pre_release = true

--- a/src/config.rs
+++ b/src/config.rs
@@ -239,6 +239,7 @@ pub struct Vagrant {
 #[serde(deny_unknown_fields)]
 pub struct Windows {
     accept_all_updates: Option<bool>,
+    updates_auto_reboot: Option<bool>,
     self_rename: Option<bool>,
     open_remotes_in_new_terminal: Option<bool>,
     wsl_update_pre_release: Option<bool>,
@@ -1207,6 +1208,15 @@ impl Config {
             .as_ref()
             .and_then(|windows| windows.accept_all_updates)
             .unwrap_or(true)
+    }
+
+    /// Whether to auto reboot for Windows updates that require it
+    pub fn windows_updates_auto_reboot(&self) -> bool {
+        self.config_file
+            .windows
+            .as_ref()
+            .and_then(|windows| windows.updates_auto_reboot)
+            .unwrap_or(false)
     }
 
     /// Whether to self rename the Topgrade executable during the run

--- a/src/steps/powershell.rs
+++ b/src/steps/powershell.rs
@@ -174,6 +174,11 @@ mod windows {
         if ctx.config().accept_all_windows_updates() {
             command_str.push_str(" -AcceptAll");
         }
+        if ctx.config().windows_updates_auto_reboot() {
+            command_str.push_str(" -AutoReboot");
+        } else {
+            command_str.push_str(" -IgnoreReboot");
+        }
 
         // Pass the command string using the -Command flag
         powershell


### PR DESCRIPTION
Before this change, the `Install-WindowsUpdate` powershell command would sometimes prompt the user for reboot. See below
```
── 08:15:08 - Windows Update ───────────────────────────────────────────────────
DEBUG Executing command `C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -NoProfile -Command 'Get-Module -ListAvailable PSWindowsUpdate'`
The installer will request to run as administrator, expect a prompt.
DEBUG Executing command `C:\Program Files\gsudo\Current\gsudo.exe 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe' -NoProfile 'Install-WindowsUpdate -Verbose' -AcceptAll`
VERBOSE: MyPC (5/2/2025 8:15:10 AM): Connecting to Microsoft Update server. Please wait...
VERBOSE: Found [2] Updates in pre search criteria
VERBOSE: Found [2] Updates in post search criteria

X ComputerName Result     KB          Size Title
- ------------ ------     --          ---- -----
1 MyPC         Accepted   KB5056580   72MB 2025-04 Cumulative Update Preview for .NET Framework 3.5 and 4.8.1 for Windows 11, version 23H2 for x64 (KB5056580)
1 MyPC         Accepted               23MB SATO CORPORATION - Printer - 8.4.16.27981
VERBOSE: Accepted [2] Updates ready to Download
2 MyPC         Downloaded KB5056580   72MB 2025-04 Cumulative Update Preview for .NET Framework 3.5 and 4.8.1 for Windows 11, version 23H2 for x64 (KB5056580)
2 MyPC         Downloaded             23MB SATO CORPORATION - Printer - 8.4.16.27981
VERBOSE: Downloaded [2] Updates ready to Install
3 MyPC         Installed  KB5056580   72MB 2025-04 Cumulative Update Preview for .NET Framework 3.5 and 4.8.1 for Windows 11, version 23H2 for x64 (KB5056580)
3 MyPC         Failed                 23MB SATO CORPORATION - Printer - 8.4.16.27981
VERBOSE: Installed [1] Updates
Reboot is required. Do it now? [Y / N] (default is 'N')

```
## What does this PR do

Pass the `-IgnoreReboot` option to `Install-WindowsUpdate` by default, and add a config option to pass the `-AutoReboot` option instead.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
