### PR TITLE
feat: add install-release step

### DIFF
--- a/src/step.rs
+++ b/src/step.rs
@@ -74,6 +74,7 @@ pub enum Step {
     GnomeShellExtensions,
     Go,
     Guix,
+    InstallRelease,
     Haxelib,
     Helix,
     HelixDb,
@@ -368,6 +369,7 @@ impl Step {
                 #[cfg(unix)]
                 runner.execute(*self, "guix", || unix::run_guix(ctx))?
             }
+            InstallRelease => runner.execute(*self, "install-release", || generic::run_install_release(ctx))?,
             Haxelib => runner.execute(*self, "haxelib", || generic::run_haxelib_update(ctx))?,
             Helix => runner.execute(*self, "helix", || generic::run_helix_grammars(ctx))?,
             HelixDb => runner.execute(*self, "HelixDB", || generic::run_helix_db(ctx))?,
@@ -820,6 +822,7 @@ pub(crate) fn default_steps() -> Vec<Step> {
         Nix,
         NixHelper,
         Guix,
+        InstallRelease,
         HomeManager,
         Asdf,
         Mise,

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -2054,6 +2054,15 @@ pub fn run_colima(ctx: &ExecutionContext) -> Result<()> {
     ctx.execute(colima).arg("update").status_checked()
 }
 
+/// <https://github.com/Rishang/install-release>
+pub fn run_install_release(ctx: &ExecutionContext) -> Result<()> {
+    let ir = require("ir")?;
+
+    print_separator("install-release");
+
+    ctx.execute(ir).arg("upgrade").status_checked()
+}
+
 pub fn run_skills(ctx: &ExecutionContext) -> Result<()> {
     let npx = require("npx")?;
 


### PR DESCRIPTION
## Summary

Adds support for [install-release](https://github.com/Rishang/install-release) (`ir`), a GitHub/GitLab release installer for binary files, tar.gz archives, and system packages (.deb, .rpm, AppImages).

## Changes

- `src/steps/generic.rs`: Added `run_install_release()` function that runs `ir upgrade`
- `src/step.rs`: Added `InstallRelease` variant to the Step enum and wired it to the runner

## How it works

When install-release (`ir`) is found on PATH, topgrade runs `ir upgrade` to update all installed releases. If `ir` is not installed, the step is skipped.

Supported on Linux and macOS (same platforms as install-release itself).

Closes #1789

This contribution was developed with AI assistance (Claude Code).