### PR TITLE
Add falconf step

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -84,6 +84,7 @@ pub enum Step {
     Dotnet,
     Elan,
     Emacs,
+    Falconf,
     Firmware,
     Flatpak,
     Flutter,

--- a/src/main.rs
+++ b/src/main.rs
@@ -503,6 +503,7 @@ fn run() -> Result<()> {
         generic::run_jetbrains_webstorm(&ctx)
     })?;
     runner.execute(Step::Yazi, "Yazi packages", || generic::run_yazi(&ctx))?;
+    runner.execute(Step::Falconf, "falconf sync", || generic::run_falconf(&ctx))?;
 
     if should_run_powershell {
         runner.execute(Step::Powershell, "Powershell Modules Update", || {

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -1704,3 +1704,11 @@ pub fn run_yazi(ctx: &ExecutionContext) -> Result<()> {
 
     ctx.run_type().execute(ya).args(["pkg", "upgrade"]).status_checked()
 }
+
+pub fn run_falconf(ctx: &ExecutionContext) -> Result<()> {
+    let falconf = require("falconf")?;
+
+    print_separator("falconf sync");
+
+    ctx.run_type().execute(falconf).arg("sync").status_checked()
+}


### PR DESCRIPTION
## What does this PR do
Adds [falconf](https://github.com/GideonBear/falconf), an in-development synchronization tool.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated
 
## For new steps

- [x] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
