### PR TITLE
chore(deps): bump clap_complete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,9 +420,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.62"
+version = "4.5.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "004eef6b14ce34759aa7de4aea3217e368f463f46a3ed3764ca4b5a4404003b4"
+checksum = "90ef1fcbbf16b486489d0df91725ccc653c07115dd61f46363162535b74c6bc3"
 dependencies = [
  "clap",
 ]


### PR DESCRIPTION
Supersedes #1654 because of https://github.com/rust-lang/cargo/issues/13942