### PR TITLE
refactor: replace once_cell crate with std equivalent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2909,7 +2909,6 @@ dependencies = [
  "merge",
  "nix 0.29.0",
  "notify-rust",
- "once_cell",
  "parselnk",
  "regex",
  "regex-split",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ path = "src/main.rs"
 [dependencies]
 home = "~0.5"
 etcetera = "~0.8"
-once_cell = "~1.19"
 serde = { version = "~1.0", features = ["derive"] }
 toml = "0.8"
 which_crate = { version = "~6.0", package = "which" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,8 +17,8 @@ use etcetera::base_strategy::BaseStrategy;
 use etcetera::base_strategy::Windows;
 #[cfg(unix)]
 use etcetera::base_strategy::Xdg;
-use once_cell::sync::Lazy;
 use rust_i18n::{i18n, t};
+use std::sync::LazyLock;
 use tracing::debug;
 
 use self::config::{CommandLineArgs, Config};
@@ -50,12 +50,12 @@ mod sudo;
 mod terminal;
 mod utils;
 
-pub(crate) static HOME_DIR: Lazy<PathBuf> = Lazy::new(|| home::home_dir().expect("No home directory"));
+pub(crate) static HOME_DIR: LazyLock<PathBuf> = LazyLock::new(|| home::home_dir().expect("No home directory"));
 #[cfg(unix)]
-pub(crate) static XDG_DIRS: Lazy<Xdg> = Lazy::new(|| Xdg::new().expect("No home directory"));
+pub(crate) static XDG_DIRS: LazyLock<Xdg> = LazyLock::new(|| Xdg::new().expect("No home directory"));
 
 #[cfg(windows)]
-pub(crate) static WINDOWS_DIRS: Lazy<Windows> = Lazy::new(|| Windows::new().expect("No home directory"));
+pub(crate) static WINDOWS_DIRS: LazyLock<Windows> = LazyLock::new(|| Windows::new().expect("No home directory"));
 
 // Init and load the i18n files
 i18n!("locales", fallback = "en");


### PR DESCRIPTION
## What does this PR do
Replaces the `once_cell` crate with equivalent functionality provided by `std (1.80)` via [`LazyLock`](https://doc.rust-lang.org/beta/std/sync/struct.LazyLock.html).

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
