### PR TITLE
ci: add Zizmor pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,11 @@ repos:
   hooks:
   - id: typos
 
+- repo: https://github.com/zizmorcore/zizmor-pre-commit
+  rev: v1.16.3
+  hooks:
+  - id: zizmor
+    args: ['--persona=auditor', '--no-progress']
 
 ci:
   autoupdate_commit_msg: "chore(pre-commit): autoupdate"


### PR DESCRIPTION
Zizmor can flag many common security issues using static analysis of CI workflows. See https://docs.zizmor.sh/ for documentation.