### PR TITLE
fix: use `edit` crate for --edit-config editor resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,7 +154,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix",
+ "rustix 1.1.3",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -185,7 +185,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix",
+ "rustix 1.1.3",
 ]
 
 [[package]]
@@ -211,7 +211,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix",
+ "rustix 1.1.3",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
@@ -755,6 +755,16 @@ dependencies = [
  "signature",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "edit"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f364860e764787163c8c8f58231003839be31276e821e2ad2092ddf496b1aa09"
+dependencies = [
+ "tempfile",
+ "which 4.4.2",
 ]
 
 [[package]]
@@ -1540,6 +1550,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
@@ -1886,7 +1902,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix",
+ "rustix 1.1.3",
  "windows-sys 0.61.2",
 ]
 
@@ -2285,6 +2301,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.10.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
@@ -2292,7 +2321,7 @@ dependencies = [
  "bitflags 2.10.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.11.0",
  "windows-sys 0.61.2",
 ]
 
@@ -2737,7 +2766,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.4",
  "once_cell",
- "rustix",
+ "rustix 1.1.3",
  "windows-sys 0.61.2",
 ]
 
@@ -2998,6 +3027,7 @@ dependencies = [
  "clap_mangen",
  "color-eyre",
  "console 0.16.2",
+ "edit",
  "etcetera",
  "futures",
  "glob",
@@ -3031,7 +3061,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "walkdir",
- "which",
+ "which 8.0.0",
  "wildmatch",
  "windows 0.62.2",
  "windows-registry",
@@ -3395,12 +3425,24 @@ dependencies = [
 
 [[package]]
 name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
+]
+
+[[package]]
+name = "which"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
 dependencies = [
  "env_home",
- "rustix",
+ "rustix 1.1.3",
  "winsafe",
 ]
 
@@ -3865,7 +3907,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.1.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ globset = "=0.4.16"
 base64ct = "<1.8.0"
 async-lock = "=3.4.1"
 clap-cargo = "0.15.2"
+edit = "0.1.5"
 
 [package.metadata.generate-rpm]
 assets = [{ source = "target/release/topgrade", dest = "/usr/bin/topgrade" }]

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,7 +3,6 @@
 use std::fs::{write, File};
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use std::{env, fmt, fs};
 
 use clap::{Parser, ValueEnum};
@@ -19,10 +18,7 @@ use rust_i18n::t;
 use serde::Deserialize;
 use strum::IntoEnumIterator;
 use tracing::{debug, error};
-use which_crate::which;
 
-use super::utils::editor;
-use crate::command::CommandExt;
 use crate::execution_context::RunType;
 use crate::step::{Step, DEPRECATED_STEPS};
 use crate::sudo::SudoKind;
@@ -730,18 +726,9 @@ impl ConfigFile {
 
     fn edit() -> Result<()> {
         let config_path = Self::ensure()?.0;
-        let editor = editor();
-        debug!("Editor: {:?}", editor);
+        debug!("Editing config file: {:?}", config_path);
 
-        let command = which(&editor[0])?;
-        let args: Vec<&String> = editor.iter().skip(1).collect();
-
-        #[allow(clippy::disallowed_methods)]
-        Command::new(command)
-            .args(args)
-            .arg(config_path)
-            .status_checked()
-            .context("Failed to open configuration file editor")
+        edit::edit_file(&config_path).context("Failed to open configuration file editor")
     }
 
     /// [Misc] was added later, here we check if it is present in the config file and add it if not

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,3 @@
-use std::env;
 use std::ffi::OsStr;
 use std::fmt::Debug;
 use std::path::{Path, PathBuf};
@@ -80,14 +79,6 @@ pub fn which<T: AsRef<OsStr> + Debug>(binary_name: T) -> Option<PathBuf> {
             None
         }
     }
-}
-
-pub fn editor() -> Vec<String> {
-    env::var("EDITOR")
-        .unwrap_or_else(|_| String::from(if cfg!(windows) { "notepad" } else { "vi" }))
-        .split_whitespace()
-        .map(std::borrow::ToOwned::to_owned)
-        .collect()
 }
 
 pub fn require<T: AsRef<OsStr> + Debug>(binary_name: T) -> Result<PathBuf> {


### PR DESCRIPTION
## What does this PR do

Replace the custom editor() function that only checked $EDITOR (falling back to vi) with the `edit` crate's edit_file(), which checks $VISUAL, $EDITOR, then falls back to sensible-editor, nano, and other common editors. This respects /usr/bin/editor (Debian alternatives) properly.

Fixes topgrade-rs/topgrade#1750

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated

## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
