### PR TITLE
Fix execution policy check 

### DIFF
--- a/locales/app.yml
+++ b/locales/app.yml
@@ -104,6 +104,14 @@ _version: 2
   zh_CN: "正在更新模块..."
   zh_TW: "正在更新模組..."
   de: "Module werden aktualisiert..."
+"Checking for PowerShell module updates...":
+  en: "Checking for PowerShell module updates..."
+  lt: "Tikrinami PowerShell modulių atnaujinimai..."
+  es: "Comprobando actualizaciones de módulos PowerShell..."
+  fr: "Vérification des mises à jour des modules PowerShell..."
+  zh_CN: "正在检查 PowerShell 模块更新..."
+  zh_TW: "正在檢查 PowerShell 模組更新..."
+  de: "Überprüfe PowerShell-Modul-Updates..."
 "Powershell Modules Update":
   en: "Powershell Modules Update"
   lt: "PowerShell modulių atnaujinimas"
@@ -1235,6 +1243,7 @@ _version: 2
 "Microsoft Store":
   en: "Microsoft Store"
   lt: "Microsoft parduotuvė"
+
   es: "Tienda de Microsoft"
   fr: "Microsoft Store"
   zh_CN: "Microsoft Store"

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,7 +136,7 @@ fn run() -> Result<()> {
     }
 
     let powershell = powershell::Powershell::new();
-    let should_run_powershell = powershell.profile().is_some() && config.should_run(Step::Powershell);
+    let should_run_powershell = powershell.is_available() && config.should_run(Step::Powershell);
     let emacs = emacs::Emacs::new();
     #[cfg(target_os = "linux")]
     let distribution = linux::Distribution::detect();

--- a/src/steps/powershell.rs
+++ b/src/steps/powershell.rs
@@ -118,7 +118,11 @@ impl Powershell {
             let target_idx = valid_policies.iter().position(|&p| p == policy);
 
             let output = Command::new(powershell)
-                .args(["-NoProfile", "-Command", "Get-ExecutionPolicy"])
+                .args([
+                    "-NoProfile",
+                    "-Command",
+                    "Import-Module Microsoft.PowerShell.Security -ErrorAction SilentlyContinue; Get-ExecutionPolicy",
+                ])
                 .output_checked_utf8();
 
             if let Ok(output) = output {

--- a/src/steps/powershell.rs
+++ b/src/steps/powershell.rs
@@ -82,15 +82,20 @@ impl Powershell {
 
     pub fn update_modules(&self, ctx: &ExecutionContext) -> Result<()> {
         print_separator(t!("Powershell Modules Update"));
+
         let mut cmd_args = vec!["Update-Module"];
 
         if ctx.config().verbose() {
             cmd_args.push("-Verbose");
+            println!("{}", t!("Checking for PowerShell module updates..."));
+        } else {
+            println!("{}", t!("Updating modules..."));
         }
+
         if ctx.config().yes(Step::Powershell) {
             cmd_args.push("-Force");
         }
-        println!("{}", t!("Updating modules..."));
+
         self.build_command_internal(ctx, &cmd_args)?.status_checked()
     }
 


### PR DESCRIPTION
## What does this PR do
Enhance execution policy check by importing the Microsoft.PowerShell.Security module
Fix https://github.com/topgrade-rs/topgrade/issues/1189
fix https://github.com/topgrade-rs/topgrade/issues/1173

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

@SteveLauC 
@AThePeanut4
@GideonBear 