### PR TITLE
fix(config): Sync with config-reference

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -111,19 +111,6 @@
 # poetry_force_self_update = true
 
 
-[conda]
-# Additional named conda environments to update (`conda env update -n env_name`)
-# env_names = [
-#     "Toolbox",
-#     "PyTorch"
-# ]
-# Additional conda environment paths to update (`conda env update -p env_path`)
-# env_paths = [
-#     "~/webserver/.conda/",
-#     "~/experiments/.conda/"
-# ]
-
-
 [composer]
 # self_update = true
 
@@ -226,10 +213,6 @@
 # Manually select Windows updates
 # accept_all_updates = false
 
-# Controls whether to automatically reboot the computer when updates are
-# installed that request it. (default: "no", allowed values: "yes", "no", "ask")
-# updates_auto_reboot = "yes"
-
 # open_remotes_in_new_terminal = true
 
 # wsl_update_pre_release = true
@@ -244,16 +227,6 @@
 # to upgrade it. Use this only if you installed Topgrade by using a package
 # manager such as Scoop or Cargo
 # self_rename = true
-
-# Use sudo to elevate privileges for the Windows Package Manager (winget)
-# Only use this option if you want to run the Winget step in sudo-mode.
-# Running winget in sudo-mode is generally not recommended, as not every
-# package supports installing / upgrading in sudo-mode and it may cause issues
-# with some packages or may even cause the Winget-step to fail.
-# If any problems occur, please try running Topgrade without this option first
-# before reporting an issue.
-# (default: false)
-# winget_use_sudo = true
 
 
 [npm]
@@ -352,9 +325,3 @@
 # extensions should be updated for.
 # (default: this won't be set by default)
 # profile = ""
-
-[pixi]
-# Show the release notes of the latest pixi release
-# during the pixi step
-# (default: false)
-# include_release_notes = false


### PR DESCRIPTION
## What does this PR do

this removes e.g. config sections that do not exist anymore
(conda, pixi) and so lead to parsing errors
`topgrade --config-reference > config.example.toml`

## Standards checklist

- [ ] The PR title is descriptive
- [ ] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
