### PR TITLE
fix(sudo): ignore set_home for run0

### DIFF
--- a/src/sudo.rs
+++ b/src/sudo.rs
@@ -470,12 +470,9 @@ impl Sudo {
                 SudoKind::Sudo => {
                     cmd.arg("-H");
                 }
-                SudoKind::Doas
-                | SudoKind::WinSudo
-                | SudoKind::Gsudo
-                | SudoKind::Pkexec
-                | SudoKind::Run0
-                | SudoKind::Please => {
+                // This is already the default behavior for run0
+                SudoKind::Run0 => {}
+                SudoKind::Doas | SudoKind::WinSudo | SudoKind::Gsudo | SudoKind::Pkexec | SudoKind::Please => {
                     return Err(UnsupportedSudo {
                         sudo_kind: self.kind,
                         option: "set_home",


### PR DESCRIPTION
## What does this PR do

`run0` already uses the target user's environment by default, so the correct behavior for `set_home` with `run0` is to do nothing. This allows `run0` to be used for update steps such as `brew` when the brew installation is owned by a different user.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [x] If this PR introduces new user-facing messages they are translated

### AI involvement

I did not use LLMs ("AI") at all.