### PR TITLE
ci: don't persist credentials in actions/checkout

### DIFF
--- a/.github/workflows/check_config_creation_if_not_exists.yml
+++ b/.github/workflows/check_config_creation_if_not_exists.yml
@@ -16,6 +16,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5.0.0
+        with:
+          persist-credentials: false
+
       - run: |
           CONFIG_PATH=~/.config/topgrade.toml;
           if [ -f "$CONFIG_PATH" ]; then rm $CONFIG_PATH; fi

--- a/.github/workflows/check_i18n.yml
+++ b/.github/workflows/check_i18n.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Install checker
         # Build it with the dev profile as this is faster and the checker still works

--- a/.github/workflows/check_security_vulnerability.yml
+++ b/.github/workflows/check_security_vulnerability.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Run DevSkim scanner
         uses: microsoft/DevSkim-Action@4b5047945a44163b94642a1cecc0d93a3f428cc6 # v1.0.16

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Run cargo fmt
         env:
@@ -34,6 +36,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Check if `Step` enum is sorted
         run: |
@@ -125,6 +129,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup Rust Cache
         uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1

--- a/.github/workflows/create_release_assets.yml
+++ b/.github/workflows/create_release_assets.yml
@@ -28,6 +28,8 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Install needed components
         run: |
@@ -158,6 +160,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Install needed components
         run: |

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -18,5 +18,8 @@ jobs:
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@v5.0.0
+        with:
+          persist-credentials: false
+
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@40c09b7dc99638e5ddb0bfd91c1673effc064d8a # v4.8.1

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -16,14 +16,12 @@ jobs:
       contents: write
       id-token: write  # For trusted publishing
     steps:
-      - &checkout
-        name: Checkout repository
+      - name: Checkout repository
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
           persist-credentials: false
-      - &install-rust
-        name: Install Rust toolchain
+      - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Run release-plz
         id: release-plz
@@ -53,8 +51,13 @@ jobs:
       group: release-plz-${{ github.ref }}
       cancel-in-progress: false
     steps:
-      - *checkout
-      - *install-rust
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
       - name: Run release-plz
         uses: release-plz/action@v0.5
         with:

--- a/.github/workflows/release_to_pypi.yml
+++ b/.github/workflows/release_to_pypi.yml
@@ -16,6 +16,9 @@ jobs:
         target: [x86_64, x86, aarch64]
     steps:
       - uses: actions/checkout@v5.0.0
+        with:
+          persist-credentials: false
+
       - name: Build wheels
         uses: PyO3/maturin-action@86b9d133d34bc1b40018696f782949dac11bd380 # v1.49.4
         with:
@@ -35,6 +38,9 @@ jobs:
         target: [x64, x86]
     steps:
       - uses: actions/checkout@v5.0.0
+        with:
+          persist-credentials: false
+
       - name: Build wheels
         uses: PyO3/maturin-action@86b9d133d34bc1b40018696f782949dac11bd380 # v1.49.4
         with:
@@ -53,6 +59,9 @@ jobs:
         target: [x86_64, aarch64]
     steps:
       - uses: actions/checkout@v5.0.0
+        with:
+          persist-credentials: false
+
       - name: Build wheels
         uses: PyO3/maturin-action@86b9d133d34bc1b40018696f782949dac11bd380 # v1.49.4
         with:
@@ -68,6 +77,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5.0.0
+        with:
+          persist-credentials: false
+
       - name: Build sdist
         uses: PyO3/maturin-action@86b9d133d34bc1b40018696f782949dac11bd380 # v1.49.4
         with:


### PR DESCRIPTION
Setting `persist-credentials: false` helps mitigate the risk of accidental leakage of GitHub actions tokens in artifacts. See https://docs.zizmor.sh/audits/#artipacked for details.

Also remove YAML anchors from `release-plz.yml`, since they increase the complexity of static analysis and interfere with Zizmor.