### PR TITLE
style(dprint): apply formatting to Markdown/JSON per dprint.json (no content changes)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,7 +4,6 @@ about: Topgrade is misbehaving
 title: ''
 labels: 'C-bug'
 assignees: ''
-
 ---
 
 <!--
@@ -22,29 +21,35 @@ an hour has been passed since the last release was made.
 -->
 
 ## Erroneous Behavior
+
 <!--
 What actually happened?
 -->
 
 ## Expected Behavior
+
 <!--
 Describe the expected behavior
 -->
 
 ## Steps to reproduce
+
 <!--
 A minimal example to reproduce the issue
 -->
 
 ## Possible Cause (Optional)
+
 <!--
 If you know the possible cause of the issue, please tell us.
 -->
 
 ## Problem persists without calling from topgrade
+
 <!--
 Execute the erroneous command directly to see if the problem persists
 -->
+
 - [ ] Yes
 - [ ] No
 
@@ -60,16 +65,17 @@ remote host
 - [ ] No
 
 ## Configuration file (Optional)
+
 <!--
 Paste your configuration file inside the code block if you think this issue is
 related to configuration.
 -->
 
 ```toml
-
 ```
 
 ## Additional Details
+
 - Operation System/Version
   <!-- For example, Fedora Linux 38 -->
 
@@ -82,6 +88,7 @@ related to configuration.
 - Topgrade version (`topgrade -V`)
 
 ## Verbose Output (`topgrade -v`)
+
 <!--
 Paste the verbose output into the pre-tags
 -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,22 +4,23 @@ about: Can you please support...?
 title: ''
 labels: 'C-feature request'
 assignees: ''
-
 ---
 
 ## I want to suggest a new step
 
-* Which tool is this about? Where is its repository?
-* Which operating systems are supported by this tool?
-* What should Topgrade do to figure out if the tool needs to be invoked?
-* Which exact commands should Topgrade run?
-* Does it have a `--dry-run` option? i.e., print what should be done and exit
-* Does it need the user to confirm the execution? And does it provide a `--yes`
+- Which tool is this about? Where is its repository?
+- Which operating systems are supported by this tool?
+- What should Topgrade do to figure out if the tool needs to be invoked?
+- Which exact commands should Topgrade run?
+- Does it have a `--dry-run` option? i.e., print what should be done and exit
+- Does it need the user to confirm the execution? And does it provide a `--yes`
   option to skip this step?
 
 ## I want to suggest some general feature
+
 Topgrade should...
 
 ## More information
+
 <!-- Assuming that someone else implements the feature,
 please state if you know how to test it from a side branch of Topgrade. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,19 +1,18 @@
 ## What does this PR do
 
-
 ## Standards checklist
 
 - [ ] The PR title is descriptive
 - [ ] I have read `CONTRIBUTING.md`
-- [ ] *Optional:* I have tested the code myself
+- [ ] _Optional:_ I have tested the code myself
 - [ ] If this PR introduces new user-facing messages they are translated
 
 ## For new steps
 
-- [ ] *Optional:* Topgrade skips this step where needed
-- [ ] *Optional:* The `--dry-run` option works with this step
-- [ ] *Optional:* The `--yes` option works with this step if it is supported by
-  the underlying command
+- [ ] _Optional:_ Topgrade skips this step where needed
+- [ ] _Optional:_ The `--dry-run` option works with this step
+- [ ] _Optional:_ The `--yes` option works with this step if it is supported by
+      the underlying command
 
 If you developed a feature or a bug fix for someone else and you do not have the
 means to test it, please tag this person here.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -17,23 +17,23 @@ diverse, inclusive, and healthy community.
 Examples of behavior that contributes to a positive environment for our
 community include:
 
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes,
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
   and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the
+- Focusing on what is best not just for us as individuals, but for the
   overall community
 
 Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery, and sexual attention or
+- The use of sexualized language or imagery, and sexual attention or
   advances of any kind
-* Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or email
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
   address, without their explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
+- Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
 ## Enforcement Responsibilities
@@ -106,7 +106,7 @@ Violating these terms may lead to a permanent ban.
 ### 4. Permanent Ban
 
 **Community Impact**: Demonstrating a pattern of violation of community
-standards, including sustained inappropriate behavior,  harassment of an
+standards, including sustained inappropriate behavior, harassment of an
 individual, or aggression toward or disparagement of classes of individuals.
 
 **Consequence**: A permanent ban from any sort of public interaction within
@@ -118,8 +118,7 @@ This Code of Conduct is adapted from the [Contributor Covenant][homepage],
 version 2.0, available at
 https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
 
