### PR TITLE
fix: use measure_text_width instead of byte count for header border calculation

### DIFF
--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use chrono::{Local, Timelike};
 use color_eyre::eyre;
 use color_eyre::eyre::Context;
-use console::{style, Key, Term};
+use console::{measure_text_width, style, Key, Term};
 use notify_rust::{Notification, Timeout};
 use rust_i18n::t;
 use tracing::{debug, error};
@@ -119,7 +119,7 @@ impl Terminal {
                                 2,
                                 min(80, width as usize)
                                     .checked_sub(4)
-                                    .and_then(|e| e.checked_sub(message.len()))
+                                    .and_then(|e| e.checked_sub(measure_text_width(&message)))
                                     .unwrap_or(0)
                             )
                         ))


### PR DESCRIPTION
## What does this PR do

The `print_separator` method was using `message.len()` which returns the byte count of the string. This caused incorrect border calculations when the message contains multi-byte UTF-8 characters.

Using `message.chars().count()` properly counts Unicode characters for accurate 80-character header formatting regardless of character encoding.

**Before:**
<img width="676" height="82" alt="image" src="https://github.com/user-attachments/assets/c8592de1-374b-4fd9-adda-1b9782d921e5" />

**After:**
<img width="663" height="85" alt="image" src="https://github.com/user-attachments/assets/e1e7265a-23de-4b98-bacf-d1278c05a888" />

## Standards checklist

- [✅] The PR title is descriptive
- [✅] I have read `CONTRIBUTING.md`
- [✅] *Optional:* I have tested the code myself
- [n/a] If this PR introduces new user-facing messages they are translated
