### PR TITLE
feat!: remove deprecated --skip-notify and skip_notify

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -80,9 +80,6 @@
 # (default: "always", allowed values: "always", "never", "on_failure")
 # notify_end = "on_failure"
 
-# Deprecated: use `notify_end = "never"` instead (default: false)
-# skip_notify = true
-
 # The Bash-it branch to update (default: "stable")
 # bashit_branch = "stable"
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -370,9 +370,6 @@ pub struct Misc {
 
     notify_each_step: Option<bool>,
 
-    /// Deprecated: use `notify_end = "never"` instead
-    skip_notify: Option<bool>,
-
     notify_end: Option<NotifyEnd>,
 
     bashit_branch: Option<String>,
@@ -833,10 +830,6 @@ pub struct CommandLineArgs {
     #[arg(short = 'k', long = "keep")]
     keep_at_end: bool,
 
-    /// Skip sending a notification at the end of a run (deprecated: use --notify-end never)
-    #[arg(long = "skip-notify", hide = true)]
-    skip_notify: bool,
-
     /// When to send a notification at the end of a run
     #[arg(long = "notify-end", value_enum, default_value_t)]
     notify_end: NotifyEnd,
@@ -1266,26 +1259,11 @@ impl Config {
 
     /// When to send a notification at the end of a run
     pub fn notify_end(&self) -> NotifyEnd {
-        let skip_notify = self
-            .config_file
-            .misc
-            .as_ref()
-            .and_then(|misc| misc.skip_notify)
-            .unwrap_or(self.opt.skip_notify);
-
-        let notify_end = self
-            .config_file
+        self.config_file
             .misc
             .as_ref()
             .and_then(|misc| misc.notify_end)
-            .unwrap_or(self.opt.notify_end);
-
-        // TODO: deprecate skip_notify
-        if skip_notify {
-            return NotifyEnd::Never;
-        }
-
-        notify_end
+            .unwrap_or(self.opt.notify_end)
     }
 
     /// Whether to set the terminal title


### PR DESCRIPTION
## What does this PR do

Removes the `--skip-notify` CLI flag and `skip_notify` config option that were deprecated in #1760. The `notify_end()` method is simplified to only read from the `notify_end` config/flag. Users should use `--notify-end never` or `notify_end = "never"` instead.

Closes #1761

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] I have tested the code myself, with the relevant tools installed.
- [ ] If this PR introduces new user-facing messages they are translated

### AI involvement

I used Claude Code to help locate all references to `skip_notify` across the codebase and draft the removal. The actual changes (deleting the deprecated field, flag, and simplifying the method) were straightforward removals.