### PR TITLE
ci(release): fix OpenBSD release job

### DIFF
--- a/.github/workflows/create_release_assets.yml
+++ b/.github/workflows/create_release_assets.yml
@@ -356,7 +356,8 @@ jobs:
           cd $GITHUB_WORKSPACE
           cargo install default-target
           mkdir -p assets
-          FILENAME=topgrade-${tag}-$(default-target)
+          # TODO: this should use the env var (${tag}), but can't because it's not set in the VM.
+          FILENAME=topgrade-${{ github.event.client_payload.tag }}-$(/root/.cargo/bin/default-target)
           mv target/release/topgrade assets
           cd assets
           tar -F ustar -czf "$FILENAME.tar.gz" topgrade


### PR DESCRIPTION
Failure: https://github.com/topgrade-rs/topgrade/actions/runs/20853511120/job/59914172856
<img width="901" height="153" alt="image" src="https://github.com/user-attachments/assets/282b827c-bf2a-4084-99bb-80a2d11b73e8" />
Ref https://github.com/topgrade-rs/topgrade/pull/1630
@Izder456 
