### PR TITLE
Generate artifact attestations for release assets

### DIFF
--- a/.github/workflows/create_release_assets.yml
+++ b/.github/workflows/create_release_assets.yml
@@ -22,6 +22,13 @@ on:
 jobs:
   # Publish release files for CD native environments
   native_build:
+    permissions:
+      # Use to sign the release artifacts
+      id-token: write
+      # Used to upload release artifacts
+      contents: write
+      # Used to generate artifact attestations
+      attestations: write
     strategy:
       fail-fast: false
       matrix:
@@ -119,8 +126,20 @@ jobs:
           tag_name: ${{ steps.determine_tag_name.outputs.tag_name }}
           files: assets/*
 
+      - name: Generate artifact attestations
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: assets/*
+
   # Publish release files for non-CD-native environments
   cross_build:
+    permissions:
+      # Use to sign the release artifacts
+      id-token: write
+      # Used to upload release artifacts
+      contents: write
+      # Used to generate artifact attestations
+      attestations: write
     strategy:
       fail-fast: false
       matrix:
@@ -223,3 +242,8 @@ jobs:
         with:
           tag_name: ${{ steps.determine_tag_name.outputs.tag_name }}
           files: assets/*
+
+      - name: Generate artifact attestations
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: assets/*


### PR DESCRIPTION
## What does this PR do

Closes https://github.com/topgrade-rs/topgrade/issues/1207

Seems to work, results from my fork for a fake tag: https://github.com/scop/topgrade/attestations

Note that the freebsd attestation is missing but that's expected, because the freebsd build failed due to unrelated reasons.

## Standards checklist

- [x] The PR title is descriptive
- [ ] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
