### PR TITLE
feat: add mise configuration options for bump and interactive modes

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -291,6 +291,16 @@
 # (default: false)
 # exclude_encrypted = false
 
+[mise]
+# Upgrades to the latest version available, bumping the version in mise.toml
+# (default: false)
+# bump = false
+
+# Run interactively
+# (default: false)
+# interactive = false
+
+
 [npm]
 # Use sudo if the NPM directory isn't owned by the current user
 # use_sudo = true

--- a/src/config.rs
+++ b/src/config.rs
@@ -176,6 +176,14 @@ pub struct Chezmoi {
 #[derive(Deserialize, Default, Debug, Merge)]
 #[serde(deny_unknown_fields)]
 #[allow(clippy::upper_case_acronyms)]
+pub struct Mise {
+    bump: Option<bool>,
+    interactive: Option<bool>,
+}
+
+#[derive(Deserialize, Default, Debug, Merge)]
+#[serde(deny_unknown_fields)]
+#[allow(clippy::upper_case_acronyms)]
 pub struct Firmware {
     upgrade: Option<bool>,
 }
@@ -470,6 +478,9 @@ pub struct ConfigFile {
 
     #[merge(strategy = crate::utils::merge_strategies::inner_merge_opt)]
     chezmoi: Option<Chezmoi>,
+
+    #[merge(strategy = crate::utils::merge_strategies::inner_merge_opt)]
+    mise: Option<Mise>,
 
     #[merge(strategy = crate::utils::merge_strategies::inner_merge_opt)]
     yarn: Option<Yarn>,
@@ -1801,6 +1812,22 @@ impl Config {
             .chezmoi
             .as_ref()
             .and_then(|chezmoi| chezmoi.exclude_encrypted)
+            .unwrap_or(false)
+    }
+
+    pub fn mise_bump(&self) -> bool {
+        self.config_file
+            .mise
+            .as_ref()
+            .and_then(|mise| mise.bump)
+            .unwrap_or(false)
+    }
+
+    pub fn mise_interactive(&self) -> bool {
+        self.config_file
+            .mise
+            .as_ref()
+            .and_then(|mise| mise.interactive)
             .unwrap_or(false)
     }
 

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -824,7 +824,19 @@ pub fn run_mise(ctx: &ExecutionContext) -> Result<()> {
         }
     }
 
-    ctx.execute(&mise).arg("upgrade").status_checked()
+    let mut cmd = ctx.execute(&mise);
+
+    cmd.arg("upgrade");
+
+    if ctx.config().mise_interactive() {
+        cmd.arg("--interactive");
+    }
+
+    if ctx.config().mise_bump() {
+        cmd.arg("--bump");
+    }
+
+    cmd.status_checked()
 }
 
 pub fn run_home_manager(ctx: &ExecutionContext) -> Result<()> {


### PR DESCRIPTION
## What does this PR do

add more options for mise 

https://mise.jdx.dev/cli/upgrade.html#flags

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated

## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
