### PR TITLE
ci: apply principle of least privilege to github token permissions

### DIFF
--- a/.github/workflows/create_release_assets.yml
+++ b/.github/workflows/create_release_assets.yml
@@ -2,11 +2,10 @@ name: Publish release files for CD native and non-cd-native environments
 
 on:
   repository_dispatch:
-    types: [ release-created ]
+    types: [release-created]
 
 permissions:
-  # Write permissions to call the repository dispatch
-  contents: write
+  contents: read
 
 jobs:
   # Publish release files for CD native environments
@@ -24,7 +23,7 @@ jobs:
         # Use the Ubuntu 22.04 image to link with a low version of glibc
         #
         # https://github.com/topgrade-rs/topgrade/issues/1095
-        platform: [ ubuntu-22.04, macos-latest, macos-15-intel, windows-latest ]
+        platform: [ubuntu-22.04, macos-latest, macos-15-intel, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v5.0.0
@@ -122,8 +121,7 @@ jobs:
         shell: bash
 
       - name: Upload assets
-        run:
-          gh release upload "${{ github.event.client_payload.tag }}" assets/*
+        run: gh release upload "${{ github.event.client_payload.tag }}" assets/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -261,10 +259,8 @@ jobs:
         if: ${{ matrix.target == 'aarch64-unknown-linux-gnu' || matrix.target == 'armv7-unknown-linux-gnueabihf' }}
         shell: bash
 
-
       - name: Upload assets
-        run:
-          gh release upload "${{ github.event.client_payload.tag }}" assets/*
+        run: gh release upload "${{ github.event.client_payload.tag }}" assets/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -275,7 +271,7 @@ jobs:
 
   triggers:
     runs-on: ubuntu-latest
-    needs: [ native_build, cross_build ]
+    needs: [native_build, cross_build]
     steps:
       - name: Trigger workflows
         run: |

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -5,8 +5,10 @@ on:
     branches:
       - main
 
-jobs:
+permissions:
+  contents: read
 
+jobs:
   # Release unpublished packages.
   release-plz-release:
     name: Release-plz release
@@ -14,7 +16,7 @@ jobs:
     environment: crates_io
     permissions:
       contents: write
-      id-token: write  # For trusted publishing
+      id-token: write # For trusted publishing
     steps:
       - &checkout
         name: Checkout repository

--- a/.github/workflows/release_to_pypi.yml
+++ b/.github/workflows/release_to_pypi.yml
@@ -2,7 +2,7 @@ name: Update PyPi
 
 on:
   repository_dispatch:
-    types: [ release-created ]
+    types: [release-created]
 
 permissions:
   contents: read
@@ -84,10 +84,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [linux, windows, macos, sdist]
     permissions:
-      # Use to sign the release artifacts
+      # Use to sign the release artifacts (PyPI trusted publishing)
       id-token: write
-      # Used to upload release artifacts
-      contents: write
       # Used to generate artifact attestation
       attestations: write
     steps:
@@ -96,7 +94,7 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v3.0.0
         with:
-          subject-path: 'wheels-*/*'
+          subject-path: "wheels-*/*"
 
       - name: Publish to PyPI
         uses: PyO3/maturin-action@86b9d133d34bc1b40018696f782949dac11bd380 # v1.49.4


### PR DESCRIPTION
## What does this PR do

This PR improves the security posture of GitHub Actions workflows by implementing the **Principle of Least Privilege (PoLP)** for GitHub Token permissions. It addresses multiple GitHub Scorecard security violations related to overprivileged token permissions.

### Changes Made

- **release-plz.yml**: Added workflow-level `permissions: contents: read` (was missing, causing Scorecard violations)
- **release_to_pypi.yml**: Removed unnecessary `contents: write` from the release job (job only publishes to PyPI via trusted publishing, doesn't upload to GitHub Releases)
- **create_release_assets.yml**: Changed workflow-level from `permissions: contents: write` to `permissions: contents: read` (jobs escalate permissions only when needed)

### Security Improvement

These changes implement security best practices:
- **Workflow-level permissions** default to minimal access (read)
- **Individual jobs** override with write permissions **only when necessary**
- Significantly **reduces attack surface** if credentials are compromised
- Aligns with GitHub's security recommendations and Scorecard guidelines

### Addresses

- GitHub Scorecard Token-Permissions violations (all 6 instances)
- Job-level `contents: write` overprivilege issue

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] I have tested the code myself (pre-commit validation passed in WSL)
- [x] All pre-commit hooks passed:
  - ✅ Detect hardcoded secrets (gitleaks)
  - ✅ shellcheck
  - ✅ fix end of files
  - ✅ trim trailing whitespace
  - ✅ typos

## Testing

Pre-commit validation was run from WSL (as documented in copilot-instructions.md) and all checks passed successfully.
