### PR TITLE
fix(juliaup): don't crash when failing to canonicalize juliaup path

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -343,7 +343,7 @@ pub fn run_juliaup(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("juliaup");
 
-    if juliaup.canonicalize()?.is_descendant_of(&HOME_DIR) {
+    if juliaup.canonicalize().is_ok_and(|p| p.is_descendant_of(&HOME_DIR)) {
         ctx.execute(&juliaup).args(["self", "update"]).status_checked()?;
     }
 


### PR DESCRIPTION
Fixes #1797

## What does this PR do

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated

## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
