### PR TITLE
feat(step): add install-release

### DIFF
--- a/src/step.rs
+++ b/src/step.rs
@@ -80,6 +80,7 @@ pub enum Step {
     Helm,
     HomeManager,
     Hyprpm,
+    InstallRelease,
     // These names are miscapitalized on purpose, so the CLI name is
     //  `jetbrains_pycharm` instead of `jet_brains_py_charm`.
     JetbrainsAqua,
@@ -381,6 +382,11 @@ impl Step {
             {
                 #[cfg(unix)]
                 runner.execute(*self, "hyprpm", || unix::run_hyprpm(ctx))?
+            }
+            InstallRelease =>
+            {
+                #[cfg(unix)]
+                runner.execute(*self, "install-release", || generic::run_install_release(ctx))?
             }
             JetbrainsAqua => runner.execute(*self, "JetBrains Aqua Plugins", || generic::run_jetbrains_aqua(ctx))?,
             JetbrainsClion => runner.execute(*self, "JetBrains CL", || generic::run_jetbrains_clion(ctx))?,
@@ -836,6 +842,7 @@ pub(crate) fn default_steps() -> Vec<Step> {
         Rcm,
         Maza,
         Hyprpm,
+        InstallRelease,
         Atuin,
     ]);
 

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -176,6 +176,14 @@ pub fn run_getnf_update(ctx: &ExecutionContext) -> Result<()> {
     ctx.execute(getnf).args(["-U"]).status_checked()
 }
 
+pub fn run_install_release(ctx: &ExecutionContext) -> Result<()> {
+    let ir = require("ir")?;
+
+    print_separator("install-release");
+
+    ctx.execute(ir).arg("upgrade").status_checked()
+}
+
 pub fn run_sheldon(ctx: &ExecutionContext) -> Result<()> {
     let sheldon = require("sheldon")?;
 


### PR DESCRIPTION
Adds support for [install-release](https://github.com/Rishang/install-release) (`ir`), a GitHub/GitLab release installer that manages binary files, tar.gz archives, and system packages (.deb, .rpm, AppImages).

Runs `ir upgrade` on Linux and macOS to update all installed packages.

Follows the same pattern as getnf and tpack steps.

Closes #1789

**This PR was authored by a human with AI coding assistance.**