### PR TITLE
feat: add Soar package manager step

### DIFF
--- a/src/step.rs
+++ b/src/step.rs
@@ -154,6 +154,7 @@ pub enum Step {
     Shell,
     Skills,
     Snap,
+    Soar,
     Sparkle,
     Spicetify,
     Stack,
@@ -617,6 +618,7 @@ impl Step {
                 #[cfg(target_os = "linux")]
                 runner.execute(*self, "snap", || linux::run_snap(ctx))?
             }
+            Soar => runner.execute(*self, "soar", || generic::run_soar(ctx))?,
             Sparkle =>
             {
                 #[cfg(target_os = "macos")]
@@ -794,6 +796,7 @@ pub(crate) fn default_steps() -> Vec<Step> {
         DebGet,
         Toolbx,
         Snap,
+        Soar,
         Pacstall,
         Pacdef,
         Protonup,

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -2054,6 +2054,15 @@ pub fn run_colima(ctx: &ExecutionContext) -> Result<()> {
     ctx.execute(colima).arg("update").status_checked()
 }
 
+/// <https://github.com/pkgforge/soar>
+pub fn run_soar(ctx: &ExecutionContext) -> Result<()> {
+    let soar = require("soar")?;
+
+    print_separator("soar");
+
+    ctx.execute(soar).arg("update").status_checked()
+}
+
 pub fn run_skills(ctx: &ExecutionContext) -> Result<()> {
     let npx = require("npx")?;
 


### PR DESCRIPTION
Adds support for [Soar](https://github.com/pkgforge/soar), a package manager from pkgforge. Runs `soar update` to update installed packages. Unix-compatible.

Closes #1377

This contribution was developed with AI assistance (Claude Code).