### PR TITLE
feat: add colors to --help/-h

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,6 +394,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap-cargo"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d546f0e84ff2bfa4da1ce9b54be42285767ba39c688572ca32412a09a73851e5"
+dependencies = [
+ "anstyle",
+ "clap",
+]
+
+[[package]]
 name = "clap_builder"
 version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2969,6 +2979,7 @@ dependencies = [
  "base64ct",
  "chrono",
  "clap",
+ "clap-cargo",
  "clap_complete",
  "clap_mangen",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ serde_json = "1.0.145"
 ignore = "=0.4.23"
 globset = "=0.4.16"
 base64ct = "<1.8.0"
+clap-cargo = "0.15.2"
 
 [patch.crates-io]
 mac-notification-sys = { git = "https://github.com/h4llow3En/mac-notification-sys" }

--- a/src/config.rs
+++ b/src/config.rs
@@ -729,7 +729,7 @@ impl ConfigFile {
 // TODO: i18n of clap currently not easily possible. Waiting for https://github.com/clap-rs/clap/issues/380
 // Tracking issue for i18n: https://github.com/topgrade-rs/topgrade/issues/859
 #[derive(Parser, Debug)]
-#[command(name = "topgrade", version)]
+#[command(name = "topgrade", version, styles = clap_cargo::style::CLAP_STYLING)]
 pub struct CommandLineArgs {
     /// Edit the configuration file
     #[arg(long = "edit-config")]


### PR DESCRIPTION
## What does this PR do

It adds colorful output of `--help`/`-h`
I used [clap-cargo](https://github.com/crate-ci/clap-cargo) as it's easy to use and provides sensible default styles.
User can disable colors via `NO_COLOR=1` environment variable

Output of `topgrade --help`:
| before | after | `NO_COLOR=1` |
| - | - | - |
| <img width="1160" height="2629" alt="topgrade-before" src="https://github.com/user-attachments/assets/afb11c50-6fa8-4184-a458-07b31df40a81" /> | <img width="1160" height="2629" alt="topgrade-colors" src="https://github.com/user-attachments/assets/c167b6cc-49ae-4f9d-af63-9bb0ac487350" /> | <img width="1160" height="2629" alt="topgrade-no-color" src="https://github.com/user-attachments/assets/40ce8672-82b6-4235-bdf7-421b6e730085" /> |

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated - not applicable

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.