### PR TITLE
feat(sudo): propagate --env to sudo commands (#1588)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2992,6 +2992,7 @@ dependencies = [
  "ignore",
  "indexmap",
  "is_elevated",
+ "itertools",
  "jetbrains-toolbox-updater",
  "merge",
  "nix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ sys-locale = "0.3.1"
 jetbrains-toolbox-updater = "5.0.0"
 indexmap = { version = "2.9.0", features = ["serde"] }
 serde_json = "1.0.145"
+itertools = "0.11.0"
 # Temporary transitive dependency pins
 ignore = "=0.4.23"
 globset = "=0.4.16"

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,8 +8,8 @@ use std::{env, fmt, fs};
 
 use clap::{Parser, ValueEnum};
 use clap_complete::Shell;
-use color_eyre::eyre::Context;
 use color_eyre::eyre::Result;
+use color_eyre::eyre::{Context, OptionExt};
 use etcetera::base_strategy::BaseStrategy;
 use indexmap::IndexMap;
 use merge::Merge;
@@ -845,14 +845,10 @@ pub struct CommandLineArgs {
 }
 
 fn env_args_parser(arg: &str) -> Result<(String, String)> {
-    let parts: Vec<&str> = arg.splitn(2, '=').collect();
-    if parts.len() != 2 {
-        Err(color_eyre::eyre::eyre!(
-            "Environment variable must be in the format NAME=VALUE"
-        ))
-    } else {
-        Ok((parts[0].to_string(), parts[1].to_string()))
-    }
+    let (key, value) = arg
+        .split_once("=")
+        .ok_or_eyre("Environment variable must be in the format NAME=VALUE")?;
+    Ok((key.to_string(), value.to_string()))
 }
 
 impl CommandLineArgs {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,6 @@
 use std::env;
 use std::ffi::OsStr;
-use std::fmt::{Debug, Write};
+use std::fmt::Debug;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -149,23 +149,6 @@ pub fn string_prepend_str(string: &mut String, s: &str) {
     new_string.push_str(s);
     new_string.push_str(string);
     *string = new_string;
-}
-
-pub fn join_iter(mut iterator: impl Iterator<Item = impl std::fmt::Display>, separator: &str) -> String {
-    match iterator.next() {
-        None => String::new(),
-        Some(first) => {
-            let (lower_bound, _) = iterator.size_hint();
-            let mut result = String::with_capacity(separator.len() * lower_bound);
-            // SAFETY: We only use this method with string-like types, which should be infallible to fmt().
-            write!(&mut result, "{}", first).unwrap();
-            for item in iterator {
-                result.push_str(separator);
-                write!(&mut result, "{}", item).unwrap();
-            }
-            result
-        }
-    }
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## What does this PR do

1.  Extracts environment variables set via `--env` from `ExecutionContext` within `SudoExecuteOpts::new` to serve as defaults.
2.  Adds tests.
3.  Modifies `preserve_env_list` to `extend_preserve_env_list`, allowing new preserved variables to be added additively.

### Note on `extend_preserve_env_list`

To maintain the original zero-copy behavior for strings and keep the rest of the codebase concise, the signature of `extend_preserve_env_list` is slightly more complex. The implementation could be much simpler if we were willing to use `Vec<String>` to store `SudoPreserveEnv`.

Closes #1588.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [x] If this PR introduces new user-facing messages they are translated
