### PR TITLE
chore(pre-commit): Make pre-commit.ci use conventional commits

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,7 @@ repos:
   rev: v1.38.1
   hooks:
   - id: typos
+
+
+ci:
+  autoupdate_commit_msg: "chore(pre-commit): autoupdate"


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos