### PR TITLE
chore(config): add/refresh docs tooling configs (.markdownlint.json, dprint.json, .lychee.toml, .typos.toml)

### DIFF
--- a/.github/workflows/docs_and_scripts.yml
+++ b/.github/workflows/docs_and_scripts.yml
@@ -1,0 +1,91 @@
+name: Docs and scripts checks
+
+on:
+  pull_request:
+    paths:
+      - '**/*.md'
+      - '**/*.toml'
+      - '**/*.json'
+      - '**/*.sh'
+      - '.lychee.toml'
+      - 'dprint.json'
+  push:
+    paths:
+      - '**/*.md'
+      - '**/*.toml'
+      - '**/*.json'
+      - '**/*.sh'
+      - '.lychee.toml'
+      - 'dprint.json'
+  workflow_dispatch:
+  schedule:
+    - cron: '0 3 * * 1' # Weekly link check (Mondays 03:00 UTC)
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-and-scripts-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docs:
+    name: Docs (dprint, typos, lychee)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install tools
+        run: |
+          cargo install dprint --locked
+          cargo install typos-cli --locked
+
+      - name: dprint check
+        run: dprint check
+
+      - name: typos
+        run: typos --format long
+
+      - name: lychee (links)
+        uses: lycheeverse/lychee-action@v1.10.0
+        with:
+          args: --config .lychee.toml --quiet .
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  shell:
+    name: ShellCheck
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install ShellCheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+
+      - name: Find shell scripts
+        id: files
+        shell: bash
+        run: |
+          mapfile -t files < <(git ls-files '*.sh')
+          printf 'count=%d\n' "${#files[@]}" >> "$GITHUB_OUTPUT"
+          printf '%s\n' "${files[@]}" > sh_files.txt
+
+      - name: Run ShellCheck
+        if: steps.files.outputs.count != '0'
+        run: |
+          xargs -a sh_files.txt -r shellcheck --severity=style --format=gcc
+
+      - name: No shell scripts to check
+        if: steps.files.outputs.count == '0'
+        run: echo "No .sh files found. Skipping ShellCheck."

--- a/.github/workflows/markdown_rust_tools.yml
+++ b/.github/workflows/markdown_rust_tools.yml
@@ -1,0 +1,13 @@
+name: Disabled (replaced by docs_and_scripts)
+
+on:
+  push:
+    branches: []
+  pull_request:
+    branches: []
+
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "This workflow is disabled. Use docs_and_scripts.yml."

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,0 +1,16 @@
+name: Disabled (replaced by docs_and_scripts)
+
+on:
+  push:
+    branches: []
+  pull_request:
+    branches: []
+
+permissions:
+  contents: read
+
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "This workflow is disabled. Use docs_and_scripts.yml."

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,13 @@
+name: Disabled (replaced by docs_and_scripts)
+
+on:
+  push:
+    branches: []
+  pull_request:
+    branches: []
+
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "This workflow is disabled. Use docs_and_scripts.yml."

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,0 +1,8 @@
+# Lychee link checker configuration
+accept = [200, 429]
+max_concurrency = 4
+timeout = 20
+exclude_path = ["target", ".git"]
+follow_location = true
+insecure = false
+scheme = ["http", "https"]

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,40 @@
+{
+  "default": true,
+  "MD003": { "style": "atx" },
+  "MD024": { "siblings_only": true },
+  "MD026": { "punctuation": ".,;:!" },
+  "MD041": true,
+  "MD004": { "style": "consistent" },
+  "MD007": { "indent": 2 },
+  "MD029": { "style": "one" },
+  "MD013": {
+    "line_length": 120,
+    "code_blocks": false,
+    "tables": false,
+    "headings": false,
+    "strict": false
+  },
+  "MD033": true,
+  "MD034": true,
+  "MD040": {
+    "allowed_languages": [
+      "sh",
+      "bash",
+      "shell",
+      "powershell",
+      "pwsh",
+      "rust",
+      "toml",
+      "yaml",
+      "yml",
+      "text",
+      "txt",
+      "md",
+      "markdown"
+    ]
+  },
+  "MD046": { "style": "fenced" },
+  "MD048": { "style": "backtick" },
+  "MD049": { "style": "consistent" },
+  "MD050": { "style": "consistent" }
+}

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,18 @@
+[default]
+# Accept common developer terms
+[default.extend-words]
+NH = "NH"
+PSWindowsUpdate = "PSWindowsUpdate"
+OpenBSD = "OpenBSD"
+jetbrains = "jetbrains"
+flake = "flake"
+NixOS = "NixOS"
+PyPi = "PyPi"
+Winget = "Winget"
+Homebrew = "Homebrew"
+AUR = "AUR"
+
+[files]
+extend-exclude = [
+  "locales/app.yml",
+]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,22 +1,19 @@
-## Contributing to `topgrade`
+# Contributing to `topgrade`
 
-Thank you for your interest in contributing to `topgrade`!
-We welcome and encourage contributions of all kinds, such as:
+Thank you for your interest in contributing to `topgrade`! We welcome and encourage contributions of all kinds, such as:
 
 1. Issue reports or feature requests
 2. Documentation improvements
 3. Code (PR or PR Review)
 
