### PR TITLE
fix(bun): skip self-update if not installed via official script

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -1574,7 +1574,7 @@ pub fn run_bun(ctx: &ExecutionContext) -> Result<()> {
     // `$HOME/.bun`
     //
     // UNIX: https://bun.sh/install.sh
-    // Windows:https://bun.sh/install.ps1
+    // Windows: https://bun.sh/install.ps1
     let bun_install_env = env::var("BUN_INSTALL")
         .map(PathBuf::from)
         .unwrap_or(HOME_DIR.join(".bun"));


### PR DESCRIPTION
## What does this PR do

Rebase of #894 on `main`.

After this PR, we only update bun if it is installed through the official script. We determine this by checking if the binary location is a descendant of `bun_install_env`, which will be set through the environment variable `$BUN_INSTALL`, and defaults to `$HOME/.bun`.

Closes #892
Closes #894 

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated
