### PR TITLE
fix: ensure PowerShell module Update Command is prefixed with `-Command`

### DIFF
--- a/src/steps/powershell.rs
+++ b/src/steps/powershell.rs
@@ -79,7 +79,7 @@ impl Powershell {
 
     pub fn update_modules(&self, ctx: &ExecutionContext) -> Result<()> {
         print_separator(t!("Powershell Modules Update"));
-        let mut cmd_args = vec!["Update-Module"];
+        let mut cmd_args = vec!["-Command", "Update-Module"];
 
         if ctx.config().verbose() {
             cmd_args.push("-Verbose");


### PR DESCRIPTION
## What does this PR do

Fixes the command used during PowerShell Module Update to be prefixed by the `-Command` argument.
This should resolve https://github.com/topgrade-rs/topgrade/issues/1174

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
