### PR TITLE
fix(archlinux): don't overwrite PATH

### DIFF
--- a/src/steps/os/archlinux.rs
+++ b/src/steps/os/archlinux.rs
@@ -1,5 +1,3 @@
-use std::env::var_os;
-use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
 use color_eyre::eyre;
@@ -13,12 +11,6 @@ use crate::execution_context::ExecutionContext;
 use crate::step::Step;
 use crate::utils::which;
 use crate::{config, output_changed_message};
-
-fn get_execution_path() -> OsString {
-    let mut path = OsString::from("/usr/bin:");
-    path.push(var_os("PATH").unwrap());
-    path
-}
 
 pub trait ArchPackageManager {
     fn upgrade(&self, ctx: &ExecutionContext) -> Result<()>;
@@ -43,8 +35,7 @@ impl ArchPackageManager for YayParu {
             .arg("--pacman")
             .arg(&self.pacman)
             .arg("-Syu")
-            .args(ctx.config().yay_arguments().split_whitespace())
-            .env("PATH", get_execution_path());
+            .args(ctx.config().yay_arguments().split_whitespace());
 
         if ctx.config().yes(Step::System) {
             command.arg("--noconfirm");
@@ -81,10 +72,7 @@ impl ArchPackageManager for GarudaUpdate {
     fn upgrade(&self, ctx: &ExecutionContext) -> Result<()> {
         let mut command = ctx.execute(&self.executable);
 
-        command
-            .env("PATH", get_execution_path())
-            .env("UPDATE_AUR", "1")
-            .env("SKIP_MIRRORLIST", "1");
+        command.env("UPDATE_AUR", "1").env("SKIP_MIRRORLIST", "1");
 
         if ctx.config().yes(Step::System) {
             command.env("PACMAN_NOCONFIRM", "1");
@@ -114,8 +102,7 @@ impl ArchPackageManager for Trizen {
 
         command
             .arg("-Syu")
-            .args(ctx.config().trizen_arguments().split_whitespace())
-            .env("PATH", get_execution_path());
+            .args(ctx.config().trizen_arguments().split_whitespace());
 
         if ctx.config().yes(Step::System) {
             command.arg("--noconfirm");
@@ -151,7 +138,7 @@ impl ArchPackageManager for Pacman {
     fn upgrade(&self, ctx: &ExecutionContext) -> Result<()> {
         let sudo = ctx.require_sudo()?;
         let mut command = sudo.execute(ctx, &self.executable)?;
-        command.arg("-Syu").env("PATH", get_execution_path());
+        command.arg("-Syu");
         if ctx.config().yes(Step::System) {
             command.arg("--noconfirm");
         }
@@ -196,8 +183,7 @@ impl ArchPackageManager for Pikaur {
 
         command
             .arg("-Syu")
-            .args(ctx.config().pikaur_arguments().split_whitespace())
-            .env("PATH", get_execution_path());
+            .args(ctx.config().pikaur_arguments().split_whitespace());
 
         if ctx.config().yes(Step::System) {
             command.arg("--noconfirm");
@@ -235,8 +221,7 @@ impl ArchPackageManager for Pamac {
 
         command
             .arg("upgrade")
-            .args(ctx.config().pamac_arguments().split_whitespace())
-            .env("PATH", get_execution_path());
+            .args(ctx.config().pamac_arguments().split_whitespace());
 
         if ctx.config().yes(Step::System) {
             command.arg("--no-confirm");


### PR DESCRIPTION
Overwriting PATH with just `/usr/bin` disregards user settings regarding preferred commands. For example, when sudo-rs is symlinked as `/usr/local/bin/sudo`, some of the commands will still call `/usr/bin/sudo` because of the modified PATH.

This leads to double password prompt: one for sudo and another one for sudo-rs.

---

## What does this PR do

Removes PATH environment variable modification from Arch Linux system update handler. AFAICT, this was the only place where such modification was performed.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
I have daily driven this change for over two weeks using Paru and the original Pacman, I didn't test other Pacman helpers. 
- [ ] If this PR introduces new user-facing messages they are translated

## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
