### PR TITLE
fix(sparkle): correct CLI argument usage

### DIFF
--- a/src/steps/os/macos.rs
+++ b/src/steps/os/macos.rs
@@ -124,13 +124,13 @@ pub fn run_sparkle(ctx: &ExecutionContext) -> Result<()> {
         let probe = ctx
             .execute(&sparkle)
             .always()
-            .args(["--probe", "--application"])
             .arg(application.path())
+            .args(["--probe", "--user-agent-name", "topgrade"])
             .output_checked_utf8();
         if probe.is_ok() {
             let mut command = ctx.execute(&sparkle);
-            command.args(["bundle", "--check-immediately", "--application"]);
             command.arg(application.path());
+            command.args(["--check-immediately", "--user-agent-name", "topgrade"]);
             command.status_checked()?;
         }
     }

--- a/src/steps/os/macos.rs
+++ b/src/steps/os/macos.rs
@@ -121,18 +121,10 @@ pub fn run_sparkle(ctx: &ExecutionContext) -> Result<()> {
     print_separator("Sparkle");
 
     for application in (fs::read_dir("/Applications")?).flatten() {
-        let probe = ctx
-            .execute(&sparkle)
-            .always()
-            .arg(application.path())
-            .args(["--probe", "--user-agent-name", "topgrade"])
-            .output_checked_utf8();
-        if probe.is_ok() {
-            let mut command = ctx.execute(&sparkle);
-            command.arg(application.path());
-            command.args(["--check-immediately", "--user-agent-name", "topgrade"]);
-            command.status_checked()?;
-        }
+        let mut command = ctx.execute(&sparkle);
+        command.arg(application.path());
+        command.args(["--check-immediately", "--user-agent-name", "topgrade"]);
+        command.status_checked()?;
     }
     Ok(())
 }

--- a/src/steps/os/macos.rs
+++ b/src/steps/os/macos.rs
@@ -121,10 +121,18 @@ pub fn run_sparkle(ctx: &ExecutionContext) -> Result<()> {
     print_separator("Sparkle");
 
     for application in (fs::read_dir("/Applications")?).flatten() {
-        let mut command = ctx.execute(&sparkle);
-        command.arg(application.path());
-        command.args(["--check-immediately", "--user-agent-name", "topgrade"]);
-        command.status_checked()?;
+        let probe = ctx
+            .execute(&sparkle)
+            .always()
+            .arg(application.path())
+            .args(["--probe", "--user-agent-name", "topgrade"])
+            .output_checked_utf8();
+        if probe.is_ok() {
+            let mut command = ctx.execute(&sparkle);
+            command.arg(application.path());
+            command.args(["--check-immediately", "--user-agent-name", "topgrade"]);
+            command.status_checked()?;
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
## What does this PR do

The Sparkle step was passing incorrect arguments to the `sparkle` CLI, causing it to fail silently for every application in `/Applications`.

The `sparkle` CLI expects the app bundle path as a positional argument, not via `--application`. The word `bundle` in the old code was treated as a subcommand, but it's actually a placeholder that should be replaced with the actual path.

This fix changes both the probe and update calls to use the correct syntax:
- Probe: `sparkle <app_path> --probe --user-agent-name topgrade`
- Update: `sparkle <app_path> --check-immediately --user-agent-name topgrade`

Based on the approach discussed by @GideonBear and @F1248 in #1517.

Closes #1517

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [x] If this PR introduces new user-facing messages they are translated

### AI involvement

Used Claude for Rust syntax help. The implementation approach came from the maintainer discussion in #1517.