### PR TITLE
Still print summary when (q)uit is used

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -197,7 +197,19 @@ fn run() -> Result<()> {
     }
 
     for step in step::default_steps() {
-        step.run(&mut runner, &ctx)?
+        match step.run(&mut runner, &ctx) {
+            Ok(()) => (),
+            Err(error)
+                if error
+                    .downcast_ref::<io::Error>()
+                    .is_some_and(|e| e.kind() == io::ErrorKind::Interrupted) =>
+            {
+                println!();
+                debug!("Interrupted (possibly with 'q' during retry prompt). Printing summary.");
+                break;
+            }
+            Err(error) => return Err(error),
+        }
     }
 
     if !runner.report().data().is_empty() {

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -196,10 +196,11 @@ impl Terminal {
             }
         }
     }
+
     #[allow(unused_variables)]
-    fn should_retry(&mut self, interrupted: bool, step_name: &str) -> eyre::Result<bool> {
+    fn should_retry(&mut self, step_name: &str) -> eyre::Result<ShouldRetry> {
         if self.width.is_none() {
-            return Ok(false);
+            return Ok(ShouldRetry::No);
         }
 
         if self.set_title {
@@ -218,7 +219,7 @@ impl Terminal {
 
         let answer = loop {
             match self.term.read_key() {
-                Ok(Key::Char('y' | 'Y')) => break Ok(true),
+                Ok(Key::Char('y' | 'Y')) => break Ok(ShouldRetry::Yes),
                 Ok(Key::Char('s' | 'S')) => {
                     println!(
                         "\n\n{}\n",
@@ -227,16 +228,16 @@ impl Terminal {
                     if let Err(err) = run_shell().context("Failed to run shell") {
                         self.term.write_fmt(format_args!("{err:?}\n{prompt_inner}")).ok();
                     } else {
-                        break Ok(true);
+                        break Ok(ShouldRetry::Yes);
                     }
                 }
-                Ok(Key::Char('n' | 'N') | Key::Enter) => break Ok(false),
+                Ok(Key::Char('n' | 'N') | Key::Enter) => break Ok(ShouldRetry::No),
                 Err(e) => {
                     error!("Error reading from terminal: {}", e);
-                    break Ok(false);
+                    break Ok(ShouldRetry::No);
                 }
                 Ok(Key::Char('q' | 'Q')) => {
-                    return Err(io::Error::from(io::ErrorKind::Interrupted)).context("Quit from user input")
+                    break Ok(ShouldRetry::Quit);
                 }
                 _ => (),
             }
@@ -252,14 +253,21 @@ impl Terminal {
     }
 }
 
+#[derive(Clone, Copy)]
+pub enum ShouldRetry {
+    Yes,
+    No,
+    Quit,
+}
+
 impl Default for Terminal {
     fn default() -> Self {
         Self::new()
     }
 }
 
-pub fn should_retry(interrupted: bool, step_name: &str) -> eyre::Result<bool> {
-    TERMINAL.lock().unwrap().should_retry(interrupted, step_name)
+pub fn should_retry(step_name: &str) -> eyre::Result<ShouldRetry> {
+    TERMINAL.lock().unwrap().should_retry(step_name)
 }
 
 pub fn print_separator<P: AsRef<str>>(message: P) {


### PR DESCRIPTION
## What does this PR do
* Still print summary when (q)uit is used
* Remove unused `interrupted` argument

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated
 