### PR TITLE
fix(uv): update silenced error messages

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -1511,7 +1511,7 @@ pub fn run_uv(ctx: &ExecutionContext) -> Result<()> {
         //
         // We run `uv self update` directly, and ignore an error if it outputs:
         //
-        // "error: uv was installed through an external package manager, and self-update is not available. Please use your package manager to update uv.\n"
+        // "error: uv was installed through an external package manager" [various continuations]
         //
         // or:
         //
@@ -1524,7 +1524,7 @@ pub fn run_uv(ctx: &ExecutionContext) -> Result<()> {
         // These two error messages can both occur, in different situations.
 
         const ERROR_MSGS: [&str; 2] = [
-            "uv was installed through an external package manager, and self-update is not available. Please use your package manager to update uv.",
+            "uv was installed through an external package manager",
             "Self-update is only available for uv binaries installed via the standalone installation scripts.",
         ];
 


### PR DESCRIPTION
## What does this PR do

uv just dropped a new error message for `uv self update` when installed through a package manager. This PR updates topgrade accordingly. See https://github.com/astral-sh/uv/pull/16838/files#diff-acdeb22c41066388ed84386bbe38879a7fab52da88324df633029e4f52e427b9L1226-R1245

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [ ] (NA) ~If this PR introduces new user-facing messages they are translated~