### PR TITLE
feat(nix): support upgrading Determinate Nix

### DIFF
--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -567,18 +567,17 @@ pub fn run_nix_self_upgrade(ctx: &ExecutionContext) -> Result<()> {
 
     if is_determinate_nix {
         let nixd = require("determinate-nixd");
-
         let nixd = match nixd {
-        	Err(_) => {
-            	println!("Found Determinate Nix, but could not find determinate-nixd");
-            	return Err(StepFailed.into());
-        	}
-        	Ok(nixd) => nixd,
+            Err(_) => {
+                println!("Found Determinate Nix, but could not find determinate-nixd");
+                return Err(StepFailed.into());
+            }
+            Ok(nixd) => nixd,
         };
 
         let sudo = ctx.require_sudo()?;
         return sudo
-            .execute_opts(ctx, nixd.unwrap(), SudoExecuteOpts::new().login_shell())?
+            .execute_opts(ctx, nixd, SudoExecuteOpts::new().login_shell())?
             .arg("upgrade")
             .status_checked();
     }


### PR DESCRIPTION
## What does this PR do

Add support for upgrading [Determinate Nix][1] on macOS.

[Upgrading Determinate Nix][2] works a little bit different than upgrading vanilla Nix and running `nix upgrade-nix` will print the following error message and exit with a non-zero exit code:

> ```
> error: The upgrade-nix command isn't available in Determinate Nix; use sudo determinate-nixd upgrade instead
> ```

This change set checks if `nix` is in fact Determinate Nix and in this case will run `sudo determinate-nixd upgrade` instead of `nix upgrade-nix`.

[1]: https://determinate.systems/nix/
[2]: https://docs.determinate.systems/determinate-nix/#determinate-nixd-upgrade

### Example

```text
# topgrade --only nix --verbose
[...]

── 19:45:09 - Nix ──────────────────────────────────────────────────────────────
DEBUG Executing command `/nix/var/nix/profiles/default/bin/nix-channel --update`
warning: nix-channel is deprecated in favor of flakes in Determinate Nix. See https://zero-to-nix.com for a guide to Nix flakes. For details and to offer feedback on the deprecation process, see: https://github.com/DeterminateSystems/nix-src/issues/34.
unpacking 1 channels...
DEBUG Executing command `/nix/var/nix/profiles/default/bin/nix --version`
DEBUG `nix --version` output output=nix (Determinate Nix 3.11.3) 2.31.2
 is_lix=false
DEBUG Raw Nix version: 2.31.2
DEBUG Corrected raw Nix version: 2.31.2
DEBUG Nix version: Version { major: 2, minor: 31, patch: 2 }
DEBUG Executing command `/nix/var/nix/profiles/default/bin/nix-env --upgrade`
DEBUG Step "nix upgrade-nix"
DEBUG Detected "/nix/var/nix/profiles/default/bin/nix" as "nix"
DEBUG Found Nix in "/nix/var/nix/profiles/default"
DEBUG Found Nix profile "/nix/store/fk1gcq0ccqvlkgigj3wn8d60xhmlbni5-user-environment"

── 19:45:19 - Nix (self-upgrade) ──────────────────────────────────────
DEBUG Executing command `/nix/var/nix/profiles/default/bin/nix --version`
DEBUG `nix --version` output output=nix (Determinate Nix 3.11.3) 2.31.2
 is_determinate_nix=true
DEBUG Detected "/usr/local/bin/determinate-nixd" as "determinate-nixd"
DEBUG Executing command `/usr/bin/sudo -i /usr/local/bin/determinate-nixd upgrade`
You are already running the latest version of Determinate Nix (3.11.3).

── 19:45:19 - Summary ──────────────────────────────────────────────────
nix: OK
nix upgrade-nix: OK
```

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself