### PR TITLE
feat(step): add skills for skills.sh

### DIFF
--- a/src/step.rs
+++ b/src/step.rs
@@ -150,6 +150,7 @@ pub enum Step {
     SelfUpdate,
     Sheldon,
     Shell,
+    Skills,
     Snap,
     Sparkle,
     Spicetify,
@@ -600,6 +601,7 @@ impl Step {
                     runner.execute(*self, "fundle", || unix::run_fundle(ctx))?
                 }
             }
+            Skills => runner.execute(*self, "Skills", || generic::run_skills(ctx))?,
             Snap =>
             {
                 #[cfg(target_os = "linux")]
@@ -887,6 +889,7 @@ pub(crate) fn default_steps() -> Vec<Step> {
         ClamAvDb,
         ClaudeCode,
         Colima,
+        Skills,
         PlatformioCore,
         Lensfun,
         Poetry,

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -2015,3 +2015,16 @@ pub fn run_colima(ctx: &ExecutionContext) -> Result<()> {
 
     ctx.execute(colima).arg("update").status_checked()
 }
+
+pub fn run_skills(ctx: &ExecutionContext) -> Result<()> {
+    let npx = require("npx")?;
+
+    let skill_lock = HOME_DIR.join(".agents").join(".skill-lock.json");
+    if !skill_lock.exists() {
+        return Err(SkipStep("No ~/.agents/.skill-lock.json found".to_string()).into());
+    }
+
+    print_separator("Skills");
+
+    ctx.execute(npx).args(["skills", "update"]).status_checked()
+}


### PR DESCRIPTION
## What does this PR do

Add support for updating skills installed via [skills.sh](https://skills.sh/).

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself (Tested on macOS)
- [x] If this PR introduces new user-facing messages they are translated

## For new steps

- [x] *Optional:* Topgrade skips this step where needed (checks for `npx` command and `.agents/.skill-lock.json`)
- [x] *Optional:* The `--dry-run` option works with this step 
- [ ] *Optional:* The `--yes` option works with this step if it is supported by
  the underlying command (no underlying support)

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
