### PR TITLE
ci(release): fix OpenBSD release job

### DIFF
--- a/.github/workflows/create_release_assets.yml
+++ b/.github/workflows/create_release_assets.yml
@@ -348,7 +348,7 @@ jobs:
           FILENAME=topgrade-${tag}-$(default-target)
           mv target/release/topgrade assets
           cd assets
-          tar --format=ustar -czf "$FILENAME.tar.gz" topgrade
+          tar -F ustar -czf "$FILENAME.tar.gz" topgrade
           rm topgrade
           ls .
 


### PR DESCRIPTION
## What does this PR do
@Izder456 I found some more errors(?) in #1630:
1. Adding it to `trigger.needs` makes it block the entire pipeline if it fails, my bad
2. Looks like the filename won't be correct, `self_update` requires a correct triplet. Was there a reason you deviated from the standard `run` block from above?

Please have a look, I don't want to break it if there was a reason you did it differently :)

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated
