### PR TITLE
ci(dprint): enforce dprint formatting on Linux (guarded, gates main job)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,34 @@ jobs:
           sort original.txt > sorted.txt
           diff original.txt sorted.txt
 
+  dprint:
+    name: dprint formatting check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5.0.0
+
+      - name: Check if dprint.json exists
+        id: cfg
+        run: |
+          if [ -f dprint.json ]; then
+            echo "present=true" >> $GITHUB_OUTPUT
+          else
+            echo "present=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Install dprint
+        if: steps.cfg.outputs.present == 'true'
+        run: |
+          curl -fsSL https://dprint.dev/install.sh | sh -s 0.50.0
+          echo "$HOME/.dprint/bin" >> $GITHUB_PATH
+
+      - name: Check formatting
+        if: steps.cfg.outputs.present == 'true'
+        run: dprint fmt --config=./dprint.json --check
+
   main:
-    needs: [ fmt, step-enum-sorted, step-match-sorted ]
+    needs: [ fmt, dprint, step-enum-sorted, step-match-sorted ]
     name: ${{ matrix.target_name }} (check, clippy)
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
## Summary

Add a Linux-only dprint formatting check to CI. The job is guarded on the presence of `dprint.json` and the main matrix job depends on it. This enforces Markdown/JSON formatting consistently without impacting Windows/macOS runners.

## Rationale

- Separation of concerns: CI enforcement lands separately from the hooks/config/docs PRs.
- Guarded behavior: before `dprint.json` exists, the job skips install/check and succeeds; once present, it enforces `dprint fmt --check`.
- Predictable: gates the main job via `needs`, so formatting drift fails PRs only when enforcement is intended.

## How to test

- On CI (Ubuntu): job "dprint formatting check" installs dprint 0.50.0 and runs `dprint fmt --config=./dprint.json --check` when `dprint.json` is present.
- Locally (Linux/WSL):
  - Install dprint (0.50.x)
  - Run `dprint fmt --config=./dprint.json --check`

## Screenshots/Logs

N/A

## Breaking changes

None.

## Checklist

- [x] Linux-only job; guarded on `dprint.json`
- [x] Main matrix job gated on `dprint`
- [x] No code changes; CI only
- [x] Aligns with CONTRIBUTING.md guidance
- [x] Intended merge order: after config/docs + formatting-only PRs

## Additional context

This keeps Windows contributors unblocked while ensuring formatting is enforced consistently on Linux CI.