### PR TITLE
chore(pyproject): remove deprecated license classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ maintainers = [
 ]
 requires-python = ">=3.7"
 classifiers = [
-    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",


### PR DESCRIPTION
These were deprecated in [PEP 639](https://peps.python.org/pep-0639/#deprecate-license-classifiers)

Committed via https://github.com/asottile/all-repos