### PR TITLE
fix: Add more alternate names for Intellij IDEA

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -1775,7 +1775,9 @@ pub fn run_jetbrains_idea(ctx: &ExecutionContext) -> Result<()> {
         require_one([
             "idea",
             "intellij-idea-ultimate-edition",
+            "intellij-idea-ultimate",
             "intellij-idea-community-edition",
+            "intellij-idea-community",
         ])?,
         "IntelliJ IDEA",
     )


### PR DESCRIPTION
## What does this PR do

When installing Intellij IDEA Ultimate on Ubuntu (from snap), the binary is named `intellij-idea-ultimate`.
I assume (haven't checked) that the community edition will be named `intellij-idea-community`.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [x] If this PR introduces new user-facing messages they are translated

## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
