### PR TITLE
refactor: Replace main's self update with a proper step call

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -187,17 +187,7 @@ fn run() -> Result<()> {
         }
     }
 
-    // Self-Update step, this will execute only if:
-    // 1. the `self-update` feature is enabled
-    // 2. it is not disabled from configuration (env var/CLI opt/file)
-    #[cfg(feature = "self-update")]
-    {
-        let should_self_update = env::var("TOPGRADE_NO_SELF_UPGRADE").is_err() && !config.no_self_update();
-
-        if should_self_update {
-            runner.execute(step::Step::SelfUpdate, "Self Update", || self_update::self_update(&ctx))?;
-        }
-    }
+    step::Step::SelfUpdate.run(&mut runner, &ctx)?;
 
     #[cfg(windows)]
     let _self_rename = if config.self_rename() {

--- a/src/step.rs
+++ b/src/step.rs
@@ -544,6 +544,9 @@ impl Step {
                 runner.execute(*self, "SDKMAN!", || unix::run_sdkman(ctx))?
             }
             SelfUpdate => {
+                // Self-Update step, this will execute only if:
+                // 1. the `self-update` feature is enabled
+                // 2. it is not disabled from configuration (env var/CLI opt/file)
                 #[cfg(feature = "self-update")]
                 {
                     if std::env::var("TOPGRADE_NO_SELF_UPGRADE").is_err() && !ctx.config().no_self_update() {


### PR DESCRIPTION
## What does this PR do

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated

## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
