### PR TITLE
chore(pyproject): mark version as dynamic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "topgrade"
+dynamic = ["version"]
 requires-python = ">=3.7"
 classifiers = [
     "Programming Language :: Rust",


### PR DESCRIPTION
## What does this PR do

- mark the Python wheel version as dynamic so maturin reads the package version from Cargo metadata
- confirmed `cargo fmt`, `cargo clippy`, and `cargo test` pass locally

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated

## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by the underlying command

_No new steps were added in this change._