### PR TITLE
Drop lazy_static

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2886,7 +2886,6 @@ dependencies = [
  "glob",
  "home",
  "jetbrains-toolbox-updater",
- "lazy_static",
  "merge",
  "nix 0.29.0",
  "notify-rust",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ clap_complete = "~4.5"
 clap_mangen = "~0.2"
 walkdir = "~2.5"
 console = "~0.15"
-lazy_static = "~1.4"
 chrono = "~0.4"
 glob = "~0.3"
 strum = { version = "~0.26", features = ["derive"] }

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -1,17 +1,16 @@
-use std::ffi::OsString;
-use std::path::PathBuf;
-use std::process::Command;
-use std::{env, path::Path};
-use std::{fs, io::Write};
-
 use color_eyre::eyre::eyre;
 use color_eyre::eyre::Context;
 use color_eyre::eyre::Result;
 use jetbrains_toolbox_updater::{find_jetbrains_toolbox, update_jetbrains_toolbox, FindError};
-use lazy_static::lazy_static;
 use regex::bytes::Regex;
 use rust_i18n::t;
 use semver::Version;
+use std::ffi::OsString;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::LazyLock;
+use std::{env, path::Path};
+use std::{fs, io::Write};
 use tempfile::tempfile_in;
 use tracing::{debug, error};
 
@@ -1233,9 +1232,8 @@ pub fn run_poetry(ctx: &ExecutionContext) -> Result<()> {
         use std::ffi::OsStr;
         use std::os::unix::ffi::OsStrExt;
 
-        lazy_static! {
-            static ref SHEBANG_REGEX: Regex = Regex::new(r"^#![ \t]*([^ \t\n]+)(?:[ \t]+([^\n]+)?)?").unwrap();
-        }
+        static SHEBANG_REGEX: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new(r"^#![ \t]*([^ \t\n]+)(?:[ \t]+([^\n]+)?)?").unwrap());
 
         let script = fs::read(poetry)?;
         if let Some(c) = SHEBANG_REGEX.captures(&script) {
@@ -1254,10 +1252,8 @@ pub fn run_poetry(ctx: &ExecutionContext) -> Result<()> {
 
         use std::str;
 
-        lazy_static! {
-            static ref SHEBANG_REGEX: Regex =
-                Regex::new(r#"^#![ \t]*(?:"([^"\n]+)"|([^" \t\n]+))(?:[ \t]+([^\n]+)?)?"#).unwrap();
-        }
+        static SHEBANG_REGEX: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new(r#"^#![ \t]*(?:"([^"\n]+)"|([^" \t\n]+))(?:[ \t]+([^\n]+)?)?"#).unwrap());
 
         let data = fs::read(poetry)?;
 

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -1,11 +1,3 @@
-use std::ffi::OsStr;
-use std::fs;
-use std::os::unix::fs::MetadataExt;
-use std::path::Component;
-use std::path::PathBuf;
-use std::process::Command;
-use std::{env::var, path::Path};
-
 use crate::command::CommandExt;
 use crate::{output_changed_message, Step, HOME_DIR};
 use color_eyre::eyre::eyre;
@@ -13,12 +5,19 @@ use color_eyre::eyre::Context;
 use color_eyre::eyre::Result;
 use home;
 use ini::Ini;
-use lazy_static::lazy_static;
 #[cfg(target_os = "linux")]
 use nix::unistd::Uid;
 use regex::Regex;
 use rust_i18n::t;
 use semver::Version;
+use std::ffi::OsStr;
+use std::fs;
+use std::os::unix::fs::MetadataExt;
+use std::path::Component;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::LazyLock;
+use std::{env::var, path::Path};
 use tracing::debug;
 
 #[cfg(target_os = "linux")]
@@ -461,10 +460,8 @@ pub fn run_nix(ctx: &ExecutionContext) -> Result<()> {
         "`nix --version` output"
     );
 
-    lazy_static! {
-        static ref NIX_VERSION_REGEX: Regex =
-            Regex::new(r"^nix \([^)]*\) ([0-9.]+)").expect("Nix version regex always compiles");
-    }
+    static NIX_VERSION_REGEX: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"^nix \([^)]*\) ([0-9.]+)").expect("Nix version regex always compiles"));
 
     if get_version_cmd_first_line_stdout.is_empty() {
         return Err(eyre!("`nix --version` output was empty"));

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -2,14 +2,13 @@ use std::cmp::{max, min};
 use std::env;
 use std::io::{self, Write};
 use std::process::Command;
-use std::sync::Mutex;
+use std::sync::{LazyLock, Mutex};
 use std::time::Duration;
 
 use chrono::{Local, Timelike};
 use color_eyre::eyre;
 use color_eyre::eyre::Context;
 use console::{style, Key, Term};
-use lazy_static::lazy_static;
 use notify_rust::{Notification, Timeout};
 use rust_i18n::t;
 use tracing::{debug, error};
@@ -19,9 +18,7 @@ use which_crate::which;
 use crate::command::CommandExt;
 use crate::report::StepResult;
 
-lazy_static! {
-    static ref TERMINAL: Mutex<Terminal> = Mutex::new(Terminal::new());
-}
+static TERMINAL: LazyLock<Mutex<Terminal>> = LazyLock::new(|| Mutex::new(Terminal::new()));
 
 #[cfg(unix)]
 pub fn shell() -> String {


### PR DESCRIPTION
## What does this PR do
Drop `lazy_static` for std's `LazyLock`.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
