### PR TITLE
feat: expose TOPGRADE_YES and TOPGRADE_CLEANUP env vars for custom commands

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -1038,7 +1038,18 @@ pub fn run_custom_command(name: &str, command: &str, ctx: &ExecutionContext) -> 
     } else {
         command
     };
-    exec.arg("-c").arg(command).status_checked()
+    exec.env(
+        "TOPGRADE_YES",
+        if ctx.config().yes(Step::CustomCommands) {
+            "1"
+        } else {
+            "0"
+        },
+    )
+    .env("TOPGRADE_CLEANUP", if ctx.config().cleanup() { "1" } else { "0" })
+    .arg("-c")
+    .arg(command)
+    .status_checked()
 }
 
 pub fn run_composer_update(ctx: &ExecutionContext) -> Result<()> {


### PR DESCRIPTION
## Summary

Sets `TOPGRADE_YES` and `TOPGRADE_CLEANUP` environment variables when running custom commands, so scripts can check whether `--yes` or `--cleanup` flags were passed.

## Why this matters

Per #1013, custom commands can't detect topgrade's `-y`/`--yes` or `-c`/`--cleanup` flags without checking the parent process. Built-in steps handle these flags automatically, but custom shell scripts need a way to know. The project already sets env vars like `TOPGRADE_KEEP_END`, `TOPGRADE_INSIDE_TMUX`, and `IN_TOPGRADE` for similar purposes.

## Changes

- `src/steps/generic.rs`: In `run_custom_command()`, set `TOPGRADE_YES=1` (if `--yes` applies to custom commands) or `TOPGRADE_YES=0`, and `TOPGRADE_CLEANUP=1`/`0` based on the `--cleanup` flag.

## Usage

```toml
[commands]
"Update custom" = "if [ \"$TOPGRADE_YES\" = \"1\" ]; then apt upgrade -y; else apt upgrade; fi"
```

## Testing

`cargo check` passes. Follows the same env var pattern used by `TOPGRADE_KEEP_END` in `src/tmux.rs:123` and `IN_TOPGRADE` in `src/terminal.rs:35`.

Fixes #1013

This contribution was developed with AI assistance (Claude Code).