### PR TITLE
ci: update pre-commit typos hook stages

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,20 @@
 repos:
-- repo: https://github.com/gitleaks/gitleaks
-  rev: v8.16.3
-  hooks:
-  - id: gitleaks
-- repo: https://github.com/shellcheck-py/shellcheck-py
-  rev: v0.10.0.1
-  hooks:
-  - id: shellcheck
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
-  hooks:
-  - id: end-of-file-fixer
-  - id: trailing-whitespace
-  
-- repo: https://github.com/crate-ci/typos
-  rev: v1.36.2
-  hooks:
-  - id: typos
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.16.3
+    hooks:
+      - id: gitleaks
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.36.2
+    hooks:
+      - id: typos
+        stages: [pre-commit, pre-push]


### PR DESCRIPTION
## What does this PR do

- align the typos hook stage list with supported values so pre-commit 4.x runs cleanly
- keep 	ypos on commit/push stages to match earlier behaviour

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read CONTRIBUTING.md
- [x] *Optional:* I have tested the code myself (pre-commit run --all-files)
- [ ] If this PR introduces new user-facing messages they are translated

## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The --dry-run option works with this step
- [ ] *Optional:* The --yes option works with this step if it is supported by the underlying command
