### PR TITLE
fix(deps): restore custom commands order

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 home = "=0.5.11"
 etcetera = "=0.10.0"
 serde = { version = "~1.0", features = ["derive"] }
-toml = "=0.9.8"
+toml = { version = "=0.9.8", features = ["preserve_order"] }
 which_crate = { version = "~8.0", package = "which" }
 shellexpand = "~3.1"
 clap = { version = "~4.5", features = ["cargo", "derive"] }


### PR DESCRIPTION
## What does this PR do
The toml update to 0.9.8 (in commit 9ec8e83f410f) broke custom command ordering because toml 0.9.0+ don't preserve order by default.

Quoting from toml 0.9.0 changelog [1]:
> from_str, Deserializer, etc no longer preserve order, requiring the
> preserve_order feature like Table

Enable preserve_order feature for toml to restore the ordering.

[1] https://github.com/toml-rs/toml/blob/toml-v0.9.8/crates/toml/CHANGELOG.md#compatibility-1

## Standards checklist

- [X] The PR title is descriptive
- [X] I have read `CONTRIBUTING.md`
- [X] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated
