### PR TITLE
ci: harden workflow by SHA-pinning rust-toolchain action

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -21,8 +21,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install Rust toolchain
-        # NOTE: Must pin to SHA from master branch history per dtolnay/rust-toolchain docs
-        # to avoid garbage collection. Do not pin to SHAs from feature branches.
         uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561 # master
         with:
           toolchain: stable
@@ -61,8 +59,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install Rust toolchain
-        # NOTE: Must pin to SHA from master branch history per dtolnay/rust-toolchain docs
-        # to avoid garbage collection. Do not pin to SHAs from feature branches.
         uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561 # master
         with:
           toolchain: stable

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -21,7 +21,9 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
       - name: Run release-plz
         id: release-plz
         uses: release-plz/action@52440b50d383aa252927de395c8b2c1e0a9cf8e9 # v0.5
@@ -57,7 +59,9 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
       - name: Run release-plz
         uses: release-plz/action@52440b50d383aa252927de395c8b2c1e0a9cf8e9 # v0.5
         with:

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -58,7 +58,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 #stable
+        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
       - name: Run release-plz
         uses: release-plz/action@e592230ad39e3ec735402572601fc621aa24355c # v0.5
         with:

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -6,6 +6,7 @@ on:
       - main
 
 jobs:
+
   # Release unpublished packages.
   release-plz-release:
     name: Release-plz release
@@ -13,7 +14,7 @@ jobs:
     environment: crates_io
     permissions:
       contents: write
-      id-token: write # For trusted publishing
+      id-token: write  # For trusted publishing
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -58,7 +58,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 #stable
       - name: Run release-plz
         uses: release-plz/action@e592230ad39e3ec735402572601fc621aa24355c # v0.5
         with:

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -6,7 +6,6 @@ on:
       - main
 
 jobs:
-
   # Release unpublished packages.
   release-plz-release:
     name: Release-plz release
@@ -14,7 +13,7 @@ jobs:
     environment: crates_io
     permissions:
       contents: write
-      id-token: write  # For trusted publishing
+      id-token: write # For trusted publishing
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
@@ -22,7 +21,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
       - name: Run release-plz
         id: release-plz
         uses: release-plz/action@e592230ad39e3ec735402572601fc621aa24355c # v0.5

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -21,7 +21,9 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        # NOTE: Must pin to SHA from master branch history per dtolnay/rust-toolchain docs
+        # to avoid garbage collection. Do not pin to SHAs from feature branches.
+        uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561 # master
         with:
           toolchain: stable
       - name: Run release-plz
@@ -59,7 +61,9 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        # NOTE: Must pin to SHA from master branch history per dtolnay/rust-toolchain docs
+        # to avoid garbage collection. Do not pin to SHAs from feature branches.
+        uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561 # master
         with:
           toolchain: stable
       - name: Run release-plz


### PR DESCRIPTION
## What does this PR do
Update the Rust toolchain version in the release workflow to a specific commit to satisfy Scorecard requirements.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself
- [x] If this PR introduces new user-facing messages they are translated

## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

