### PR TITLE
Detect when running as root/elevated, and skip using sudo in this case

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1454,6 +1454,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
+name = "is_elevated"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5299060ff5db63e788015dcb9525ad9b84f4fd9717ed2cbdeba5018cbf42f9b5"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2883,6 +2892,7 @@ dependencies = [
  "glob",
  "home",
  "indexmap 2.9.0",
+ "is_elevated",
  "jetbrains-toolbox-updater",
  "merge",
  "nix 0.29.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,9 +78,10 @@ rust-ini = "~0.21"
 self_update_crate = { version = "~0.40", default-features = false, optional = true, package = "self_update", features = ["archive-tar", "compression-flate2", "rustls"] }
 
 [target.'cfg(windows)'.dependencies]
+is_elevated = "~0.1"
+parselnk = "~0.1"
 self_update_crate = { version = "~0.40", default-features = false, optional = true, package = "self_update", features = ["archive-zip", "compression-zip-deflate", "rustls"] }
 winapi = { version = "~0.3", features = ["consoleapi", "wincon"] }
-parselnk = "~0.1"
 
 [profile.release]
 lto = true

--- a/config.example.toml
+++ b/config.example.toml
@@ -6,6 +6,13 @@
 
 
 [misc]
+# On Unix systems, Topgrade should not be run as root, it
+# will run commands with sudo or equivalent where needed.
+# Set this to true to suppress the warning and confirmation
+# prompt if Topgrade detects it is being run as root.
+# (default: false)
+# allow_root = false
+
 # Run `sudo -v` to cache credentials at the start of the run
 # This avoids a blocking password prompt in the middle of an unattended run
 # (default: false)

--- a/locales/app.yml
+++ b/locales/app.yml
@@ -1120,6 +1120,24 @@ _version: 2
   zh_CN: "\n(R)重启\n(S)Shell\n(Q)退出"
   zh_TW: "\n(R)重新啟動\n(S)殼層\n(Q)退出"
   de: "\n(R) Neustarten\n(S)hell\n(Q)uit beenden"
+
+"Continue?":
+  en: "Continue?"
+  lt: "Tęsti?"
+  es: "¿Continuar?"
+  fr: "Continuer ?"
+  zh_CN: "继续？"
+  zh_TW: "繼續？"
+  de: "Fortfahren?"
+
+"Topgrade should not be run as root, it will run commands with sudo or equivalent where needed.":
+  en: "Topgrade should not be run as root, it will run commands with sudo or equivalent where needed."
+  lt: "Topgrade neturėtų būti paleistas kaip root, jis vykdys komandas su sudo ar atitikmeniu, kai to reikės."
+  es: "Topgrade no debe ejecutarse como root, ejecutará comandos con sudo o equivalente cuando sea necesario."
+  fr: "Topgrade ne doit pas être exécuté en tant que root, il exécutera les commandes avec sudo ou équivalent si nécessaire."
+  zh_CN: "Topgrade 不应以 root 身份运行，它会在需要时使用 sudo 或等效工具执行命令。"
+  zh_TW: "Topgrade 不應以 root 身份執行，它會在需要時使用 sudo 或等效工具執行命令。"
+  de: "Topgrade sollte nicht als Root ausgeführt werden, es führt Befehle mit sudo oder einem Äquivalent aus, wenn erforderlich."
 "Require sudo or counterpart but not found, skip":
   en: "Require sudo or counterpart but not found, skip"
   lt: "Reikalingas sudo arba atitikmuo, bet nerasta, praleidžiama"

