### PR TITLE
fix(vim): AstroNvim - wait for AstroUpdateCompleted and finish.

### DIFF
--- a/src/steps/upgrade.vim
+++ b/src/steps/upgrade.vim
@@ -4,9 +4,11 @@
 "   skip_prompts = true,
 " },
 if exists(":AstroUpdate")
-   echo "AstroUpdate"
-   AstroUpdate
-   quitall
+    echo "AstroUpdate"
+    autocmd User AstroUpdateCompleted quitall
+    AstroUpdate
+    " Astro includes Lazy etc. So we end early.
+    finish
 endif
 
 if exists(":MasonUpdate")


### PR DESCRIPTION
## What does this PR do                                                                                                                                                                                                                                         
### Summary of Changes:                                                                                                                                                                                                                                           
- ~~Paq: async quitall~~                                                                                                                                                                                                                                     
- AstroNvim: async quitall + finish (it uses Lazy + Mason, we end early)
- ~~Lazy: remove " | qa" to enable Mason updates. Use async.~~
- ~~All plugin managers: run MasonUpdate and MasonToolsUpdate~~

~~When trying to fix AstroNvim (it used to quit early), I added autocmd (See [AstroNvim/astrocore#62](https://github.com/AstroNvim/astrocore/pull/62)). I refactored upgrade.vim to run plugin managers, then MasonUpdate (tools registry) and then MasonToolsUpdate.~~

~~It uses async when possible including Lazy.~~

~~This is a bigger change than I need personally. It needs testing by other plugin manager users (tagged other contributors to this file below).~~

~~If not ok, I can modify PR to just fix AstroNvim but felt this structure is more extensible and would keep nvim upgrades on par with vscode extension updates.~~

Reduced scope based on feedback. 
## Standards checklist

-  [x] The PR title is descriptive
-  [x] I have read `CONTRIBUTING.md`
- :x: *Optional:* I have tested the code myself - I have only tested AstroNvim. I have tagged other contributors to test other plugin managers.
- [ ] If this PR introduces new user-facing messages they are translated

## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.

