### PR TITLE
feat: add soar package manager step

### DIFF
--- a/src/step.rs
+++ b/src/step.rs
@@ -152,6 +152,7 @@ pub enum Step {
     SelfUpdate,
     Sheldon,
     Shell,
+    Soar,
     Skills,
     Snap,
     Sparkle,
@@ -589,6 +590,7 @@ impl Step {
                 }
             }
             Sheldon => runner.execute(*self, "sheldon", || generic::run_sheldon(ctx))?,
+            Soar => runner.execute(*self, "soar", || generic::run_soar(ctx))?,
             Shell => {
                 #[cfg(unix)]
                 {
@@ -898,6 +900,7 @@ pub(crate) fn default_steps() -> Vec<Step> {
         Julia,
         Haxelib,
         Sheldon,
+        Soar,
         Stew,
         Rtcl,
         Bin,

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -184,6 +184,15 @@ pub fn run_sheldon(ctx: &ExecutionContext) -> Result<()> {
     ctx.execute(sheldon).args(["lock", "--update"]).status_checked()
 }
 
+/// <https://github.com/pkgforge/soar>
+pub fn run_soar(ctx: &ExecutionContext) -> Result<()> {
+    let soar = require("soar")?;
+
+    print_separator("Soar");
+
+    ctx.execute(soar).arg("update").status_checked()
+}
+
 pub fn run_fossil(ctx: &ExecutionContext) -> Result<()> {
     let fossil = require("fossil")?;
 


### PR DESCRIPTION
## Summary

Adds support for the [soar](https://github.com/pkgforge/soar) package manager. Topgrade runs `soar update` when soar is detected.

## Changes

- `src/steps/generic.rs`: Added `run_soar` function following the same pattern as `run_sheldon` and `run_fossil`
- `src/step.rs`: Added `Soar` variant to the `Step` enum, dispatch entry, and i18n list

## Testing

`cargo check` passes. The step follows the exact same pattern as other package manager steps (require binary, print separator, execute update command).

Closes #1377

This contribution was developed with AI assistance (Claude Code).