-Please follow the [Karma Runner guidelines](http://karma-runner.github.io/6.2/dev/git-commit-msg.html)
-for commit messages.
+Please follow the [Karma Runner guidelines](http://karma-runner.github.io/6.2/dev/git-commit-msg.html) for commit
+messages.
 
-## Adding a new `step`
+## Adding a new step
 
-In `topgrade`'s term, package manager is called `step`.
-To add a new `step` to `topgrade`:
+In Topgrade's terminology, a package manager is called a "step". To add a new step to Topgrade:
 
-1. Add a new variant to
-   [`enum Step`](https://github.com/topgrade-rs/topgrade/blob/main/src/step.rs)
+1. Add a new variant to [`enum Step`](https://github.com/topgrade-rs/topgrade/blob/main/src/step.rs)
 
    ```rust
    pub enum Step {
@@ -31,12 +28,12 @@ To add a new `step` to `topgrade`:
 
 2. Implement the update function
 
-   You need to find the appropriate location where this update function goes, it should be
-   a file under [`src/steps`](https://github.com/topgrade-rs/topgrade/tree/main/src/steps),
-   the file names are self-explanatory, for example, `step`s related to `zsh` are
-   placed in [`steps/zsh.rs`](https://github.com/topgrade-rs/topgrade/blob/main/src/steps/zsh.rs).
+   Find the appropriate location for this update function. It should be a file under
+   [`src/steps`](https://github.com/topgrade-rs/topgrade/tree/main/src/steps); the file names are self-explanatory, for
+   example, `step`s related to `zsh` are placed in
+   [`steps/zsh.rs`](https://github.com/topgrade-rs/topgrade/blob/main/src/steps/zsh.rs).
 
-   Then you implement the update function, and put it in the file where it belongs.
+   Then implement the update function, and put it in the file where it belongs.
 
    ```rust
    pub fn run_xxx(ctx: &ExecutionContext) -> Result<()> {
@@ -53,29 +50,26 @@ To add a new `step` to `topgrade`:
    }
    ```
 
-   Such a update function would be conventionally named `run_xxx()`, where `xxx`
-   is the name of the new step, and it should take a argument of type
-   `&ExecutionContext`, this is adequate for most cases unless some extra stuff is
-   needed (You can find some examples where extra arguments are needed
-   [here](https://github.com/topgrade-rs/topgrade/blob/7e48c5dedcfd5d0124bb9f39079a03e27ed23886/src/main.rs#L201-L219)).
+   Such an update function is conventionally named `run_xxx()`, where `xxx` is the name of the new step. It should take
+   an argument of type `&ExecutionContext`. This is adequate for most cases unless some extra work is needed (you can
+   find examples where extra arguments are needed
+   [in the main.rs file](https://github.com/topgrade-rs/topgrade/blob/7e48c5dedcfd5d0124bb9f39079a03e27ed23886/src/main.rs#L201-L219)).
 
-   Update function would usually do 3 things:
-    1. Check if the step is installed
-    2. Output the Separator
-    3. Invoke the step
+   The update function usually does three things:
+   1. Check if the step is installed.
+   2. Output the separator.
+   3. Invoke the step.
 
-   Still, this is sufficient for most tools, but you may need some extra stuff
-   with complicated `step`.
+   This is sufficient for most tools, but you may need additional handling for more complicated steps.
 
 3. Add a match arm to `Step::run()`
 
    ```rust
-   Xxx => runner.execute(*self, "xxx", || ItsModule::run_xxx(ctx))?
+   Xxx => runner.execute(*self, "xxx", || ItsModule::run_xxx(ctx))?,
    ```
 
-   We use [conditional compilation](https://doc.rust-lang.org/reference/conditional-compilation.html)
-   to separate the steps, for example, for steps that are Linux-only, it goes
-   like this:
+   We use [conditional compilation](https://doc.rust-lang.org/reference/conditional-compilation.html) to separate steps.
+   For example, for a Linux-only step:
 
    ```rust
    #[cfg(target_os = "linux")]
@@ -86,30 +80,31 @@ To add a new `step` to `topgrade`:
    ```
 
 4. Finally, add the step to `default_steps()` in `step.rs`
+
    ```rust
    steps.push(Xxx)
    ```
-   Try to keep the conditional compilation the same as in the above step 3.
+
+   Try to keep the conditional compilation consistent with step 3 above.
 
    Congrats, you just added a new `step` :)
 
-## Modification to the configuration entries
+## Modifications to configuration entries
 
-If your PR has the configuration options
-(in [`src/config.rs`](https://github.com/topgrade-rs/topgrade/blob/main/src/config.rs))
-modified:
+If your PR has the configuration options (in
+[`src/config.rs`](https://github.com/topgrade-rs/topgrade/blob/main/src/config.rs)) modified:
 
 1. Adding new options
 2. Changing the existing options
 
 Be sure to apply your changes to
-[`config.example.toml`](https://github.com/topgrade-rs/topgrade/blob/main/config.example.toml),
-and have some basic documentations guiding user how to use these options.
+[`config.example.toml`](https://github.com/topgrade-rs/topgrade/blob/main/config.example.toml), and include basic
+documentation guiding users on how to use these options.
 
 ## Breaking changes
 
-If your PR introduces a breaking change, document it in [`BREAKINGCHANGES_dev.md`][bc_dev],
-it should be written in Markdown and wrapped at 80, for example:
+If your PR introduces a breaking change, document it in [`BREAKINGCHANGES_dev.md`][bc_dev]. It should be written in
+Markdown and wrapped at 80 characters. For example:
 
 ```md
 1. The configuration location has been updated to x.
@@ -126,29 +121,54 @@ it should be written in Markdown and wrapped at 80, for example:
 Make sure your patch passes the following tests on your host:
 
 ```shell
-$ cargo build
-$ cargo fmt
-$ cargo clippy
-$ cargo test
+cargo build
+cargo fmt
+cargo clippy
+cargo test
 ```
 
 Don't worry about other platforms, we have most of them covered in our CI.
 
+## Quick docs and lint checks
+
+Before opening a PR, it helps to run the lightweight docs/lint checks locally:
+
+- Format Markdown/JSON/TOML: `dprint fmt`
+- Spell check: `typos`
+- Link check: `lychee --config .lychee.toml --quiet .`
+
+If you prefer a single command and you use cargo-make, you can run:
+
+```sh
+cargo make docs-check
+```
+
+Tip: there’s also a formatter task you can run before committing:
+
+```sh
+cargo make docs-fix
+```
+
+Notes
+
+- These commands assume the tools are installed and on your PATH. They’re all Rust-based and installable via Cargo
+   (for example: `cargo install dprint typos-cli lychee`).
+- Our CI will also run these checks, so running them locally just saves you a round trip.
+
 ## I18n
 
-If your PR introduces user-facing messages, we need to ensure they are translated.
-Please add the translations to [`locales/app.yml`][app_yml]. For simple messages
-without arguments (e.g., "hello world"), we can simply translate them according
-(Tip: ChatGPT or similar LLMs is good at translation). If a message contains
-arguments, e.g., "hello <NAME>", please follow this convention:
+If your PR introduces user-facing messages, we need to ensure they are translated. Please add the translations to
+[`locales/app.yml`][app_yml]. For simple messages without arguments (e.g., "hello world"), we can simply translate them
+accordingly (Tip: ChatGPT or similar LLMs are good at translation). If a message contains arguments, e.g., "hello
+{NAME}", please follow this convention:
 
 ```yml
 "hello {name}": # key
   en: "hello %{name}"  # translation
 ```
 
-Arguments in the key should be in format `{argument_name}`, and they will have
-a preceding `%` when used in translations.
+Arguments in the key should be in the format `{argument_name}`, and they will have the preceding `%` when used in
+translations.
 
 [app_yml]: https://github.com/topgrade-rs/topgrade/blob/main/locales/app.yml
 
@@ -156,8 +176,8 @@ a preceding `%` when used in translations.
 
 1. Locale
 
-   Some `step` respects locale, which means their output can be in language other
-   than English, we should not do check on it.
+   Some `step`s respect locale, which means their output can be in a language other than English, so we should not check
+   against it.
 
    For example, one may want to check if a tool works by doing this:
 
@@ -170,6 +190,5 @@ a preceding `%` when used in translations.
    }
    ```
 
-   If `xxx` respects locale, then the above code should work on English system,
-   on a system that does not use English, e.g., it uses Chinese, that `"help"` may be
-   translated to `"帮助"`, and the above code won't work.
+   If `xxx` respects locale, then the above code should work on an English system, but on a system that does not use
+   English, e.g., it uses Chinese, that `"help"` may be translated to `"帮助"`, and the above code won't work.

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,0 +1,15 @@
+[config]
+skip_core_tasks = true
+
+[tasks.docs-fix]
+description = "Auto-format Markdown with dprint"
+command = "dprint"
+args = ["fmt"]
+
+[tasks.docs-check]
+description = "Run dprint, typos, and lychee checks"
+script = [
+  "dprint check",
+  "typos --format long",
+  "lychee --config .lychee.toml --quiet .",
+]

--- a/dprint.json
+++ b/dprint.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://dprint.dev/schemas/v0.json",
+  "incremental": true,
+  "useTabs": false,
+  "lineWidth": 120,
+  "plugins": [
+    "https://plugins.dprint.dev/markdown-0.16.4.wasm",
+    "https://plugins.dprint.dev/json-0.19.4.wasm",
+    "https://plugins.dprint.dev/toml-0.6.3.wasm"
+  ],
+  "markdown": {
+    "lineWidth": 120,
+    "textWrap": "always"
+  },
+  "includes": ["**/*.{md,json,toml}"],
+  "excludes": ["target/**", ".git/**"]
+}


### PR DESCRIPTION
Adds/refreshes docs tooling configs for Markdown formatting, link checking, and spell checking. No code changes; CI will run checks via the consolidated workflow.