### PR TITLE
fix(tldr): move tldr to be a generic step

### DIFF
--- a/src/step.rs
+++ b/src/step.rs
@@ -603,11 +603,7 @@ impl Step {
                 #[cfg(target_os = "openbsd")]
                 runner.execute(*self, "OpenBSD Upgrade", || openbsd::upgrade_openbsd(ctx))?
             }
-            Tldr =>
-            {
-                #[cfg(unix)]
-                runner.execute(*self, "TLDR", || unix::run_tldr(ctx))?
-            }
+            Tldr => runner.execute(*self, "TLDR", || generic::run_tldr(ctx))?,
             Tlmgr => runner.execute(*self, "tlmgr", || generic::run_tlmgr_update(ctx))?,
             Tmux =>
             {
@@ -762,7 +758,6 @@ pub(crate) fn default_steps() -> Vec<Step> {
         BunPackages,
         Shell,
         Tmux,
-        Tldr,
         Pearl,
         #[cfg(not(any(target_os = "macos", target_os = "android")))]
         GnomeShellExtensions,
@@ -812,6 +807,7 @@ pub(crate) fn default_steps() -> Vec<Step> {
         Pipupgrade,
         Ghcup,
         Stack,
+        Tldr,
         Tlmgr,
         Myrepos,
         Chezmoi,

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -858,6 +858,14 @@ pub fn run_ghcup_update(ctx: &ExecutionContext) -> Result<()> {
     ctx.execute(ghcup).arg("upgrade").status_checked()
 }
 
+pub fn run_tldr(ctx: &ExecutionContext) -> Result<()> {
+    let tldr = require("tldr")?;
+
+    print_separator("TLDR");
+
+    ctx.execute(tldr).arg("--update").status_checked()
+}
+
 pub fn run_tlmgr_update(ctx: &ExecutionContext) -> Result<()> {
     cfg_if::cfg_if! {
         if #[cfg(any(target_os = "linux", target_os = "android"))] {

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -814,13 +814,6 @@ pub fn run_home_manager(ctx: &ExecutionContext) -> Result<()> {
     cmd.status_checked()
 }
 
-pub fn run_tldr(ctx: &ExecutionContext) -> Result<()> {
-    let tldr = require("tldr")?;
-
-    print_separator("TLDR");
-    ctx.execute(tldr).arg("--update").status_checked()
-}
-
 pub fn run_pearl(ctx: &ExecutionContext) -> Result<()> {
     let pearl = require("pearl")?;
     print_separator("pearl");


### PR DESCRIPTION
## What does this PR do

Currently, `tldr` updates are only run on Unix systems. `tldr` can be installed under Windows and has the same command for updating.
To reflect that, I moved the `run_tldr` function to the `generic` module and made the necessary changes in the `step` module.

I didn't link any issue for this, because I couldn't find any.

## Standards checklist

- [X] The PR title is descriptive
- [X] I have read `CONTRIBUTING.md`
- [X] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated

## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
