### PR TITLE
chore: fix simple typos in code and comments (split var, whether, Extensions)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -97,9 +97,9 @@ fn run() -> Result<()> {
     }
 
     for env in opt.env_variables() {
-        let mut splitted = env.split('=');
-        let var = splitted.next().unwrap();
-        let value = splitted.next().unwrap();
+        let mut parts = env.split('=');
+        let var = parts.next().unwrap();
+        let value = parts.next().unwrap();
         env::set_var(var, value);
     }
 

--- a/src/step.rs
+++ b/src/step.rs
@@ -309,7 +309,7 @@ impl Step {
             Gem => runner.execute(*self, "gem", || generic::run_gem(ctx))?,
             Ghcup => runner.execute(*self, "ghcup", || generic::run_ghcup_update(ctx))?,
             GitRepos => runner.execute(*self, "Git Repositories", || git::run_git_pull(ctx))?,
-            GithubCliExtensions => runner.execute(*self, "GitHub CLI Extenstions", || {
+            GithubCliExtensions => runner.execute(*self, "GitHub CLI Extensions", || {
                 generic::run_ghcli_extensions_upgrade(ctx)
             })?,
             GnomeShellExtensions =>

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -677,7 +677,7 @@ pub fn run_nix_helper(ctx: &ExecutionContext) -> Result<()> {
     };
 
     // We assume that if the user has set these variables, we can throw an error if nh cannot find
-    // a flake there. So we do not anymore perform an eval check to find out wether we should skip
+    // a flake there. So we do not anymore perform an eval check to find out whether we should skip
     // or not.
     #[cfg(target_os = "macos")]
     if darwin_flake_path.is_some() || fallback_flake_path.is_some() {


### PR DESCRIPTION
# What does this PR do

Fixes a few simple spelling issues in code and comments. No functional changes.

Changes

- `src/main.rs`: rename local variable for clarity — `splitted` → `parts`; use `parts.next()` for var/value extraction.
- `src/steps/os/unix.rs`: comment typo — `wether` → `whether`.
- `src/step.rs`: user-visible label typo — “GitHub CLI Extenstions” → “GitHub CLI Extensions”.

Intentionally not included

- No configuration, documentation, templates, or workflow changes.
- No formatting/tooling policy changes.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [ ] Optional: I have tested the code myself (N/A — no behavioral changes)
- [ ] If this PR introduces new user-facing messages they are translated (N/A)

## For new steps

- [ ] Optional: Topgrade skips this step where needed (N/A)
- [ ] Optional: The `--dry-run` option works with this step (N/A)
- [ ] Optional: The `--yes` option works with this step if it is supported by the underlying command (N/A)

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

## Local checks (per CONTRIBUTING)

- `cargo build` — PASS
- `cargo fmt` — N/A (no formatting changes)
- `cargo clippy` — N/A (no behavioral changes)
- `cargo test` — N/A (no tests affected)

## Relationship to other work

- This PR is code-only (typo fixes). The pre-commit typos configuration is proposed separately to avoid mixing policy and content changes: [chore/pre-commit-typos-excludes](https://github.com/niStee/topgrade/pull/new/chore/pre-commit-typos-excludes).
