### PR TITLE
Fix WSL distribution name cleanup

### DIFF
--- a/src/steps/os/windows.rs
+++ b/src/steps/os/windows.rs
@@ -122,8 +122,8 @@ fn get_wsl_distributions(wsl: &Path) -> Result<Vec<String>> {
     let output = Command::new(wsl).args(["--list", "-q"]).output_checked_utf8()?.stdout;
     Ok(output
         .lines()
+        .map(|x| x.replace(['\u{0}', '\r'], "").trim().to_owned())
         .filter(|s| !s.is_empty())
-        .map(|x| x.replace(['\u{0}', '\r'], ""))
         .collect())
 }
 


### PR DESCRIPTION
## Summary
- trim WSL distribution names before running topgrade
- filter out empty entries from wsl --list output

Fixes topgrade-rs/topgrade#1136