### PR TITLE
Support "Insiders" versions of VSCode and VSCodium

### DIFF
--- a/src/step.rs
+++ b/src/step.rs
@@ -152,6 +152,7 @@ pub enum Step {
     Vim,
     VoltaPackages,
     Vscode,
+    VscodeInsiders,
     Vscodium,
     Waydroid,
     Winget,
@@ -620,6 +621,9 @@ impl Step {
             Vscode => runner.execute(*self, "Visual Studio Code extensions", || {
                 generic::run_vscode_extensions_update(ctx)
             })?,
+            VscodeInsiders => runner.execute(*self, "Visual Studio Code Insiders extensions", || {
+                generic::run_vscode_insiders_extensions_update(ctx)
+            })?,
             Vscodium => runner.execute(*self, "VSCodium extensions", || {
                 generic::run_vscodium_extensions_update(ctx)
             })?,
@@ -764,6 +768,7 @@ pub(crate) fn default_steps() -> Vec<Step> {
         Pipx,
         Pipxu,
         Vscode,
+        VscodeInsiders,
         Vscodium,
         Conda,
         Mamba,

--- a/src/step.rs
+++ b/src/step.rs
@@ -154,6 +154,7 @@ pub enum Step {
     Vscode,
     VscodeInsiders,
     Vscodium,
+    VscodiumInsiders,
     Waydroid,
     Winget,
     Wsl,
@@ -627,6 +628,9 @@ impl Step {
             Vscodium => runner.execute(*self, "VSCodium extensions", || {
                 generic::run_vscodium_extensions_update(ctx)
             })?,
+            VscodiumInsiders => runner.execute(*self, "VSCodium Insiders extensions", || {
+                generic::run_vscodium_insiders_extensions_update(ctx)
+            })?,
             Waydroid =>
             {
                 #[cfg(target_os = "linux")]
@@ -770,6 +774,7 @@ pub(crate) fn default_steps() -> Vec<Step> {
         Vscode,
         VscodeInsiders,
         Vscodium,
+        VscodiumInsiders,
         Conda,
         Mamba,
         Pixi,

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -441,15 +441,54 @@ pub fn run_vcpkg_update(ctx: &ExecutionContext) -> Result<()> {
     command.args(["upgrade", "--no-dry-run"]).status_checked()
 }
 
-/// This functions runs for both VSCode and VSCodium, as most of the process is the same for both.
-fn run_vscode_compatible<const VSCODIUM: bool>(ctx: &ExecutionContext) -> Result<()> {
+enum VSCodeVariant {
+    Code,
+    CodeInsiders,
+    Codium,
+}
+
+impl VSCodeVariant {
+    fn name(&self) -> &'static str {
+        match self {
+            VSCodeVariant::Code => "VSCode",
+            VSCodeVariant::CodeInsiders => "VSCode Insiders",
+            VSCodeVariant::Codium => "VSCodium",
+        }
+    }
+
+    fn bin_name(&self) -> &'static str {
+        match self {
+            VSCodeVariant::Code => "code",
+            VSCodeVariant::CodeInsiders => "code-insiders",
+            VSCodeVariant::Codium => "codium",
+        }
+    }
+
+    fn display_name(&self) -> &'static str {
+        match self {
+            VSCodeVariant::Code => "Visual Studio Code extensions",
+            VSCodeVariant::CodeInsiders => "Visual Studio Code Insiders extensions",
+            VSCodeVariant::Codium => "VSCodium extensions",
+        }
+    }
+
+    fn supports_profiles(&self) -> bool {
+        match self {
+            VSCodeVariant::Code | VSCodeVariant::CodeInsiders => true,
+            VSCodeVariant::Codium => false,
+        }
+    }
+}
+
+/// This functions runs for VSCode, VSCode Insiders, and VSCodium, as most of the process is the same for all.
+fn run_vscode_compatible(variant: VSCodeVariant, ctx: &ExecutionContext) -> Result<()> {
     // Calling VSCode/VSCodium in WSL may install a server instead of updating extensions (https://github.com/topgrade-rs/topgrade/issues/594#issuecomment-1782157367)
     if is_wsl()? {
         return Err(SkipStep(String::from("Should not run in WSL")).into());
     }
 
-    let name = if VSCODIUM { "VSCodium" } else { "VSCode" };
-    let bin_name = if VSCODIUM { "codium" } else { "code" };
+    let name = variant.name();
+    let bin_name = variant.bin_name();
     let bin = require(bin_name)?;
 
     // VSCode has update command only since 1.86 version ("january 2024" update), disable the update for prior versions
@@ -464,6 +503,8 @@ fn run_vscode_compatible<const VSCODIUM: bool>(ctx: &ExecutionContext) -> Result
         .next()
     {
         Some(item) => {
+            // VS Code Insiders versions have "-insider" suffix which we can simply ignore.
+            let item = item.trim_end_matches("-insider");
             // Strip leading zeroes because `semver` does not allow them, but VSCodium uses them sometimes.
             //  This is not the case for VSCode, but just in case, and it can't really cause any issues.
             let item = item
@@ -492,15 +533,11 @@ fn run_vscode_compatible<const VSCODIUM: bool>(ctx: &ExecutionContext) -> Result
         return Err(SkipStep(format!("Too old {name} version to have update extensions command")).into());
     }
 
-    print_separator(if VSCODIUM {
-        "VSCodium extensions"
-    } else {
-        "Visual Studio Code extensions"
-    });
+    print_separator(variant.display_name());
 
     let mut cmd = ctx.execute(bin);
-    // If its VSCode (not VSCodium)
-    if !VSCODIUM {
+    // If the variant supports profiles
+    if variant.supports_profiles() {
         // And we have configured use of a profile
         if let Some(profile) = ctx.config().vscode_profile() {
             // Add the profile argument
@@ -516,11 +553,15 @@ fn run_vscode_compatible<const VSCODIUM: bool>(ctx: &ExecutionContext) -> Result
 /// 1. Users could use both VSCode and VSCodium
 /// 2. Just in case, VSCodium could have incompatible changes with VSCode
 pub fn run_vscodium_extensions_update(ctx: &ExecutionContext) -> Result<()> {
-    run_vscode_compatible::<true>(ctx)
+    run_vscode_compatible(VSCodeVariant::Codium, ctx)
 }
 
 pub fn run_vscode_extensions_update(ctx: &ExecutionContext) -> Result<()> {
-    run_vscode_compatible::<false>(ctx)
+    run_vscode_compatible(VSCodeVariant::Code, ctx)
+}
+
+pub fn run_vscode_insiders_extensions_update(ctx: &ExecutionContext) -> Result<()> {
+    run_vscode_compatible(VSCodeVariant::CodeInsiders, ctx)
 }
 
 pub fn run_pipx_update(ctx: &ExecutionContext) -> Result<()> {

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -445,6 +445,7 @@ enum VSCodeVariant {
     Code,
     CodeInsiders,
     Codium,
+    CodiumInsiders,
 }
 
 impl VSCodeVariant {
@@ -453,6 +454,7 @@ impl VSCodeVariant {
             VSCodeVariant::Code => "VSCode",
             VSCodeVariant::CodeInsiders => "VSCode Insiders",
             VSCodeVariant::Codium => "VSCodium",
+            VSCodeVariant::CodiumInsiders => "VSCodium Insiders",
         }
     }
 
@@ -461,6 +463,7 @@ impl VSCodeVariant {
             VSCodeVariant::Code => "code",
             VSCodeVariant::CodeInsiders => "code-insiders",
             VSCodeVariant::Codium => "codium",
+            VSCodeVariant::CodiumInsiders => "codium-insiders",
         }
     }
 
@@ -469,18 +472,19 @@ impl VSCodeVariant {
             VSCodeVariant::Code => "Visual Studio Code extensions",
             VSCodeVariant::CodeInsiders => "Visual Studio Code Insiders extensions",
             VSCodeVariant::Codium => "VSCodium extensions",
+            VSCodeVariant::CodiumInsiders => "VSCodium Insiders extensions",
         }
     }
 
     fn supports_profiles(&self) -> bool {
         match self {
             VSCodeVariant::Code | VSCodeVariant::CodeInsiders => true,
-            VSCodeVariant::Codium => false,
+            VSCodeVariant::Codium | VSCodeVariant::CodiumInsiders => false,
         }
     }
 }
 
-/// This functions runs for VSCode, VSCode Insiders, and VSCodium, as most of the process is the same for all.
+/// This functions runs for VSCode, VSCode Insiders, VSCodium, and VSCodium Insiders, as most of the process is the same for all.
 fn run_vscode_compatible(variant: VSCodeVariant, ctx: &ExecutionContext) -> Result<()> {
     // Calling VSCode/VSCodium in WSL may install a server instead of updating extensions (https://github.com/topgrade-rs/topgrade/issues/594#issuecomment-1782157367)
     if is_wsl()? {
@@ -503,7 +507,7 @@ fn run_vscode_compatible(variant: VSCodeVariant, ctx: &ExecutionContext) -> Resu
         .next()
     {
         Some(item) => {
-            // VS Code Insiders versions have "-insider" suffix which we can simply ignore.
+            // Insiders versions have "-insider" suffix which we can simply ignore.
             let item = item.trim_end_matches("-insider");
             // Strip leading zeroes because `semver` does not allow them, but VSCodium uses them sometimes.
             //  This is not the case for VSCode, but just in case, and it can't really cause any issues.
@@ -562,6 +566,10 @@ pub fn run_vscode_extensions_update(ctx: &ExecutionContext) -> Result<()> {
 
 pub fn run_vscode_insiders_extensions_update(ctx: &ExecutionContext) -> Result<()> {
     run_vscode_compatible(VSCodeVariant::CodeInsiders, ctx)
+}
+
+pub fn run_vscodium_insiders_extensions_update(ctx: &ExecutionContext) -> Result<()> {
+    run_vscode_compatible(VSCodeVariant::CodiumInsiders, ctx)
 }
 
 pub fn run_pipx_update(ctx: &ExecutionContext) -> Result<()> {


### PR DESCRIPTION
closes https://github.com/topgrade-rs/topgrade/issues/1272

## What does this PR do
- adds support for VSCode Inisders and VSCodium insiders.
- runs `code-insiders --update-extensions` and `codium-insiders --update-extensions` respectively.
- refactors the vscode section to use an enum for all 4 vscode variants.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [x] If this PR introduces new user-facing messages they are translated

<img width="689" height="147" alt="image" src="https://github.com/user-attachments/assets/e510eb1b-61f8-4432-bb3d-375428bad4bd" />

## For new steps

- [x] *Optional:* Topgrade skips this step where needed
- [x] *Optional:* The `--dry-run` option works with this step
<img width="471" height="107" alt="image" src="https://github.com/user-attachments/assets/7069012e-ffbb-47ec-91a6-901d6c03a709" />

- [x] *Optional:* The `--yes` option works with this step if it is supported by
  the underlying command: _not supported, always updates_
