### PR TITLE
Move step logic out of Powershell struct

### DIFF
--- a/src/steps/os/windows.rs
+++ b/src/steps/os/windows.rs
@@ -3,15 +3,16 @@ use std::{ffi::OsStr, process::Command};
 
 use color_eyre::eyre::Result;
 use etcetera::base_strategy::BaseStrategy;
+use rust_i18n::t;
 use tracing::debug;
 
 use crate::command::CommandExt;
+use crate::config::UpdatesAutoReboot;
 use crate::execution_context::ExecutionContext;
 use crate::step::Step;
 use crate::terminal::{print_separator, print_warning};
 use crate::utils::{require, which};
 use crate::{error::SkipStep, steps::git::RepoStep};
-use rust_i18n::t;
 
 pub fn run_chocolatey(ctx: &ExecutionContext) -> Result<()> {
     let choco = require("choco")?;
@@ -215,15 +216,27 @@ pub fn windows_update(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator(t!("Windows Update"));
 
-    if powershell.supports_windows_update() {
-        powershell.windows_update(ctx)
-    } else {
+    if !powershell.has_module("PSWindowsUpdate") {
         print_warning(t!(
             "The PSWindowsUpdate PowerShell module isn't installed so Topgrade can't run Windows Update.\nInstall PSWindowsUpdate by running `Install-Module PSWindowsUpdate` in PowerShell."
         ));
 
-        Err(SkipStep(t!("PSWindowsUpdate is not installed").to_string()).into())
+        return Err(SkipStep(t!("PSWindowsUpdate is not installed").to_string()).into());
     }
+
+    let mut cmd = "Import-Module PSWindowsUpdate; Install-WindowsUpdate -Verbose".to_string();
+
+    if ctx.config().accept_all_windows_updates() {
+        cmd.push_str(" -AcceptAll");
+    }
+
+    match ctx.config().windows_updates_auto_reboot() {
+        UpdatesAutoReboot::Yes => cmd.push_str(" -AutoReboot"),
+        UpdatesAutoReboot::No => cmd.push_str(" -IgnoreReboot"),
+        UpdatesAutoReboot::Ask => (), // Prompting is the default for Install-WindowsUpdate
+    }
+
+    powershell.build_command(ctx, &cmd, true)?.status_checked()
 }
 
 pub fn microsoft_store(ctx: &ExecutionContext) -> Result<()> {
@@ -231,7 +244,31 @@ pub fn microsoft_store(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator(t!("Microsoft Store"));
 
-    powershell.microsoft_store(ctx)
+    println!("{}", t!("Scanning for updates..."));
+
+    // Scan for updates using the MDM UpdateScanMethod
+    // This method is also available for non-MDM devices
+    let cmd = r#"(Get-CimInstance -Namespace "Root\cimv2\mdm\dmmap" -ClassName "MDM_EnterpriseModernAppManagement_AppManagement01" | Invoke-CimMethod -MethodName UpdateScanMethod).ReturnValue"#;
+
+    powershell
+        .build_command(ctx, cmd, true)?
+        .output_checked_with_utf8(|output| {
+            if !output.status.success() {
+                return Err(());
+            }
+            let ret_val = output.stdout.trim();
+            debug!("Command return value: {}", ret_val);
+            if ret_val == "0" {
+                Ok(())
+            } else {
+                Err(())
+            }
+        })?;
+    println!(
+        "{}",
+        t!("Success, Microsoft Store apps are being updated in the background")
+    );
+    Ok(())
 }
 
 pub fn reboot(ctx: &ExecutionContext) -> Result<()> {

--- a/src/steps/powershell.rs
+++ b/src/steps/powershell.rs
@@ -4,12 +4,10 @@ use std::process::Command;
 #[cfg(windows)]
 use color_eyre::eyre::eyre;
 use color_eyre::eyre::Result;
-use rust_i18n::t;
 use tracing::debug;
 
 use crate::command::CommandExt;
 use crate::execution_context::ExecutionContext;
-use crate::step::Step;
 use crate::terminal;
 use crate::utils::{which, PathExt};
 
@@ -56,8 +54,12 @@ impl Powershell {
         self.profile = profile;
     }
 
+    pub fn is_pwsh(&self) -> bool {
+        self.is_pwsh
+    }
+
     /// Builds an "internal" powershell command
-    fn build_command_internal(&self, cmd: &str) -> Command {
+    pub fn build_command_internal(&self, cmd: &str) -> Command {
         let mut command = Command::new(&self.path);
 
         command.args(["-NoProfile", "-Command"]);
@@ -74,7 +76,12 @@ impl Powershell {
 
     /// Builds a "primary" powershell command (uses dry-run if required):
     /// {powershell} -NoProfile -Command {cmd}
-    fn build_command<'a>(&self, ctx: &'a ExecutionContext, cmd: &str, use_sudo: bool) -> Result<impl CommandExt + 'a> {
+    pub fn build_command<'a>(
+        &self,
+        ctx: &'a ExecutionContext,
+        cmd: &str,
+        use_sudo: bool,
+    ) -> Result<impl CommandExt + 'a> {
         // if use_sudo and sudo is available, use it, otherwise run directly
         let mut command = match ctx.sudo() {
             Some(sudo) if use_sudo => sudo.execute(ctx, &self.path)?,
@@ -99,33 +106,8 @@ impl Powershell {
         Ok(command)
     }
 
-    pub fn update_modules(&self, ctx: &ExecutionContext) -> Result<()> {
-        let mut cmd = "Update-Module".to_string();
-
-        if ctx.config().verbose() {
-            cmd.push_str(" -Verbose");
-        }
-        if ctx.config().yes(Step::Powershell) {
-            cmd.push_str(" -Force");
-        }
-
-        println!("{}", t!("Updating modules..."));
-
-        if self.is_pwsh {
-            // For PowerShell Core, run Update-Module without sudo since it defaults to CurrentUser scope
-            // and Update-Module updates all modules regardless of their original installation scope
-            self.build_command(ctx, &cmd, false)?.status_checked()?;
-        } else {
-            // For (Windows) PowerShell, use sudo if available since it defaults to AllUsers scope
-            // and may need administrator privileges
-            self.build_command(ctx, &cmd, true)?.status_checked()?;
-        }
-
-        Ok(())
-    }
-
     #[cfg(windows)]
-    pub fn execution_policy_args_if_needed(&self) -> Result<()> {
+    fn execution_policy_args_if_needed(&self) -> Result<()> {
         if !self.is_execution_policy_set("RemoteSigned") {
             Err(eyre!(
                 "PowerShell execution policy is too restrictive. \
@@ -163,66 +145,14 @@ impl Powershell {
             }
         })
     }
-}
 
-#[cfg(windows)]
-impl Powershell {
-    fn has_module(&self, module_name: &str) -> bool {
+    #[cfg(windows)]
+    pub fn has_module(&self, module_name: &str) -> bool {
         let cmd = format!("Get-Module -ListAvailable {}", module_name);
 
         self.build_command_internal(&cmd)
             .output_checked()
             .map(|output| !output.stdout.trim_ascii().is_empty())
             .unwrap_or(false)
-    }
-
-    pub fn supports_windows_update(&self) -> bool {
-        self.has_module("PSWindowsUpdate")
-    }
-
-    pub fn windows_update(&self, ctx: &ExecutionContext) -> Result<()> {
-        use crate::config::UpdatesAutoReboot;
-
-        debug_assert!(self.supports_windows_update());
-
-        let mut cmd = "Import-Module PSWindowsUpdate; Install-WindowsUpdate -Verbose".to_string();
-
-        if ctx.config().accept_all_windows_updates() {
-            cmd.push_str(" -AcceptAll");
-        }
-
-        match ctx.config().windows_updates_auto_reboot() {
-            UpdatesAutoReboot::Yes => cmd.push_str(" -AutoReboot"),
-            UpdatesAutoReboot::No => cmd.push_str(" -IgnoreReboot"),
-            UpdatesAutoReboot::Ask => (), // Prompting is the default for Install-WindowsUpdate
-        }
-
-        self.build_command(ctx, &cmd, true)?.status_checked()
-    }
-
-    pub fn microsoft_store(&self, ctx: &ExecutionContext) -> Result<()> {
-        println!("{}", t!("Scanning for updates..."));
-
-        // Scan for updates using the MDM UpdateScanMethod
-        // This method is also available for non-MDM devices
-        let cmd = r#"(Get-CimInstance -Namespace "Root\cimv2\mdm\dmmap" -ClassName "MDM_EnterpriseModernAppManagement_AppManagement01" | Invoke-CimMethod -MethodName UpdateScanMethod).ReturnValue"#;
-
-        self.build_command(ctx, cmd, true)?.output_checked_with_utf8(|output| {
-            if !output.status.success() {
-                return Err(());
-            }
-            let ret_val = output.stdout.trim();
-            debug!("Command return value: {}", ret_val);
-            if ret_val == "0" {
-                Ok(())
-            } else {
-                Err(())
-            }
-        })?;
-        println!(
-            "{}",
-            t!("Success, Microsoft Store apps are being updated in the background")
-        );
-        Ok(())
     }
 }


### PR DESCRIPTION
## What does this PR do

Some simple refactoring, moving the step logic out of `Powershell` and into the respective calling functions under `steps/*`. I think it's cleaner this way, `Powershell` is then just a wrapper for running PowerShell commands, rather than having step logic that just uses PowerShell to run commands but don't have much to do with PowerShell itself.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself