### PR TITLE
feat(aqua): run `aqua update --config $AQUA_GLOBAL_CONFIG` instead of `aqua update`

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -249,14 +249,17 @@ pub fn run_aqua(ctx: &ExecutionContext) -> Result<()> {
     let aqua = Aqua::get(ctx)?.aqua_cli()?;
 
     print_separator("Aqua");
-    if ctx.run_type().dry() {
-        println!("{}", t!("Updating aqua ..."));
-        println!("{}", t!("Updating aqua installed cli tools ..."));
-        Ok(())
-    } else {
-        ctx.execute(&aqua).arg("update-aqua").status_checked()?;
-        ctx.execute(&aqua).arg("update").status_checked()
+
+    ctx.execute(&aqua).arg("update-aqua").status_checked()?;
+
+    // Don't run plain `aqua update` because it uses the current directory by default.
+    if let Ok(path) = env::var("AQUA_GLOBAL_CONFIG") {
+        ctx.execute(&aqua)
+            .args(["update", "--config", &path])
+            .status_checked()?;
     }
+
+    Ok(())
 }
 
 pub fn run_rustup(ctx: &ExecutionContext) -> Result<()> {


### PR DESCRIPTION
## What does this PR do

Closes #1592

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated

@nagromc could you check this works for you?
`cargo install --git https://github.com/GideonBear/topgrade --branch aqua && ~/.cargo/bin/topgrade --only aqua`