### PR TITLE
Fix container panic

### DIFF
--- a/src/steps/containers.rs
+++ b/src/steps/containers.rs
@@ -79,8 +79,7 @@ fn list_containers(crt: &Path, ignored_containers: Option<&Vec<String>>) -> Resu
     );
     let output = Command::new(crt)
         .args(["image", "ls", "--format", "{{.Repository}}:{{.Tag}} {{.ID}}"])
-        // TODO: Why do we ignore a non-zero exit code? Even when the list is empty the status code is 0
-        .output_checked_with_utf8(|_| Ok(()))?;
+        .output_checked_utf8()?;
 
     let mut retval = vec![];
     for line in output.stdout.lines() {

--- a/src/steps/containers.rs
+++ b/src/steps/containers.rs
@@ -1,15 +1,17 @@
 use std::fmt::{Display, Formatter};
+use std::io;
+use std::io::Write;
 use std::path::Path;
 use std::process::Command;
 
-use color_eyre::eyre::eyre;
 use color_eyre::eyre::Context;
 use color_eyre::eyre::Result;
+use color_eyre::eyre::{eyre, OptionExt};
 use tracing::{debug, error, warn};
 use wildmatch::WildMatch;
 
 use crate::command::CommandExt;
-use crate::error::{self, TopgradeError};
+use crate::error::{self, SkipStep, TopgradeError};
 use crate::terminal::print_separator;
 use crate::{execution_context::ExecutionContext, utils::require};
 use rust_i18n::t;
@@ -20,6 +22,9 @@ use rust_i18n::t;
 // the first place. This happens e.g. when the user tags an image locally
 // themselves or when using docker-compose.
 const NONEXISTENT_REPO: &str = "repository does not exist";
+
+// A string found in the output of docker when Docker Desktop is not running.
+const DOCKER_NOT_RUNNING: &str = "We recommend to activate the WSL integration in Docker Desktop settings.";
 
 /// Uniquely identifies a `Container`.
 #[derive(Debug)]
@@ -74,6 +79,7 @@ fn list_containers(crt: &Path, ignored_containers: Option<&Vec<String>>) -> Resu
     );
     let output = Command::new(crt)
         .args(["image", "ls", "--format", "{{.Repository}}:{{.Tag}} {{.ID}}"])
+        // TODO: Why do we ignore a non-zero exit code? Even when the list is empty the status code is 0
         .output_checked_with_utf8(|_| Ok(()))?;
 
     let mut retval = vec![];
@@ -99,7 +105,12 @@ fn list_containers(crt: &Path, ignored_containers: Option<&Vec<String>>) -> Resu
 
         // line is of format: `Repository:Tag ImageID`, e.g., `nixos/nix:latest d80fea9c32b4`
         let split_res = line.split(' ').collect::<Vec<&str>>();
-        assert_eq!(split_res.len(), 2);
+        if split_res.len() != 2 {
+            return Err(eyre!(format!(
+                "Got erroneous output from `{} image ls --format \"{{.Repository}}:{{.Tag}} {{.ID}}\"; Expected line to split into 2 parts",
+                crt.display()
+            )));
+        }
         let (repo_tag, image_id) = (split_res[0], split_res[1]);
 
         if let Some(ref ignored_containers) = ignored_containers {
@@ -120,7 +131,12 @@ fn list_containers(crt: &Path, ignored_containers: Option<&Vec<String>>) -> Resu
         let mut platform = inspect_output.stdout;
         // truncate the tailing new line character
         platform.truncate(platform.len() - 1);
-        assert!(platform.contains('/'));
+        if !platform.contains('/') {
+            return Err(eyre!(format!(
+                "Got erroneous output from `{} image ls --format \"{{.Repository}}:{{.Tag}} {{.ID}}\"; Expected platform to contain '/'",
+                crt.display()
+            )));
+        }
 
         retval.push(Container::new(repo_tag.to_string(), platform));
     }
@@ -135,6 +151,44 @@ pub fn run_containers(ctx: &ExecutionContext) -> Result<()> {
     debug!("Using container runtime '{}'", crt.display());
 
     print_separator(t!("Containers"));
+
+    let output = Command::new(&crt).arg("--help").output_checked_with(|_| Ok(()))?;
+    let status_code = output
+        .status
+        .code()
+        .ok_or_eyre("Couldn't get status code (terminated by signal)")?;
+    // TODO: check which it is and remove the other
+    let stdout = std::str::from_utf8(&output.stdout).wrap_err("Expected output to be valid UTF-8")?;
+    let stderr = std::str::from_utf8(&output.stderr).wrap_err("Expected output to be valid UTF-8")?;
+    if (stdout.contains(DOCKER_NOT_RUNNING) || stderr.contains(DOCKER_NOT_RUNNING)) && status_code == 1 {
+        // Write the output
+        io::stdout().write_all(&output.stdout)?;
+        io::stderr().write_all(&output.stderr)?;
+        // Don't crash, but don't be silent either.
+        // This can happen in other ways than Docker Desktop not running, but even in those cases
+        //  we don't want to crash, since the containers step is enabled by default.
+        // TODO: Is that ("but even in those cases we don't want to crash") correct?
+        warn!(
+            "{} seems to be non-functional right now (see above). Is WSL integration enabled for Docker Desktop? Is Docker Desktop running?",
+            crt.display()
+        );
+        return Err(SkipStep(format!(
+            "{} seems to be non-functional right now. Possibly WSL integration is not enabled for Docker Desktop, or Docker Desktop is not running.",
+            crt.display()
+        )).into());
+    } else if !output.status.success() {
+        // Write the output
+        io::stdout().write_all(&output.stdout)?;
+        io::stderr().write_all(&output.stderr)?;
+        // If we saw the message, but the code is not 1 (e.g. 0, or a non-1 failure), crash, as we expect a 1.
+        // If we did not see the message, it's broken in some way we do not understand.
+        return Err(eyre!(
+            "{0} seems to be non-functional (`{0} --help` returned non-zero exit code {1})",
+            crt.display(),
+            status_code,
+        ));
+    }
+
     let mut success = true;
     let containers =
         list_containers(&crt, ctx.config().containers_ignored_tags()).context("Failed to list Docker containers")?;


### PR DESCRIPTION
## What does this PR do
* Replaces panicking `assert`s with `return Err(eyre!(`
* Fixes ignoring non-0 status code (reverting the seemingly illegitimate change from https://github.com/topgrade-rs/topgrade/commit/e84173be8f7583833c6d01c68a7ab26a32031d6c#diff-ece1780c0524be77c5c5e0bad7a332730b2aa8a608c212767734568a8600c8d3R27)
* Check if `docker --help` returns a non-0 status code at the start of the step to catch the `The command 'docker' could not be found in this WSL 2 distro. We recommend to activate the WSL integration in Docker Desktop settings.` message that is output when Docker Desktop is not running, or when WSL integration is disabled
Closes #1149

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated
 

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

- [ ] @vmullapudi1 Could you install my patch of Topgrade (`cargo install --git https://github.com/GideonBear/topgrade.git --branch fix-container-panic`) and test that:
  - When Docker Desktop is not running, it shows a warning and skips the step (`docker seems to be non-functional right now (see above). Is WSL integration enabled for Docker Desktop? Is Docker Desktop running?`)
  - When Docker Desktop is running, the update proceeds like normal
- [ ] @vmullapudi1 in addition, could you check if the message that `docker` outputs is to stdout or stderr (see [my comment on your issue](https://github.com/topgrade-rs/topgrade/issues/1149#issuecomment-2855377309))
- [ ] @SteveLauC see line 169.