### PR TITLE
fix(auto-cpufreq): fix skipping on systems with merged bin/sbin

### DIFF
--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -1123,11 +1123,9 @@ pub fn run_waydroid(ctx: &ExecutionContext) -> Result<()> {
 }
 
 pub fn run_auto_cpufreq(ctx: &ExecutionContext) -> Result<()> {
-    let auto_cpu_freq = require("auto-cpufreq")?;
+    let auto_cpu_freq = require("auto-cpufreq")?.canonicalize()?;
 
-    if auto_cpu_freq != PathBuf::from("/usr/local/bin/auto-cpufreq")
-        && auto_cpu_freq != PathBuf::from("/usr/local/sbin/auto-cpufreq")
-    {
+    if auto_cpu_freq != PathBuf::from("/usr/local/bin/auto-cpufreq") {
         return Err(SkipStep(String::from(
             "`auto-cpufreq` was not installed by the official installer, but presumably by a package manager.",
         ))


### PR DESCRIPTION
Because of https://github.com/topgrade-rs/topgrade/pull/1215, auto-cpufreq is only updated if the path reported by the `which` crate is "/usr/local/bin/auto-cpufreq". In my system, however, the which crate gives "/usr/local/**s**bin/auto-cpufreq" (notice "bin" vs "sbin") and because of that, it assumes I did not install 'auto-cpufreq' with the official installer, which I have.

The fix was to create an exception for the "sbin" path.

## What does this PR do

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated

## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
