### PR TITLE
refactor(build.rs): add descriptive error when current version is missing from changelog

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -12,7 +12,9 @@ fn breaking_changes() {
     let out_dir = Path::new(out_dir_s);
     let version_str = env::var("CARGO_PKG_VERSION").unwrap();
     let changelog = parse_changelog::parse(include_str!("CHANGELOG.md")).expect("Invalid CHANGELOG.md");
-    let release = changelog.get(&*version_str).expect("Current release not found in CHANGELOG.md");
+    let release = changelog
+        .get(&*version_str)
+        .expect("Current release not found in CHANGELOG.md");
     let breaking_changes = release
         .notes
         // Get the part after the header


### PR DESCRIPTION
## What does this PR do

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated
