### PR TITLE
feat: add notify_end tristate option

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -76,7 +76,11 @@
 # Send a notification for every step (default: false)
 # notify_each_step = false
 
-# Skip sending a notification at the end of a run (default: false)
+# When to send a notification at the end of a run
+# (default: "always", allowed values: "always", "never", "on_failure")
+# notify_end = "on_failure"
+
+# Deprecated: use `notify_end = "never"` instead (default: false)
 # skip_notify = true
 
 # The Bash-it branch to update (default: "stable")

--- a/src/main.rs
+++ b/src/main.rs
@@ -309,7 +309,13 @@ fn run() -> Result<()> {
         }
     }
 
-    if !config.skip_notify() {
+    let should_notify = match config.notify_end() {
+        config::NotifyEnd::Always => true,
+        config::NotifyEnd::Never => false,
+        config::NotifyEnd::OnFailure => failed,
+    };
+
+    if should_notify {
         notify_desktop(
             if failed {
                 t!("Topgrade finished with errors")

--- a/src/steps/toolbx.rs
+++ b/src/steps/toolbx.rs
@@ -55,7 +55,8 @@ pub fn run_toolbx(ctx: &ExecutionContext) -> Result<()> {
             "--only",
             "system",
             "--no-self-update",
-            "--skip-notify",
+            "--notify-end",
+            "never",
         ];
         if ctx.config().yes(Step::Toolbx) {
             args.push("--yes");


### PR DESCRIPTION
## What does this PR do

Adds a `notify_end` option that deprecates the `skip_notify` option (but continues respecting it for back compat with a warning). I thought this was a better option than outright removing the old option or adding another bool option (`notify_on_success`).

Closes #1692.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated

## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
