### PR TITLE
ci: set dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: cargo
     directory: "/"
@@ -22,3 +24,5 @@ updates:
     groups:
       cargo-minor-patch:
         update-types: ["minor", "patch"]
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
This delays dependabot updates until 7 days after the dependency is updated, which is beneficial for stability and supply-chain security. See https://docs.zizmor.sh/audits/#dependabot-cooldown for more info.