### PR TITLE
fix(git): expand environment variables in custom git repos

### DIFF
--- a/src/steps/git.rs
+++ b/src/steps/git.rs
@@ -94,7 +94,10 @@ pub fn run_git_pull_or_fetch(ctx: &ExecutionContext) -> Result<()> {
     // Handle user-defined repos
     if let Some(custom_git_repos) = config.git_repos() {
         for git_repo in custom_git_repos {
-            repos.glob_insert(ctx, &shellexpand::tilde(git_repo));
+            repos.glob_insert(
+                ctx,
+                &shellexpand::full(git_repo).unwrap_or_else(|_| std::borrow::Cow::Borrowed(git_repo)),
+            );
         }
     }
 


### PR DESCRIPTION
## What does this PR do

Fixes #1845 by changing `shellexpand::tilde()` to `shellexpand::full()` to support environment variable expansion in git.repos configuration.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [ ] If this PR introduces new user-facing messages they are translated