--- a/src/config.rs
+++ b/src/config.rs
@@ -295,6 +295,8 @@ pub struct Vim {
 #[derive(Deserialize, Default, Debug, Merge)]
 #[serde(deny_unknown_fields)]
 pub struct Misc {
+    allow_root: Option<bool>,
+
     pre_sudo: Option<bool>,
 
     sudo_command: Option<SudoKind>,
@@ -766,6 +768,10 @@ pub struct CommandLineArgs {
     /// Show the reason for skipped steps
     #[arg(long = "show-skipped")]
     show_skipped: bool,
+
+    /// Suppress warning and confirmation prompt if running as root
+    #[arg(long = "allow-root")]
+    allow_root: bool,
 
     /// Tracing filter directives.
     ///
@@ -1533,6 +1539,16 @@ impl Config {
             .as_ref()
             .and_then(|windows| windows.winget_silent_install)
             .unwrap_or(true)
+    }
+
+    pub fn allow_root(&self) -> bool {
+        self.opt.allow_root
+            || self
+                .config_file
+                .misc
+                .as_ref()
+                .and_then(|misc| misc.allow_root)
+                .unwrap_or(false)
     }
 
     pub fn sudo_command(&self) -> Option<SudoKind> {

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -1081,7 +1081,7 @@ pub fn run_powershell(ctx: &ExecutionContext) -> Result<()> {
         // and Update-Module updates all modules regardless of their original installation scope
         powershell.build_command(ctx, &cmd, false)?.status_checked()
     } else {
-        // For (Windows) PowerShell, use sudo if available since it defaults to AllUsers scope
+        // For (Windows) PowerShell, use sudo since it defaults to AllUsers scope
         // and may need administrator privileges
         powershell.build_command(ctx, &cmd, true)?.status_checked()
     }

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -549,7 +549,7 @@ pub fn run_nix_self_upgrade(ctx: &ExecutionContext) -> Result<()> {
     let nix_args = nix_args();
     if multi_user {
         let sudo = ctx.require_sudo()?;
-        sudo.execute_opts(ctx, &nix, SudoExecuteOpts::new().interactive())?
+        sudo.execute_opts(ctx, &nix, SudoExecuteOpts::new().login_shell())?
             .args(nix_args)
             .arg("upgrade-nix")
             .status_checked()

--- a/src/steps/os/windows.rs
+++ b/src/steps/os/windows.rs
@@ -20,11 +20,9 @@ pub fn run_chocolatey(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("Chocolatey");
 
-    let mut command = match ctx.sudo() {
-        Some(sudo) => sudo.execute(ctx, &choco)?,
-        None => ctx.execute(choco),
-    };
+    let sudo = ctx.require_sudo()?;
 
+    let mut command = sudo.execute(ctx, &choco)?;
     command.args(["upgrade", "all"]);
 
     if yes {
@@ -42,10 +40,8 @@ pub fn run_winget(ctx: &ExecutionContext) -> Result<()> {
     ctx.execute(&winget).args(["source", "update"]).status_checked()?;
 
     let mut command = if ctx.config().winget_use_sudo() {
-        match ctx.sudo() {
-            Some(sudo) => sudo.execute(ctx, &winget)?,
-            None => ctx.execute(winget),
-        }
+        let sudo = ctx.require_sudo()?;
+        sudo.execute(ctx, &winget)?
     } else {
         ctx.execute(winget)
     };

--- a/src/steps/powershell.rs
+++ b/src/steps/powershell.rs
@@ -82,10 +82,11 @@ impl Powershell {
         cmd: &str,
         use_sudo: bool,
     ) -> Result<impl CommandExt + 'a> {
-        // if use_sudo and sudo is available, use it, otherwise run directly
-        let mut command = match ctx.sudo() {
-            Some(sudo) if use_sudo => sudo.execute(ctx, &self.path)?,
-            _ => ctx.execute(&self.path),
+        let mut command = if use_sudo {
+            let sudo = ctx.require_sudo()?;
+            sudo.execute(ctx, &self.path)?
+        } else {
+            ctx.execute(&self.path)
         };
 
         #[cfg(windows)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -169,6 +169,22 @@ pub fn hostname() -> Result<String> {
         .map(|output| output.stdout.trim().to_owned())
 }
 
+#[cfg(unix)]
+pub fn is_elevated() -> bool {
+    let euid = nix::unistd::Uid::effective();
+    debug!("Running with euid: {euid}");
+    euid.is_root()
+}
+
+#[cfg(windows)]
+pub fn is_elevated() -> bool {
+    let elevated = is_elevated::is_elevated();
+    if elevated {
+        debug!("Detected elevated process");
+    }
+    elevated
+}
+
 pub mod merge_strategies {
     use merge::Merge;
 


### PR DESCRIPTION
## What does this PR do

Adds a warning message if running as root, followed by a yes/no confirmation prompt.

Also adds a "null" sudo, which just runs the command directly. If Topgrade is running as root/elevated, this is used instead of calling `Sudo::detect()`.

On Windows, it doesn't print the warning, as running commands as Administrator usually doesn't cause the same kind of problems as on Unix systems. I've used the single-function `is_elevated` crate to do the elevated check here.

## Notes

- I haven't excluded the "null" sudo from being set in the config file, so you could use `sudo_command = "null"` to get the null sudo even when not running as administrator. Not sure why you'd ever want to do that, but maybe it could be useful somewhere.
- Also if a `sudo_command` is set in the config file, that is always used even when running as root/administrator. I wasn't sure whether to do it this way or have it override the config file.
- I also added a yes/no prompt after the "don't run as root" warning message. Should there be some way of skipping this prompt, a command-line flag maybe, or is that unnecessary? The prompt was mainly to give i.e. a first-time user the opportunity to quit before any steps are inadvertently run as root.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [x] If this PR introduces new user-facing messages they are translated

Closes #1114