### PR TITLE
feat: add install-release (ir) package manager step

### DIFF
--- a/src/step.rs
+++ b/src/step.rs
@@ -80,6 +80,7 @@ pub enum Step {
     Helm,
     HomeManager,
     Hyprpm,
+    InstallRelease,
     // These names are miscapitalized on purpose, so the CLI name is
     //  `jetbrains_pycharm` instead of `jet_brains_py_charm`.
     JetbrainsAqua,
@@ -381,6 +382,7 @@ impl Step {
                 #[cfg(unix)]
                 runner.execute(*self, "hyprpm", || unix::run_hyprpm(ctx))?
             }
+            InstallRelease => runner.execute(*self, "install-release", || generic::run_install_release(ctx))?,
             JetbrainsAqua => runner.execute(*self, "JetBrains Aqua Plugins", || generic::run_jetbrains_aqua(ctx))?,
             JetbrainsClion => runner.execute(*self, "JetBrains CL", || generic::run_jetbrains_clion(ctx))?,
             JetbrainsDatagrip => {
@@ -829,6 +831,7 @@ pub(crate) fn default_steps() -> Vec<Step> {
         Rcm,
         Maza,
         Hyprpm,
+        InstallRelease,
         Atuin,
     ]);
 

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -184,6 +184,15 @@ pub fn run_sheldon(ctx: &ExecutionContext) -> Result<()> {
     ctx.execute(sheldon).args(["lock", "--update"]).status_checked()
 }
 
+/// <https://github.com/Rishang/install-release>
+pub fn run_install_release(ctx: &ExecutionContext) -> Result<()> {
+    let ir = require("ir")?;
+
+    print_separator("install-release");
+
+    ctx.execute(ir).arg("upgrade").status_checked()
+}
+
 pub fn run_fossil(ctx: &ExecutionContext) -> Result<()> {
     let fossil = require("fossil")?;
 


### PR DESCRIPTION
## Summary

Adds support for [install-release](https://github.com/Rishang/install-release). Topgrade runs `ir upgrade` when the `ir` binary is detected.

## Changes

- `src/steps/generic.rs`: Added `run_install_release` function
- `src/step.rs`: Added `InstallRelease` variant to `Step` enum, dispatch entry, and i18n list

## Testing

`cargo check` passes. Follows the same pattern as the Sheldon, Soar, and Fossil steps.

Closes #1789

This contribution was developed with AI assistance (Claude Code).