### PR TITLE
fix(macos): resolve gem from Homebrew keg-only Ruby instead of system Ruby

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -169,6 +169,7 @@ fn is_homebrew_ruby(gem: &Path) -> bool {
 }
 
 pub fn run_gem(ctx: &ExecutionContext) -> Result<()> {
+    #[allow(unused_mut)]
     let mut gem = require("gem")?;
     HOME_DIR.join(".gem").require()?;
 
@@ -198,6 +199,7 @@ pub fn run_gem(ctx: &ExecutionContext) -> Result<()> {
 
 pub fn run_rubygems(ctx: &ExecutionContext) -> Result<()> {
     HOME_DIR.join(".gem").require()?;
+    #[allow(unused_mut)]
     let mut gem = require("gem")?;
 
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
## Summary

On macOS, Homebrew installs Ruby as "keg-only" — binaries live at `/opt/homebrew/opt/ruby/bin/` (ARM) or `/usr/local/opt/ruby/bin/` (Intel) and are **not** symlinked into the standard Homebrew bin directory. Topgrade uses `which_crate::which("gem")` to find `gem`, which searches PATH sequentially. If the keg-only path isn't on PATH, it falls through to `/usr/bin/gem` (Apple's system Ruby 2.6.x), causing all gem updates to fail because modern gems require Ruby >= 3.2.

This also affects `run_rubygems()` which runs `sudo gem update --system` — even if the user has the correct PATH, `sudo` with `env_reset` (the macOS default) strips it, always falling back to system Ruby.

## Changes

- **`resolve_homebrew_keg_gem()`** (macOS-only): When `which gem` resolves to `/usr/bin/gem`, probes for Homebrew's keg-only Ruby via `brew --prefix ruby` and returns the keg gem binary path if found. Checks well-known Homebrew paths (`/opt/homebrew/bin/brew`, `/usr/local/bin/brew`) before falling back to PATH for the `brew` binary itself.

- **`is_homebrew_ruby()`** (macOS-only): Detects whether a gem binary belongs to a Homebrew-managed Ruby installation by checking path prefixes (`/opt/homebrew/`, `/usr/local/Cellar/`, `/usr/local/opt/`).

- **`run_gem()`**: After `require("gem")`, checks if the resolved path is system Ruby and overrides with the Homebrew keg gem if available.

- **`run_rubygems()`**: Same keg-only resolution, plus detects Homebrew-managed Ruby to skip the `sudo` invocation (Homebrew Ruby is user-owned, so sudo is unnecessary and harmful — it would attempt to modify files owned by the current user as root).

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| Homebrew Ruby installed, keg path not on PATH | Uses `/usr/bin/gem` (Ruby 2.6), fails | Detects keg-only Ruby via `brew --prefix ruby`, uses correct gem |
| Homebrew Ruby installed, keg path on PATH | Works (gem resolves correctly) | No change (early return, not `/usr/bin/gem`) |
| No Homebrew Ruby | Uses system gem (existing behavior) | No change (keg probe returns None) |
| rbenv/rvm/asdf/mise | Uses version manager gem (existing behavior) | No change (not `/usr/bin/gem`) |
| `run_rubygems()` with Homebrew Ruby | `sudo gem update --system` (sudo strips PATH, uses system Ruby) | Runs without sudo (Homebrew Ruby is user-owned) |
| Linux | N/A (no system Ruby issue) | No change (functions are `#[cfg(target_os = "macos")]`) |

## Test plan

- [x] `cargo check` passes
- [x] `cargo clippy` passes with no warnings
- [x] All new code is gated behind `#[cfg(target_os = "macos")]` — zero impact on Linux/Windows builds
- [x] Manual testing on macOS with Homebrew Ruby installed as keg-only
- [x] Manual testing on macOS without Homebrew Ruby (graceful fallback)

Closes #1763
Closes #1011

🤖 Generated with [Claude Code](https://claude.com/claude-code)