### PR TITLE
Security: update tracing-subscriber to ~0.3.20 (ANSI escape injection fix, GHSA-xwfj-jgwm-7wp5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1062,8 +1062,8 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "log",
- "regex-automata 0.4.7",
- "regex-syntax 0.8.4",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1381,7 +1381,7 @@ dependencies = [
  "globset",
  "log",
  "memchr",
- "regex-automata 0.4.7",
+ "regex-automata",
  "same-file",
  "walkdir",
  "winapi-util",
@@ -1561,11 +1561,11 @@ dependencies = [
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata",
 ]
 
 [[package]]
@@ -1689,12 +1689,11 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
 dependencies = [
- "overload",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1796,12 +1795,6 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
 ]
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owo-colors"
@@ -2058,17 +2051,8 @@ checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.7",
- "regex-syntax 0.8.4",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2079,7 +2063,7 @@ checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.4",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2090,12 +2074,6 @@ checksum = "544861d1810a3e429bb5e80266e537138b0e69e59bed9334326ae129a4c3e676"
 dependencies = [
  "regex",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -2962,9 +2940,9 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -2974,9 +2952,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2985,9 +2963,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
@@ -3016,14 +2994,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.18"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ semver = "~1.0"
 shell-words = "~1.1"
 color-eyre = "~0.6"
 tracing = { version = "~0.1", features = ["attributes", "log"] }
-tracing-subscriber = { version = "0.3.20", features = ["env-filter", "time"] }
+tracing-subscriber = { version = "~0.3.20", features = ["env-filter", "time"] }
 merge = "~0.1"
 regex-split = "~0.1"
 notify-rust = "~4.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ semver = "~1.0"
 shell-words = "~1.1"
 color-eyre = "~0.6"
 tracing = { version = "~0.1", features = ["attributes", "log"] }
-tracing-subscriber = { version = "~0.3", features = ["env-filter", "time"] }
+tracing-subscriber = { version = "0.3.20", features = ["env-filter", "time"] }
 merge = "~0.1"
 regex-split = "~0.1"
 notify-rust = "~4.11"
@@ -79,7 +79,7 @@ self_update_crate = { version = "~0.40", default-features = false, optional = tr
 
 [target.'cfg(windows)'.dependencies]
 self_update_crate = { version = "~0.40", default-features = false, optional = true, package = "self_update", features = ["archive-zip", "compression-zip-deflate", "rustls"] }
-winapi = "~0.3"
+winapi = { version = "~0.3", features = ["consoleapi", "wincon"] }
 parselnk = "~0.1"
 
 [profile.release]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -262,6 +262,11 @@ pub fn check_is_python_2_or_shim(python: PathBuf) -> Result<PathBuf> {
 /// # Return value
 /// A reload handle will be returned so that we can change the log level at
 /// runtime.
+///
+/// Security note:
+/// To mitigate CVE-2025-58160 (ANSI escape sequence injection via logs),
+/// this project pins `tracing-subscriber` to 0.3.20. Do not downgrade.
+/// See: https://github.com/advisories/GHSA-xwfj-jgwm-7wp5
 pub fn install_tracing(filter_directives: &str) -> Result<Handle<EnvFilter, Registry>> {
     let env_filter = EnvFilter::try_new(filter_directives)
         .or_else(|_| EnvFilter::try_from_default_env())

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -262,11 +262,6 @@ pub fn check_is_python_2_or_shim(python: PathBuf) -> Result<PathBuf> {
 /// # Return value
 /// A reload handle will be returned so that we can change the log level at
 /// runtime.
-///
-/// Security note:
-/// To mitigate CVE-2025-58160 (ANSI escape sequence injection via logs),
-/// this project pins `tracing-subscriber` to 0.3.20. Do not downgrade.
-/// See: https://github.com/advisories/GHSA-xwfj-jgwm-7wp5
 pub fn install_tracing(filter_directives: &str) -> Result<Handle<EnvFilter, Registry>> {
     let env_filter = EnvFilter::try_new(filter_directives)
         .or_else(|_| EnvFilter::try_from_default_env())


### PR DESCRIPTION
## Summary
Updates `tracing-subscriber` to ~0.3.20 to address GHSA-xwfj-jgwm-7wp5, preventing ANSI escape sequence injection in logs. Also enables required `winapi` features on Windows to fix build issues (no behavior change).

## Changes
- Update `tracing-subscriber = ~0.3.20` (features: `env-filter`, `time`)
- Windows: enable `winapi` features (`consoleapi`, `wincon`) to resolve missing imports

## Testing
- Windows: cargo build successful
- Debian WSL: `cargo build --locked` successful; `topgrade --version` and `--help` run

## Compatibility
- No user-facing changes, no config/i18n changes
- Logging behavior unchanged

## Advisory
- https://github.com/advisories/GHSA-xwfj-jgwm-7wp5

## What does this PR do
Mitigates ANSI escape injection in logs by pinning `tracing-subscriber` to the fixed version and documents the rationale.

## Standards checklist
- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] Optional: I have tested the code myself
- [x] If this PR introduces new user-facing messages they are translated