### PR TITLE
chore(workflow): gate release-plz only to upstream

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -15,7 +15,7 @@ jobs:
     environment: crates_io
     permissions:
       contents: write
-      id-token: write # For trusted publishing
+      id-token: write  # For trusted publishing
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## What does this PR do

Fixes https://github.com/topgrade-rs/topgrade/issues/1515

Now `release-plz` will run only on `topgrade-rs/topgrade`.