### PR TITLE
Improve `execute` to deduplicate `key` string and remove closure

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -502,7 +502,7 @@ fn run() -> Result<()> {
     runner.execute(Step::JetbrainsWebstorm, "JetBrains WebStorm plugins", || {
         generic::run_jetbrains_webstorm(&ctx)
     })?;
-    runner.execute(Step::Yazi, "Yazi packages", || generic::run_yazi(&ctx))?;
+    runner.execute_2(Step::Yazi, "Yazi packages", generic::run_yazi)?;
 
     if should_run_powershell {
         runner.execute(Step::Powershell, "Powershell Modules Update", || {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2,7 +2,7 @@ use crate::ctrlc;
 use crate::error::{DryRun, SkipStep};
 use crate::execution_context::ExecutionContext;
 use crate::report::{Report, StepResult};
-use crate::terminal::print_error;
+use crate::terminal::{print_error, print_separator};
 use crate::{config::Step, terminal::should_retry};
 use color_eyre::eyre::Result;
 use std::borrow::Cow;
@@ -27,6 +27,14 @@ impl<'a> Runner<'a> {
         F: Fn() -> Result<()>,
         M: Into<Cow<'a, str>> + Debug,
     {
+        todo!("This function will be removed and `execute_2` will be renamed to `execute`")
+    }
+
+    pub fn execute_2<F, M>(&mut self, step: Step, key: M, func: F) -> Result<()>
+    where
+        F: Fn(&ExecutionContext, &dyn Fn()) -> Result<()>,
+        M: Into<Cow<'a, str>> + Debug,
+    {
         if !self.ctx.config().should_run(step) {
             return Ok(());
         }
@@ -34,12 +42,14 @@ impl<'a> Runner<'a> {
         let key = key.into();
         debug!("Step {:?}", key);
 
-        // alter the `func` to put it in a span
+        let confirm_run = || Runner::confirm_run(&key);
+
+        // Alter the `func` to put it in a span, and add `ctx` and `confirm_run`
         let func = || {
             let span =
                 tracing::span!(parent: tracing::Span::none(), tracing::Level::TRACE, "step", step = ?step, key = %key);
             let _guard = span.enter();
-            func()
+            func(self.ctx, &confirm_run)
         };
 
         loop {
@@ -87,6 +97,10 @@ impl<'a> Runner<'a> {
         }
 
         Ok(())
+    }
+
+    fn confirm_run(key: &str) {
+        print_separator(key);
     }
 
     pub fn report(&self) -> &Report {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -42,7 +42,7 @@ impl<'a> Runner<'a> {
         let key = key.into();
         debug!("Step {:?}", key);
 
-        let confirm_run = || Runner::confirm_run(&key);
+        let confirm_run = || self.confirm_run(&key);
 
         // Alter the `func` to put it in a span, and add `ctx` and `confirm_run`
         let func = || {
@@ -99,7 +99,7 @@ impl<'a> Runner<'a> {
         Ok(())
     }
 
-    fn confirm_run(key: &str) {
+    fn confirm_run(&self, key: &str) {
         print_separator(key);
     }
 

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -1616,10 +1616,10 @@ pub fn run_jetbrains_webstorm(ctx: &ExecutionContext) -> Result<()> {
     run_jetbrains_ide(ctx, require("webstorm")?, "WebStorm")
 }
 
-pub fn run_yazi(ctx: &ExecutionContext) -> Result<()> {
+pub fn run_yazi(ctx: &ExecutionContext, confirm_run: &dyn Fn()) -> Result<()> {
     let ya = require("ya")?;
 
-    print_separator("Yazi packages");
+    confirm_run();
 
     ctx.run_type().execute(ya).args(["pack", "-u"]).status_checked()
 }


### PR DESCRIPTION
## What does this PR do
* Passes the `ctx` parameter to `func` in `Runner::execute` to remove the unnecessary closure when calling it (see `main.rs` line 505
* Passes the `confirm_run` parameter to `func` in `Runner::execute` to:
  * Remove duplication of the `key`/`message` string (see `generic.rs` line 1622)
  * Hide Topgrade implementation details in the `run_*` functions (why would they need to know to print the separator?)
  * Create warnings when the separator is not printed (because `confirm_run` is unused)
  * Open up the possibility for adding more functionality besides printing the separator

I haven't applied it to all calls to `execute` yet, to ask for approval first. Is this acceptable?
Then I will (hopefully mostly automated with regex replaces) change the definitions and usages of the `run_*` functions.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated
 