### PR TITLE
ci: allow us to re-run AUR CI

### DIFF
--- a/.github/workflows/release_to_aur.yml
+++ b/.github/workflows/release_to_aur.yml
@@ -21,7 +21,6 @@ jobs:
     steps:
       - name: Determine version
         id: determine_version
-        shell: bash # Or it won't work on Windows
         run: |
           if [ -n "${{ github.event.inputs.version }}" ]; then
             echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## What does this PR do

Replace the AUR action with `varabyte/update-aur-package`, which allows us to specify the version to release.


## Standards checklist

- [ ] The PR title is descriptive
- [ ] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
