### PR TITLE
Sudo preserve env list argument is `--preserve-env`

### DIFF
--- a/src/sudo.rs
+++ b/src/sudo.rs
@@ -252,7 +252,7 @@ impl Sudo {
             },
             SudoPreserveEnv::Some(vars) => match self.kind {
                 SudoKind::Sudo => {
-                    cmd.arg(format!("--preserve_env={}", vars.join(",")));
+                    cmd.arg(format!("--preserve-env={}", vars.join(",")));
                 }
                 SudoKind::Run0 => {
                     for env in vars {


### PR DESCRIPTION
## What does this PR do
Replace an `_` with a `-` in `sudo`'s `--preserve-env=...` argument.

https://www.man7.org/linux/man-pages/man8/sudo.8.html

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated

## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
