### PR TITLE
fix(nix): make nix-{channel,env} optional for flake-enabled systems

### DIFF
--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -582,7 +582,7 @@ pub fn run_nix(ctx: &ExecutionContext) -> Result<()> {
         vec![".*"]
     };
 
-    // nix-channel might not be available and isn't always nessecary to perform profile updates
+    // nix-channel might not be available and isn't always necessary to perform profile updates
     let nix_channel_result = if let Ok(nix_channel) = require("nix-channel") {
         print_separator("Nix Channels");
         ctx.execute(nix_channel).arg("--update").status_checked()


### PR DESCRIPTION
## What does this PR do

This fixes an issue where `nix profile upgrade` doesn't get run at all on NixOS systems with [`nix.channel.enable = false;`](https://search.nixos.org/options?channel=unstable&show=nix.channel.enable), because the `nix-channel` binary isn't available.

Also improved the description of what codepath the `nix` step took. Instead of `Nix`, there are now `Nix Channels`, `Nix Profiles`, and `Nix` seperators.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [ ] **N/A** ~~If this PR introduces new user-facing messages they are translated~~