### PR TITLE
feat(gup): add exclude config

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -322,6 +322,10 @@
 # (default: false)
 # interactive = false
 
+[go]
+# Exclude specified binaries from `gup update`
+# gup_exclude = ["kind", "pkgsite"]
+
 
 [npm]
 # Use sudo if the NPM directory isn't owned by the current user

--- a/src/config.rs
+++ b/src/config.rs
@@ -214,6 +214,13 @@ pub struct Brew {
     fetch_head: Option<bool>,
 }
 
+#[derive(Deserialize, Default, Debug, Merge)]
+#[serde(deny_unknown_fields)]
+pub struct Go {
+    #[merge(strategy = crate::utils::merge_strategies::vec_prepend_opt)]
+    gup_exclude: Option<Vec<String>>,
+}
+
 #[derive(Debug, Deserialize, Clone, Copy, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum ArchPackageManager {
@@ -508,6 +515,9 @@ pub struct ConfigFile {
 
     #[merge(strategy = crate::utils::merge_strategies::inner_merge_opt)]
     git: Option<Git>,
+
+    #[merge(strategy = crate::utils::merge_strategies::inner_merge_opt)]
+    go: Option<Go>,
 
     #[merge(strategy = crate::utils::merge_strategies::inner_merge_opt)]
     containers: Option<Containers>,
@@ -1438,6 +1448,15 @@ impl Config {
             .as_ref()
             .and_then(|c| c.force_plug_update)
             .unwrap_or(false)
+    }
+
+    /// Binaries to exclude from `gup update`
+    pub fn gup_exclude(&self) -> &[String] {
+        self.config_file
+            .go
+            .as_ref()
+            .and_then(|g| g.gup_exclude.as_deref())
+            .unwrap_or(&[])
     }
 
     /// Whether to send a desktop notification at the beginning of every step

--- a/src/steps/go.rs
+++ b/src/steps/go.rs
@@ -23,7 +23,14 @@ pub fn run_go_gup(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("gup");
 
-    ctx.execute(gup).arg("update").status_checked()
+    let mut command = ctx.execute(gup);
+    command.arg("update");
+
+    for exclude in ctx.config().gup_exclude() {
+        command.args(["--exclude", exclude]);
+    }
+
+    command.status_checked()
 }
 
 /// Get the path of a Go binary.


### PR DESCRIPTION
## What does this PR do

Adds a `[go]` config section with a `gup_exclude` option that passes `--exclude` flags to `gup update`. This lets users pin specific Go-installed binaries to non-latest versions without skipping the entire gup step.

Example config:
```toml
[go]
gup_exclude = ["kind", "pkgsite"]
```

This produces: `gup update --exclude kind --exclude pkgsite`

The approach follows the config subsection pattern endorsed by @SteveLauC in [#604](https://github.com/topgrade-rs/topgrade/issues/604#issuecomment-1805451374).

Closes #604

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] I have tested the code myself, with the relevant tools installed.
- [ ] If this PR introduces new user-facing messages they are translated

### AI involvement

used AI tools (Claude Code) for code suggestions while implementing this. The config pattern, approach, and testing were done by me 👦🏻

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)