### PR TITLE
docs: remove note about 'no asset found' errors

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,9 +14,6 @@ Please make sure to
 before filing a new one!
 
 Questions labeled with `Optional` can be skipped.
-
-If you're here to report about a "No asset found" error, please make sure that
-an hour has been passed since the last release was made.
 -->
 
 ## Checklist


### PR DESCRIPTION
Since #1857 we have immutable releases, so this doesn't apply anymore, since releases are drafts before all assets are added.