### PR TITLE
ci: fix CodeQL missing permissions in winget workflow

### DIFF
--- a/.github/workflows/release_to_winget.yml
+++ b/.github/workflows/release_to_winget.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   publish:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: michidk/winget-updater@3045a0d80c3ac5eee06d38bbe4174df74119099c # v1.1.6


### PR DESCRIPTION
## What does this PR do
Resolves CodeQL security alert #249 by adding an explicit permissions block to the release_to_winget.yml workflow.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself
- [x] If this PR introduces new user-facing messages they are translated

## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
