### PR TITLE
chore(renovate): change semantic commit type to always be 'chore'

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,6 +3,7 @@
     "extends": [
         "config:best-practices",
         ":semanticCommits",
+        ":semanticCommitTypeAll(chore)",
     ],
     lockFileMaintenance: {
         enabled: true,


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos