### PR TITLE
feat(brew): add Homebrew cask support for Linux

### DIFF
--- a/locales/app.yml
+++ b/locales/app.yml
@@ -694,6 +694,14 @@ _version: 2
   zh_CN: "不是专用的 macOS brew"
   zh_TW: "不是專門的 macOS brew"
   de: "Kein angepasstes Brew für macOS"
+"Homebrew cask support on Linux requires Homebrew 4.5.0 or later (found {version})":
+  en: "Homebrew cask support on Linux requires Homebrew 4.5.0 or later (found %{version})"
+  lt: "Homebrew cask palaikymas Linux sistemoje reikalauja Homebrew 4.5.0 arba naujesnes versijos (rasta %{version})"
+  es: "El soporte de cask de Homebrew en Linux requiere Homebrew 4.5.0 o posterior (encontrado %{version})"
+  fr: "Le support de cask Homebrew sur Linux nécessite Homebrew 4.5.0 ou supérieur (trouvé %{version})"
+  zh_CN: "Linux 上的 Homebrew cask 支持需要 Homebrew 4.5.0 或更高版本（找到 %{version}）"
+  zh_TW: "Linux 上的 Homebrew cask 支援需要 Homebrew 4.5.0 或更高版本（找到 %{version}）"
+  de: "Homebrew-Cask-Unterstützung unter Linux erfordert Homebrew 4.5.0 oder höher (gefunden %{version})"
 "Guix Pull Failed, Skipping":
   en: "Guix Pull Failed, Skipping"
   lt: "Guix traukti nepavyko, praleidžiama"

--- a/src/step.rs
+++ b/src/step.rs
@@ -225,7 +225,7 @@ impl Step {
             Bin => runner.execute(*self, "bin", || generic::bin_update(ctx))?,
             Bob => runner.execute(*self, "Bob", || generic::run_bob(ctx))?,
             BrewCask => {
-                #[cfg(target_os = "macos")]
+                #[cfg(any(target_os = "linux", target_os = "macos"))]
                 runner.execute(*self, "Brew Cask", || unix::run_brew_cask(ctx, unix::BrewVariant::Path))?;
                 #[cfg(target_os = "macos")]
                 runner.execute(*self, "Brew Cask (Intel)", || {
@@ -750,6 +750,7 @@ pub(crate) fn default_steps() -> Vec<Step> {
         Restarts,
         Flatpak,
         BrewFormula,
+        BrewCask,
         Lure,
         Waydroid,
         AutoCpufreq,


### PR DESCRIPTION
## What does this PR do

Enable Homebrew cask upgrades on Linux systems running Homebrew 4.5.0 or later. Homebrew introduced Linux cask support in version 4.5.0 (see https://brew.sh/2025/04/29/homebrew-4.5.0/).

Changes:
- Add BrewCask to Linux default steps (positioned after BrewFormula)
- Enable run_brew_cask() for Linux with version validation
- Preserve existing macOS-specific behavior unchanged

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [x] If this PR introduces new user-facing messages they are translated

## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
