### PR TITLE
Skip `auto-cpufreq` when path is not /usr/local/bin/auto-cpufreq

### DIFF
--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -1111,6 +1111,12 @@ pub fn run_waydroid(ctx: &ExecutionContext) -> Result<()> {
 pub fn run_auto_cpufreq(ctx: &ExecutionContext) -> Result<()> {
     let sudo = require_option(ctx.sudo().as_ref(), get_require_sudo_string())?;
     let auto_cpu_freq = require("auto-cpufreq")?;
+    if auto_cpu_freq != PathBuf::from("/usr/local/bin/auto-cpufreq") {
+        return Err(SkipStep(String::from(
+            "`auto-cpufreq` was not installed by the official installer, but presumably by a package manager.",
+        ))
+        .into());
+    }
 
     print_separator("auto-cpufreq");
 


### PR DESCRIPTION
## What does this PR do
Closes #1038
The `auto-cpufreq` install script has the `/usr/local/bin/auto-cpufreq` path hardcoded, so if the executable is not in this path, we can conclude the install script was not used.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated
 
@xeruf Could you test that this works for you?
1. Install: `cargo install --git https://github.com/GideonBear/topgrade --branch auto-cpufreq-aur-fix`
2. Run: `~/.cargo/bin/topgrade --only auto-cpufreq -v`