### PR TITLE
fixed the German translation for "y/n/s/q"

### DIFF
--- a/locales/app.yml
+++ b/locales/app.yml
@@ -1117,7 +1117,7 @@ _version: 2
   fr: "Réessayer ? (y) Oui / (N) Non / (s) Shell / (q) Quitter"
   zh_CN: "再试一次？(y)是/(N)否/(s)Shell/(q)退出"
   zh_TW: "再試一次？ (y)是/(N)否/(s)殼層/(q)退出"
-  de: "Wiederholen? (y)a/(N)ein/(s)hell/(q)uit"
+  de: "Wiederholen? (y) Ja / (n) Nein / (s) Shell / (q) Beenden"
 
 # 'R', 'S', 'Q'  have to stay the same throughout all translations. Eg German would look like "\n(R) Neustarten\n(S) Konsole\n(Q) Beenden"
 '\n(R)eboot\n(S)hell\n(Q)uit':


### PR DESCRIPTION
"ya" isn't a word. :-) 

## What does this PR do

Fixes the "y/n/s/q" string in the German translation: made the accessor keys casing even, applied the same style, fixed the word "ya".

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
