### PR TITLE
ci(release): do not publish immutable release with partial assets

### DIFF
--- a/.github/workflows/create_release_assets.yml
+++ b/.github/workflows/create_release_assets.yml
@@ -378,10 +378,6 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: [ native_build, cross_build, openbsd_build ]
-    # Make sure we still publish if one fails (notably openbsd_build, which is not tested in CI).
-    #  Unfortunately because of immutable releases, aur and winget have to wait for openbsd_build
-    #  as well, even though they don't use it.
-    if: always()
     env:
       tag: ${{ github.event.client_payload.tag }}
     permissions:


### PR DESCRIPTION
This was a bad idea. I will just try to have any code that touches openbsd tested before merging.