### PR TITLE
Add doom.aot option

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -325,3 +325,9 @@
 # extensions should be updated for.
 # (default: this won't be set by default)
 # profile = ""
+
+[doom]
+# If this is set to true, the `--aot` flag is added to `doom upgrade`,
+# which enables ahead-of-time native compilation of packages.
+# (default: false)
+# aot = true

--- a/src/config.rs
+++ b/src/config.rs
@@ -501,6 +501,12 @@ pub struct VscodeConfig {
 
 #[derive(Deserialize, Default, Debug, Merge)]
 #[serde(deny_unknown_fields)]
+pub struct DoomConfig {
+    aot: Option<bool>,
+}
+
+#[derive(Deserialize, Default, Debug, Merge)]
+#[serde(deny_unknown_fields)]
 /// Configuration file
 pub struct ConfigFile {
     #[merge(strategy = crate::utils::merge_strategies::inner_merge_opt)]
@@ -574,6 +580,9 @@ pub struct ConfigFile {
 
     #[merge(strategy = crate::utils::merge_strategies::inner_merge_opt)]
     vscode: Option<VscodeConfig>,
+
+    #[merge(strategy = crate::utils::merge_strategies::inner_merge_opt)]
+    doom: Option<DoomConfig>,
 }
 
 fn config_directory() -> PathBuf {
@@ -1759,6 +1768,14 @@ impl Config {
         } else {
             Some(profile.as_str())
         }
+    }
+
+    pub fn doom_aot(&self) -> bool {
+        self.config_file
+            .doom
+            .as_ref()
+            .and_then(|doom| doom.aot)
+            .unwrap_or(false)
     }
 }
 

--- a/src/steps/emacs.rs
+++ b/src/steps/emacs.rs
@@ -65,7 +65,11 @@ impl Emacs {
             command.arg("--force");
         }
 
-        command.args(["upgrade"]);
+        command.arg("upgrade");
+
+        if ctx.config().doom_aot() {
+            command.arg("--aot");
+        }
 
         command.status_checked()
     }


### PR DESCRIPTION
## What does this PR do
Closes #884

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated
 

@raszi, @hey2022
Can one of you test that this works as expected?
1. Set the configuration option to `true`
2. Install: `cargo install --git https://github.com/GideonBear/topgrade --branch doom-aot`
3. Run: `~/.cargo/bin/topgrade --only emacs`