### PR TITLE
feat: run pre_sudo before pre_commands

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1607,8 +1607,7 @@ impl Config {
         self.config_file.misc.as_ref().and_then(|misc| misc.sudo_command)
     }
 
-    /// If `true`, `sudo` should be called after `pre_commands` in order to elevate at the
-    /// start of the session (and not in the middle).
+    /// If `true`, `sudo -v` should be called to cache credentials at the start of the run
     pub fn pre_sudo(&self) -> bool {
         self.config_file
             .misc

--- a/src/main.rs
+++ b/src/main.rs
@@ -206,15 +206,15 @@ fn run() -> Result<()> {
         None
     };
 
-    if let Some(commands) = config.pre_commands() {
-        for (name, command) in commands {
-            generic::run_custom_command(name, command, &ctx)?;
-        }
-    }
-
     if config.pre_sudo() {
         if let Some(sudo) = ctx.sudo() {
             sudo.elevate(&ctx)?;
+        }
+    }
+
+    if let Some(commands) = config.pre_commands() {
+        for (name, command) in commands {
+            generic::run_custom_command(name, command, &ctx)?;
         }
     }
 


### PR DESCRIPTION
## What does this PR do

Reorder to run `sudo -v` or equivalent before pre_commands, so that they will not prompt if they need sudo.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated
