### PR TITLE
feat(step): add soar

### DIFF
--- a/src/step.rs
+++ b/src/step.rs
@@ -149,6 +149,7 @@ pub enum Step {
     Rye,
     Scoop,
     Sdkman,
+    Soar,
     SelfUpdate,
     Sheldon,
     Shell,
@@ -578,6 +579,11 @@ impl Step {
                 #[cfg(unix)]
                 runner.execute(*self, "SDKMAN!", || unix::run_sdkman(ctx))?
             }
+            Soar =>
+            {
+                #[cfg(unix)]
+                runner.execute(*self, "soar", || generic::run_soar(ctx))?
+            }
             SelfUpdate => {
                 // Self-Update step, this will execute only if:
                 // 1. the `self-update` feature is enabled
@@ -833,6 +839,7 @@ pub(crate) fn default_steps() -> Vec<Step> {
         GnomeShellExtensions,
         Pyenv,
         Sdkman,
+        Soar,
         Rcm,
         Maza,
         Hyprpm,

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -176,6 +176,14 @@ pub fn run_getnf_update(ctx: &ExecutionContext) -> Result<()> {
     ctx.execute(getnf).args(["-U"]).status_checked()
 }
 
+pub fn run_soar(ctx: &ExecutionContext) -> Result<()> {
+    let soar = require("soar")?;
+
+    print_separator("soar");
+
+    ctx.execute(soar).arg("update").status_checked()
+}
+
 pub fn run_sheldon(ctx: &ExecutionContext) -> Result<()> {
     let sheldon = require("sheldon")?;
 


### PR DESCRIPTION
Adds support for [soar](https://github.com/pkgforge/soar), a package manager for static binaries, AppImages, AppBundles, FlatImages, and other portable formats.

Runs `soar update` on Unix systems. Follows the same pattern as the getnf and install-release steps.

Closes #1377

**This PR was authored by a human with AI coding assistance.**