### PR TITLE
fix(vim): change nvimrc base_dir for windows

### DIFF
--- a/locales/app.yml
+++ b/locales/app.yml
@@ -958,6 +958,14 @@ _version: 2
   zh_CN: "拉取 %{repo}"
   zh_TW: "拉取 %{repo}"
   de: "Würde %{repo} abrufen"
+"No Neovim config found":
+  en: "No Neovim config found"
+  lt: "Neovim konfigūracija nerasta"
+  es: "No se encontró ninguna configuración de Neovim"
+  fr: "Aucune configuration Neovim trouvée"
+  zh_CN: "未找到 Neovim 配置"
+  zh_TW: "未找到 Neovim 配置"
+  de: "Keine Neovim-Konfiguration gefunden"
 "Node Package Manager":
   en: "Node Package Manager"
   lt: "Node paketų tvarkyklė (npm)"


### PR DESCRIPTION
## What does this PR do

Closes #1091

Adds manual checking of the `XDG_CONFIG_HOME` variable when searching for nvim on windows.

Previously, the etcetera Windows strategy was used directly to get the config dir for nvim under Windows. Since XDG is not an official standard on Windows, the Windows strategy doesn't check these variables. Nvim on the other hand respects XDG even on Windows. Because of that, it can happen that the nvim config is not found under Windows.

## Standards checklist

- [X] The PR title is descriptive
- [X] I have read `CONTRIBUTING.md`
- [X] *Optional:* I have tested the code myself
- [X] If this PR introduces new user-facing messages they are translated

## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
