### PR TITLE
feat(claude code): add plugin updates

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -2023,6 +2023,7 @@ pub fn run_claude_code(ctx: &ExecutionContext) -> Result<()> {
     print_separator("Claude Code");
 
     ctx.execute(&claude).arg("update").status_checked()?;
+
     ctx.execute(&claude)
         .args(["plugin", "marketplace", "update"])
         .status_checked()?;


### PR DESCRIPTION
## What does this PR do
Adds updating claude code plugins in addition to self-update. Maybe we should add opt-out config option, since they started testing auto plugin updates at startup, however that feature is opt-in and increases startup time (so doing it with topgrade may still be better after official release).


<img width="1487" height="534" alt="image" src="https://github.com/user-attachments/assets/8aefe4ff-e648-4548-9aaf-0647c91b8ffa" />


---

Also, this is the cleanest way to do it, because:
```
$ claude plugin update --all
error: unknown option '--all'
```

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself
- [x] If this PR introduces new user-facing messages they are translated

### AI involvement
Inline hints (Copilot) and Claude Code for refactor before commit.