### PR TITLE
fix(containers):  Docker update fails on M Macs due to platform /

### DIFF
--- a/src/steps/containers.rs
+++ b/src/steps/containers.rs
@@ -142,12 +142,12 @@ pub fn run_containers(ctx: &ExecutionContext) -> Result<()> {
 
     for container in &containers {
         debug!("Pulling container '{}'", container);
-        let args = vec![
-            "pull",
-            container.repo_tag.as_str(),
-            "--platform",
-            container.platform.as_str(),
-        ];
+        let mut args = vec!["pull", container.repo_tag.as_str()];
+        if container.platform.as_str() != "/" {
+            args.push("--platform");
+            args.push(container.platform.as_str());
+        }
+
         let mut exec = ctx.execute(&crt);
 
         if let Err(e) = exec.args(&args).status_checked() {


### PR DESCRIPTION
## What does this PR do

Suppresses the `--platform` parameter to docker pull if platform is only '/'.

This is my first Rust code contribution. I hope it's ok. 
I couldn't find unit tests for the containers.rs file. If there are any, please point me to them.

fixes #1154

## Standards checklist

- [ ] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated

## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
