### PR TITLE
refactor: refactor run_containers error handling

### DIFF
--- a/src/steps/containers.rs
+++ b/src/steps/containers.rs
@@ -11,7 +11,7 @@ use tracing::{debug, error, warn};
 use wildmatch::WildMatch;
 
 use crate::command::CommandExt;
-use crate::error::{self, SkipStep, TopgradeError};
+use crate::error::{SkipStep, TopgradeError};
 use crate::terminal::print_separator;
 use crate::{execution_context::ExecutionContext, utils::require};
 use rust_i18n::t;


### PR DESCRIPTION
## What does this PR do
Closes #1524
There is a behavioral change here: it fails fast, stopping at the first failure (failed container), instead of updating all containers (and pruning) before raising the error. It is not clear why we had that behavior in the first place; fast failing is probably better.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated
