### PR TITLE
chore: fix category (os -> command-line-utlilities) in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "topgrade"
 description = "Upgrade all the things"
-categories = ["os"]
+categories = ["command-line-utilities"]
 keywords = ["upgrade", "update"]
 license = "GPL-3.0-or-later"
 repository = "https://github.com/topgrade-rs/topgrade"


### PR DESCRIPTION
The [os](https://crates.io/categories/os) category is for "Bindings to operating system-specific APIs".