### PR TITLE
Preserve custom commmand order from config instead of sorting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1090,6 +1090,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
+name = "hashbrown"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1399,12 +1405,13 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.4",
+ "serde",
 ]
 
 [[package]]
@@ -2839,7 +2846,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.9.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -2852,7 +2859,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.9.0",
  "toml_datetime",
  "winnow 0.5.40",
 ]
@@ -2863,7 +2870,7 @@ version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f21c7aaf97f1bd9ca9d4f9e73b0a6c74bd5afef56f2bc931943a6e1c37e04e38"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.9.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -2885,6 +2892,7 @@ dependencies = [
  "futures",
  "glob",
  "home",
+ "indexmap 2.9.0",
  "jetbrains-toolbox-updater",
  "merge",
  "nix 0.29.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ wildmatch = "2.3.0"
 rust-i18n = "3.0.1"
 sys-locale = "0.3.1"
 jetbrains-toolbox-updater = "5.0.0"
+indexmap = { version = "2.9.0", features = ["serde"] }
 
 [package.metadata.generate-rpm]
 assets = [{ source = "target/release/topgrade", dest = "/usr/bin/topgrade" }]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use std::collections::BTreeMap;
+use indexmap::IndexMap;
 use std::fs::{write, File};
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -44,7 +44,7 @@ macro_rules! str_value {
     };
 }
 
-pub type Commands = BTreeMap<String, String>;
+pub type Commands = IndexMap<String, String>;
 
 #[derive(ValueEnum, EnumString, VariantNames, Debug, Clone, PartialEq, Eq, Deserialize, EnumIter, Copy)]
 #[clap(rename_all = "snake_case")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,5 @@
 #![allow(dead_code)]
 
-use indexmap::IndexMap;
 use std::fs::{write, File};
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -12,6 +11,7 @@ use clap_complete::Shell;
 use color_eyre::eyre::Context;
 use color_eyre::eyre::Result;
 use etcetera::base_strategy::BaseStrategy;
+use indexmap::IndexMap;
 use merge::Merge;
 use regex::Regex;
 use regex_split::RegexSplit;


### PR DESCRIPTION
(alphabetically)

## What does this PR do
Closes #1181
Technically this is a breaking change.
```console
$ cargo run -- --only custom_commands
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.60s
     Running `target/debug/topgrade --only custom_commands`

── 13:55:04 - B command ────────────────────────────────────────────────────────
This should be first

── 13:55:04 - A command ────────────────────────────────────────────────────────
This should be second

── 13:55:04 - Summary ──────────────────────────────────────────────────────────
B command: OK
A command: OK
```

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated
 