### PR TITLE
Adds framework for listing updated components in the summary

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -16,10 +16,13 @@ assignees: ''
 * Does it have a `--dry-run` option? i.e., print what should be done and exit
 * Does it need the user to confirm the execution? And does it provide a `--yes`
   option to skip this step?
+* Can Topgrade extract the components that it updated to use in the summary?
 
 ## I want to suggest some general feature
+
 Topgrade should...
 
 ## More information
+
 <!-- Assuming that someone else implements the feature,
 please state if you know how to test it from a side branch of Topgrade. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,19 +1,19 @@
 ## What does this PR do
 
-
 ## Standards checklist
 
 - [ ] The PR title is descriptive
 - [ ] I have read `CONTRIBUTING.md`
 - [ ] *Optional:* I have tested the code myself
 - [ ] If this PR introduces new user-facing messages they are translated
- 
+
 ## For new steps
 
 - [ ] *Optional:* Topgrade skips this step where needed
 - [ ] *Optional:* The `--dry-run` option works with this step
-- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
+- [ ] *Optional:* The `--yes` option works with this step if it is supported by
   the underlying command
+- [ ] *Optional:* This step extracts and returns its updated components
 
 If you developed a feature or a bug fix for someone else and you do not have the
 means to test it, please tag this person here.

--- a/src/main.rs
+++ b/src/main.rs
@@ -441,7 +441,7 @@ fn run() -> Result<()> {
         generic::run_lensfun_update_data(&ctx)
     })?;
     runner.execute(Step::Poetry, "Poetry", || generic::run_poetry(&ctx))?;
-    runner.execute(Step::Uv, "uv", || generic::run_uv(&ctx))?;
+    runner.execute_with_updated(Step::Uv, "uv", || generic::run_uv(&ctx))?;
     runner.execute(Step::Zvm, "ZVM", || generic::run_zvm(&ctx))?;
     runner.execute(Step::Aqua, "aqua", || generic::run_aqua(&ctx))?;
     runner.execute(Step::Bun, "bun", || generic::run_bun(&ctx))?;

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,7 +1,8 @@
 use std::borrow::Cow;
+use std::fmt::Display;
 
 pub enum StepResult {
-    Success,
+    Success(Option<UpdatedComponents>),
     Failure,
     Ignored,
     Skipped(String),
@@ -10,8 +11,63 @@ pub enum StepResult {
 impl StepResult {
     pub fn failed(&self) -> bool {
         match self {
-            StepResult::Success | StepResult::Ignored | StepResult::Skipped(_) => false,
+            StepResult::Success(_) | StepResult::Ignored | StepResult::Skipped(_) => false,
             StepResult::Failure => true,
+        }
+    }
+}
+
+pub struct UpdatedComponents(Vec<UpdatedComponent>);
+
+impl UpdatedComponents {
+    pub fn new(updated: Vec<UpdatedComponent>) -> Self {
+        Self(updated)
+    }
+}
+
+impl Display for UpdatedComponents {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.0.as_slice() {
+            [] => write!(f, "No updates found"),
+            components => {
+                writeln!(f, "Updated:")?;
+                let updates = components
+                    .iter()
+                    .map(|c| format!("- {c}"))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                write!(f, "{}", updates)?;
+                Ok(())
+            }
+        }
+    }
+}
+
+pub struct UpdatedComponent {
+    name: String,
+    from_version: Option<String>,
+    to_version: Option<String>,
+}
+
+impl UpdatedComponent {
+    pub fn new(name: String, from_version: Option<String>, to_version: Option<String>) -> Self {
+        Self {
+            name,
+            from_version,
+            to_version,
+        }
+    }
+}
+
+impl Display for UpdatedComponent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match (&self.from_version, &self.to_version) {
+            (None, None) => write!(f, "{}", self.name),
+            (None, Some(to_version)) => write!(f, "{} to {}", self.name, to_version),
+            (Some(from_version), None) => write!(f, "{} from {}", self.name, from_version),
+            (Some(from_version), Some(to_version)) => {
+                write!(f, "{} from {} to {}", self.name, from_version, to_version)
+            }
         }
     }
 }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -173,7 +173,15 @@ impl Terminal {
                 "{}: {}\n",
                 key,
                 match result {
-                    StepResult::Success => format!("{}", style(t!("OK")).bold().green()),
+                    StepResult::Success(updated) => {
+                        let mut s = format!("{}", style(t!("OK")).bold().green());
+                        // Only add the ": No updates found" or ": Updated:" when this step
+                        //  supports extracting updated components
+                        if let Some(updated) = updated {
+                            s.push_str(&format!(": {updated}"));
+                        }
+                        s
+                    }
                     StepResult::Failure => format!("{}", style(t!("FAILED")).bold().red()),
                     StepResult::Ignored => format!("{}", style(t!("IGNORED")).bold().yellow()),
                     StepResult::Skipped(reason) => format!("{}: {}", style(t!("SKIPPED")).bold().blue(), reason),


### PR DESCRIPTION
## What does this PR do
Closes #943 (I am planning to open a tracking issue for implementing this for all steps where it is possible if this is merged.)
* Adds the framework for listing updated components in the summary
* Implements that for `uv` (self-updating only for now)
* Adds references to this to the "new step" issue and PR templates.

What do you think @SteveLauC? This is non-disruptive for steps that don't yet or can't support it, but opens the possibility to implement this for steps where it is very useful. Note that for some steps, machine-readable output is available (e.g. `apt-get`) and can be used instead of regexes. We can also PR to the tools themselves to support outputting in a machine-readable format. (maybe a good idea for `uv`, which already supports `--output-format=json` on some commands)

Example: (`cinnamon_spices` included to show what it looks like for a step that does not support it (yet))
```console
$ cargo run -- --only uv --only cinnamon_spices
── 11:18:45 - Cinnamon spices ──────────────────────────────────────────────────
There are no Spice updates

── 11:18:46 - uv ───────────────────────────────────────────────────────────────
info: Checking for updates...
success: Upgraded uv from v0.7.1 to v0.7.2! https://github.com/astral-sh/uv/releases/tag/0.7.2
Nothing to upgrade

── 11:18:50 - Summary ──────────────────────────────────────────────────────────
Cinnamon spices: OK
uv: OK: Updated:
- (self-update) uv from v0.7.1 to v0.7.2
$ cargo run -- --only uv --only cinnamon_spices
── 11:18:52 - Cinnamon spices ──────────────────────────────────────────────────
There are no Spice updates

── 11:18:53 - uv ───────────────────────────────────────────────────────────────
info: Checking for updates...
success: You're on the latest version of uv (v0.7.2)
Nothing to upgrade

── 11:18:53 - Summary ──────────────────────────────────────────────────────────
Cinnamon spices: OK
uv: OK: No updates found
```

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated
 