### PR TITLE
use login shell when executing topgrade

### DIFF
--- a/src/steps/os/windows.rs
+++ b/src/steps/os/windows.rs
@@ -149,12 +149,12 @@ fn upgrade_wsl_distribution(wsl: &Path, dist: &str, ctx: &ExecutionContext) -> R
     //
     // ```rust
     // command
-    //  .args(["-d", dist, "bash", "-c"])
+    //  .args(["-d", dist, "bash", "-lc"])
     //  .arg(format!("TOPGRADE_PREFIX={dist} exec {topgrade}"));
     // ```
     //
     // creates a command string like:
-    // > `C:\WINDOWS\system32\wsl.EXE -d Ubuntu bash -c 'TOPGRADE_PREFIX=Ubuntu exec /bin/topgrade'`
+    // > `C:\WINDOWS\system32\wsl.EXE -d Ubuntu bash -lc 'TOPGRADE_PREFIX=Ubuntu exec /bin/topgrade'`
     //
     // Adding the following:
     //
@@ -163,7 +163,7 @@ fn upgrade_wsl_distribution(wsl: &Path, dist: &str, ctx: &ExecutionContext) -> R
     // ```
     //
     // appends the next argument like so:
-    // > `C:\WINDOWS\system32\wsl.EXE -d Ubuntu bash -c 'TOPGRADE_PREFIX=Ubuntu exec /bin/topgrade' -v`
+    // > `C:\WINDOWS\system32\wsl.EXE -d Ubuntu bash -lc 'TOPGRADE_PREFIX=Ubuntu exec /bin/topgrade' -v`
     // which means `-v` isn't passed to `topgrade`.
     let mut args = String::new();
     if ctx.config().verbose() {
@@ -171,7 +171,7 @@ fn upgrade_wsl_distribution(wsl: &Path, dist: &str, ctx: &ExecutionContext) -> R
     }
 
     command
-        .args(["-d", dist, "bash", "-c"])
+        .args(["-d", dist, "bash", "-lc"])
         .arg(format!("TOPGRADE_PREFIX={dist} exec {topgrade} {args}"));
 
     if ctx.config().yes(Step::Wsl) {


### PR DESCRIPTION
## What does this PR do

Closes #1097

Changes how topgrade is executed in the `WSL` step by making the shell a login shell.

When topgrade (in windows) searches for `topgrade` in wsl, it uses a login shell (`bash -lc ...`). When actually executing, it doesn't (`bash -c ...`). Because of that certain shell setup files are not loaded and topgrade (in wsl) cannot find / execute all steps.

## Standards checklist

- [X] The PR title is descriptive
- [X] I have read `CONTRIBUTING.md`
- [X] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated

## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