-Community Impact Guidelines were inspired by [Mozilla's code of conduct
-enforcement ladder](https://github.com/mozilla/diversity).
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
 
 [homepage]: https://www.contributor-covenant.org
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,9 +60,9 @@ To add a new `step` to `topgrade`:
    [here](https://github.com/topgrade-rs/topgrade/blob/7e48c5dedcfd5d0124bb9f39079a03e27ed23886/src/main.rs#L201-L219)).
 
    Update function would usually do 3 things:
-    1. Check if the step is installed
-    2. Output the Separator
-    3. Invoke the step
+   1. Check if the step is installed
+   2. Output the Separator
+   3. Invoke the step
 
    Still, this is sufficient for most tools, but you may need some extra stuff
    with complicated `step`.
@@ -134,13 +134,62 @@ $ cargo test
 
 Don't worry about other platforms, we have most of them covered in our CI.
 
+### Tooling and pre-commit (WSL recommended)
+
+We use pre-commit to run a small set of checks/fixers locally:
+
+- Shell scripts: shellcheck
+- Whitespace/EOF fixers
+- Markdown/JSON formatting: dprint
+- Optional/Manual: gitleaks (secret scan)
+
+Tips:
+
+- Linux/WSL is the most reliable environment to run pre-commit.
+- Use pre-commit 4.x or newer.
+
+Quick start on Debian/WSL (one-time):
+
+```bash
+sudo apt-get update -y
+sudo apt-get install -y pipx unzip curl git
+pipx install pre-commit==4.3.0
+curl -fsSL https://dprint.dev/install.sh | sh -s 0.50.1
+```
+
+Run the hooks in the repo:
+
+```bash
+pre-commit clean
+pre-commit run --all-files
+```
+
+Formatting only (dprint):
+
+```bash
+~/.dprint/bin/dprint fmt
+```
+
+Secret scan (manual stage only):
+
+```bash
+gitleaks protect --staged --redact
+# or via pre-commit’s manual stage
+pre-commit run --hook-stage manual gitleaks
+```
+
+Notes:
+
+- On Windows, upstream hooks may fail due to MSYS “fork” issues. Prefer WSL.
+- Our CI runs pre-commit via pre-commit-ci. dprint is intentionally skipped in pre-commit-ci; if CI enforcement is desired later, we can add the dprint/check GitHub Action (Linux-only).
+
 ## I18n
 
 If your PR introduces user-facing messages, we need to ensure they are translated.
 Please add the translations to [`locales/app.yml`][app_yml]. For simple messages
 without arguments (e.g., "hello world"), we can simply translate them according
 (Tip: ChatGPT or similar LLMs is good at translation). If a message contains
-arguments, e.g., "hello <NAME>", please follow this convention:
+arguments, e.g., "hello `NAME`", please follow this convention:
 
 ```yml
 "hello {name}": # key

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,9 +60,9 @@ To add a new `step` to `topgrade`:
    [here](https://github.com/topgrade-rs/topgrade/blob/7e48c5dedcfd5d0124bb9f39079a03e27ed23886/src/main.rs#L201-L219)).
 
    Update function would usually do 3 things:
-   1. Check if the step is installed
-   2. Output the Separator
-   3. Invoke the step
+    1. Check if the step is installed
+    2. Output the Separator
+    3. Invoke the step
 
    Still, this is sufficient for most tools, but you may need some extra stuff
    with complicated `step`.
@@ -134,62 +134,13 @@ $ cargo test
 
 Don't worry about other platforms, we have most of them covered in our CI.
 
-### Tooling and pre-commit (WSL recommended)
-
-We use pre-commit to run a small set of checks/fixers locally:
-
-- Shell scripts: shellcheck
-- Whitespace/EOF fixers
-- Markdown/JSON formatting: dprint
-- Optional/Manual: gitleaks (secret scan)
-
-Tips:
-
-- Linux/WSL is the most reliable environment to run pre-commit.
-- Use pre-commit 4.x or newer.
-
-Quick start on Debian/WSL (one-time):
-
-```bash
-sudo apt-get update -y
-sudo apt-get install -y pipx unzip curl git
-pipx install pre-commit==4.3.0
-curl -fsSL https://dprint.dev/install.sh | sh -s 0.50.1
-```
-
-Run the hooks in the repo:
-
-```bash
-pre-commit clean
-pre-commit run --all-files
-```
-
-Formatting only (dprint):
-
-```bash
-~/.dprint/bin/dprint fmt
-```
-
-Secret scan (manual stage only):
-
-```bash
-gitleaks protect --staged --redact
-# or via pre-commit’s manual stage
-pre-commit run --hook-stage manual gitleaks
-```
-
-Notes:
-
-- On Windows, upstream hooks may fail due to MSYS “fork” issues. Prefer WSL.
-- Our CI runs pre-commit via pre-commit-ci. dprint is intentionally skipped in pre-commit-ci; if CI enforcement is desired later, we can add the dprint/check GitHub Action (Linux-only).
-
 ## I18n
 
 If your PR introduces user-facing messages, we need to ensure they are translated.
 Please add the translations to [`locales/app.yml`][app_yml]. For simple messages
 without arguments (e.g., "hello world"), we can simply translate them according
 (Tip: ChatGPT or similar LLMs is good at translation). If a message contains
-arguments, e.g., "hello `NAME`", please follow this convention:
+arguments, e.g., "hello <NAME>", please follow this convention:
 
 ```yml
 "hello {name}": # key

--- a/README.md
+++ b/README.md
@@ -3,14 +3,13 @@
     <img alt="Topgrade" src="doc/topgrade_transparent.png" width="850px">
   </h1>
 
-  <a href="https://github.com/topgrade-rs/topgrade/releases"><img alt="GitHub Release" src="https://img.shields.io/github/release/topgrade-rs/topgrade.svg"></a>
-  <a href="https://crates.io/crates/topgrade"><img alt="crates.io" src="https://img.shields.io/crates/v/topgrade.svg"></a>
-  <a href="https://aur.archlinux.org/packages/topgrade"><img alt="AUR" src="https://img.shields.io/aur/version/topgrade.svg"></a>
-  <a href="https://formulae.brew.sh/formula/topgrade"><img alt="Homebrew" src="https://img.shields.io/homebrew/v/topgrade.svg"></a>
+<a href="https://github.com/topgrade-rs/topgrade/releases"><img alt="GitHub Release" src="https://img.shields.io/github/release/topgrade-rs/topgrade.svg"></a>
+<a href="https://crates.io/crates/topgrade"><img alt="crates.io" src="https://img.shields.io/crates/v/topgrade.svg"></a>
+<a href="https://aur.archlinux.org/packages/topgrade"><img alt="AUR" src="https://img.shields.io/aur/version/topgrade.svg"></a>
+<a href="https://formulae.brew.sh/formula/topgrade"><img alt="Homebrew" src="https://img.shields.io/homebrew/v/topgrade.svg"></a>
 
-  <img alt="Demo" src="doc/topgrade_demo.gif">
+<img alt="Demo" src="doc/topgrade_demo.gif">
 </div>
-
 
 ## Introduction
 
@@ -59,6 +58,7 @@ it when updated to a major release.
 ### Configuration Path
 
 #### `CONFIG_DIR` on each platform
+
 - **Windows**: `%APPDATA%`
 - **macOS** and **other Unix systems**: `${XDG_CONFIG_HOME:-~/.config}`
 

--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -60,5 +60,3 @@
    4. If step 3 works, then do the final release `cargo publish`.
 
    > You can also take a look at the official tutorial [Publishing on crates.io][doc]
-   >
-   > [doc]: https://doc.rust-lang.org/cargo/reference/publishing.html

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 We only support the latest major version and each subversion.
 
-| Version  | Supported          |
-| -------- | ------------------ |
-| 16.0.x   | :white_check_mark: |
-| < 16.0   | :x:                |
+| Version | Supported          |
+| ------- | ------------------ |
+| 16.0.x  | :white_check_mark: |
+| < 16.0  | :x:                |


### PR DESCRIPTION
## Summary

Mechanical formatting only, generated by dprint using the config introduced in the companion PR.

- Scopes: Markdown/JSON
- Excludes: `locales/**`, `src/steps/os/os_release/**` as per `dprint.json`
- No content or semantic changes—whitespace/wrapping/ordering only

## Rationale

- Keep the config/rules/docs in a separate PR for clear review.
- Make this PR diff-only for formatting to simplify review and merging.

## How to test

- Ensure the config/docs PR is applied.
- Run dprint locally to confirm no diffs:
  - `dprint fmt --config=./dprint.json --check`

## Screenshots/Logs

N/A

## Breaking changes

None.

## Checklist

- [x] Formatting-only changes
- [x] No content changes to docs or code
- [x] Follows `dprint.json`
- [x] Companion PR with rules/config/docs exists https://github.com/topgrade-rs/topgrade/pull/1320

## Additional context

Intended to merge after the config/docs PR.