### PR TITLE
fix(tmux): support all default `tpm` locations (xdg and both hardcoded locations)

### DIFF
--- a/src/steps/tmux.rs
+++ b/src/steps/tmux.rs
@@ -23,8 +23,8 @@ use std::os::unix::process::CommandExt as _;
 pub fn run_tpm(ctx: &ExecutionContext) -> Result<()> {
     let tpm = match env::var("TMUX_PLUGIN_MANAGER_PATH") {
         // If `TMUX_PLUGIN_MANAGER_PATH` is set, search for
-        // `$TMUX_PLUGIN_MANAGER_PATH/bin/install_plugins/tpm/bin/update_plugins`
-        Ok(var) => PathBuf::from(var).join("bin/install_plugins/tpm/bin/update_plugins"),
+        // `$TMUX_PLUGIN_MANAGER_PATH/bin/update_plugins`
+        Ok(var) => PathBuf::from(var).join("bin/update_plugins"),
         // Otherwise, use the default location `~/.tmux/plugins/tpm/bin/update_plugins`
         Err(_) => HOME_DIR.join(".tmux/plugins/tpm/bin/update_plugins"),
     }


### PR DESCRIPTION
## What does this PR do

This PR fixes `TMUX_PLUGIN_MANAGER_PATH` handling (fix #1142) and add support for all default plugin path cases in the same order as tmux and ([tpm](https://github.com/tmux-plugins/tpm/blob/master/tpm#L24-L35)):
- `XDG_CONFIG` path
- hardcoded `~/.config/tmux` dir
- hardcoded `~/.tmux` dir

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
