### PR TITLE
feat(step): add getnf

### DIFF
--- a/src/step.rs
+++ b/src/step.rs
@@ -67,6 +67,7 @@ pub enum Step {
     Gcloud,
     Gearlever,
     Gem,
+    Getnf,
     Ghcup,
     GitRepos,
     GithubCliExtensions,
@@ -346,6 +347,7 @@ impl Step {
                 runner.execute(*self, "Gear Lever", || linux::run_gearlever(ctx))?
             }
             Gem => runner.execute(*self, "gem", || generic::run_gem(ctx))?,
+            Getnf => runner.execute(*self, "getnf", || generic::run_getnf_update(ctx))?,
             Ghcup => runner.execute(*self, "ghcup", || generic::run_ghcup_update(ctx))?,
             GitRepos => runner.execute(*self, "Git Repositories", || git::run_git_pull_or_fetch(ctx))?,
             GithubCliExtensions => runner.execute(*self, "GitHub CLI Extensions", || {
@@ -870,6 +872,7 @@ pub(crate) fn default_steps() -> Vec<Step> {
         PipReview,
         PipReviewLocal,
         Pipupgrade,
+        Getnf,
         Ghcup,
         Stack,
         Tldr,

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -168,6 +168,14 @@ pub fn run_haxelib_update(ctx: &ExecutionContext) -> Result<()> {
     command.arg("update").status_checked()
 }
 
+pub fn run_getnf_update(ctx: &ExecutionContext) -> Result<()> {
+    let getnf = require("getnf")?;
+
+    print_separator("getnf");
+
+    ctx.execute(getnf).args(["-U"]).status_checked()
+}
+
 pub fn run_sheldon(ctx: &ExecutionContext) -> Result<()> {
     let sheldon = require("sheldon")?;
 


### PR DESCRIPTION
## Summary

Adds [getnf](https://github.com/getnf/getnf) as a new update step. getnf installs and updates Nerd Fonts from the terminal. Topgrade now runs `getnf -U` to update installed fonts when getnf is detected.

## Changes

- `src/steps/generic.rs`: Added `run_getnf_update` function following the same pattern as `run_sheldon` (require binary, print separator, execute with args)
- `src/step.rs`: Added `Getnf` variant to the `Step` enum, execution match arm, and default steps list

## Testing

`cargo check` passes. The step follows the established pattern for simple CLI tool integrations (sheldon, fossil, etc.).

Closes #1872

This contribution was developed with AI assistance (Claude Code).