### PR TITLE
fix(vscode): fix parsing of different version format

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -520,10 +520,10 @@ fn run_vscode_compatible(variant: VSCodeVariant, ctx: &ExecutionContext) -> Resu
 
     // VSCode has update command only since 1.86 version ("january 2024" update), disable the update for prior versions
     //
-    // The command `code --version` has two possible formats:
+    // The output of `code --version` has two possible formats:
     // 1. 3 lines: version, git commit, instruction set. We parse only the first one
-    //    This is confirmed from deb-get (apt)
-    // 2. 1 line: bin-name 1.2.3 (commit 123abc): example `code-insiders 1.106.0 (commit 48cdf17f0e856e1daca2ad2747814085a2453df0)`
+    //    This is confirmed on an install from the apt repository
+    // 2. 1 line: 'bin-name 1.2.3 (commit 123abc)', example: `code-insiders 1.106.0 (commit 48cdf17f0e856e1daca2ad2747814085a2453df0)`
     //    See https://github.com/topgrade-rs/topgrade/issues/1605, confirmed from Microsoft website
     // This should apply to VSCodium as well.
 
@@ -543,7 +543,7 @@ fn run_vscode_compatible(variant: VSCodeVariant, ctx: &ExecutionContext) -> Resu
         line.split_whitespace().nth(1).ok_or_else(|| {
             eyre!(output_changed_message!(
                 &format!("{bin_name} --version"),
-                format!("No whitespace after '{bin_name}'")
+                format!("No version after '{bin_name}'")
             ))
         })?
     } else {
@@ -555,17 +555,17 @@ fn run_vscode_compatible(variant: VSCodeVariant, ctx: &ExecutionContext) -> Resu
 
     // Strip leading zeroes because `semver` does not allow them, but VSCodium uses them sometimes.
     //  This is not the case for VSCode, but just in case, and it can't really cause any issues.
-    let version = Version::parse(
-        &version_string
-            .split('.')
-            .map(|s| if s == "0" { "0" } else { s.trim_start_matches('0') })
-            .collect::<Vec<_>>()
-            .join("."),
-    )
-    // Raise any errors in parsing the version
-    //  The benefit of handling VSCodium versions so old that the version format is something
-    //  unexpected is outweighed by the benefit of failing fast on new breaking versions
-    .wrap_err_with(|| output_changed_message!(&format!("{bin_name} --version"), "Invalid version"))?;
+    let version_string = version_string
+        .split('.')
+        .map(|s| if s == "0" { "0" } else { s.trim_start_matches('0') })
+        .collect::<Vec<_>>()
+        .join(".");
+
+    let version = Version::parse(&version_string)
+        // Raise any errors in parsing the version
+        //  The benefit of handling VSCodium versions so old that the version format is something
+        //  unexpected is outweighed by the benefit of failing fast on new breaking versions
+        .wrap_err_with(|| output_changed_message!(&format!("{bin_name} --version"), "Invalid version"))?;
 
     debug!("Detected {name} version as: {version}");
 


### PR DESCRIPTION
## What does this PR do
Closes #1605
Tested with versions of vscode outputting both the old and the new format.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated
