### PR TITLE
Update Yazi upgrade step to use ya pkg.

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -1658,5 +1658,5 @@ pub fn run_yazi(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("Yazi packages");
 
-    ctx.run_type().execute(ya).args(["pack", "-u"]).status_checked()
+    ctx.run_type().execute(ya).args(["pkg", "upgrade"]).status_checked()
 }


### PR DESCRIPTION
## What does this PR do
Currently we get this message:
WARNING: `ya pack` is deprecated, use the new `ya pkg` instead. See https://github.com/sxyazi/yazi/pull/2770 for more details.

This PR removes this extra line of output.
## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
