### PR TITLE
feat: add KDE Linux support

### DIFF
--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -46,6 +46,7 @@ pub enum Distribution {
     Solus,
     Exherbo,
     NixOS,
+    KDELinux,
     KDENeon,
     Nobara,
 }
@@ -76,6 +77,7 @@ impl Distribution {
             Some("exherbo") => Distribution::Exherbo,
             Some("nixos") => Distribution::NixOS,
             Some("opensuse-microos") => Distribution::SuseMicro,
+            Some("kde-linux") => Distribution::KDELinux,
             Some("neon") => Distribution::KDENeon,
             Some("openmandriva") => Distribution::OpenMandriva,
             Some("pclinuxos") => Distribution::PCLinuxOS,
@@ -160,6 +162,7 @@ impl Distribution {
             Distribution::Solus => upgrade_solus(ctx),
             Distribution::Exherbo => upgrade_exherbo(ctx),
             Distribution::NixOS => upgrade_nixos(ctx),
+            Distribution::KDELinux => upgrade_kde_linux(ctx),
             Distribution::KDENeon => upgrade_neon(ctx),
             Distribution::Bedrock => update_bedrock(ctx),
             Distribution::OpenMandriva => upgrade_openmandriva(ctx),
@@ -867,6 +870,15 @@ fn upgrade_neon(ctx: &ExecutionContext) -> Result<()> {
     Ok(())
 }
 
+fn upgrade_kde_linux(ctx: &ExecutionContext) -> Result<()> {
+    let updatectl = require("updatectl")?;
+    let mut command = ctx.execute(updatectl);
+    command.arg("update");
+    command.status_checked()?;
+
+    Ok(())
+}
+
 /// `needrestart` should be skipped if:
 ///
 /// 1. This is a redhat-based distribution
@@ -1361,6 +1373,11 @@ mod tests {
     #[test]
     fn test_nilrt() {
         test_template(include_str!("os_release/nilrt"), Distribution::NILRT);
+    }
+
+    #[test]
+    fn test_kde_linux() {
+        test_template(include_str!("os_release/kde-linux"), Distribution::KDELinux);
     }
 
     #[test]

--- a/src/steps/os/os_release/kde-linux
+++ b/src/steps/os/os_release/kde-linux
@@ -1,0 +1,4 @@
+NAME="KDE Linux"
+PRETTY_NAME="KDE Linux"
+ID=kde-linux
+VERSION_ID="2026-03-02"


### PR DESCRIPTION
## What does this PR do

  Adds [KDE Linux](https://kde.org/linux/) support to the Linux system update path via its `updatectl` CLI.

  - detect `ID=kde-linux`
  - run `updatectl update`
  - add an `os-release` fixture and test
  - validate with `cargo fmt --check`, `cargo clippy --locked --all-features -- --deny warnings`, `cargo test --locked`,
  and a live KDE Linux update

  ## Standards checklist

  - [x] The PR title is descriptive
  - [x] I have read `CONTRIBUTING.md`
  - [x] *Optional:* I have tested the code myself
  - [ ] If this PR introduces new user-facing messages they are translated

  ## For new steps

  - [x] *Optional:* Topgrade skips this step where needed
  - [x] *Optional:* The `--dry-run` option works with this step
  - [x] *Optional:* The `--yes` option works with this step if it is supported by
    the underlying command

  If you developed a feature or a bug fix for someone else and you do not have the
  means to test it, please tag this person here.