### PR TITLE
feat: show step id in execution separator

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -9,7 +9,7 @@ use crate::ctrlc;
 use crate::error::{DryRun, MissingSudo, SkipStep};
 use crate::execution_context::ExecutionContext;
 use crate::step::Step;
-use crate::terminal::{ShouldRetry, print_error, print_warning, should_retry};
+use crate::terminal::{ShouldRetry, print_error, print_warning, set_current_step_id, should_retry};
 
 pub enum StepResult {
     Success,
@@ -85,6 +85,7 @@ impl<'a> Runner<'a> {
 
         let key: Cow<'a, str> = key.into();
         debug!("Step {:?}", key);
+        set_current_step_id(Some(step.to_string()));
 
         // alter the `func` to put it in a span
         let func = || {
@@ -150,6 +151,7 @@ impl<'a> Runner<'a> {
                             }
                             RetryDecision::Quit => {
                                 self.push_result(key, StepResult::Failure);
+                                set_current_step_id(None);
                                 return Err(io::Error::from(io::ErrorKind::Interrupted))
                                     .context("Quit from user input");
                             }
@@ -173,6 +175,7 @@ impl<'a> Runner<'a> {
             }
         }
 
+        set_current_step_id(None);
         Ok(())
     }
 

--- a/src/step.rs
+++ b/src/step.rs
@@ -5,7 +5,7 @@ use color_eyre::Result;
 #[cfg(target_os = "linux")]
 use rust_i18n::t;
 use serde::Deserialize;
-use strum::{EnumCount, EnumIter, EnumString, VariantNames};
+use strum::{Display, EnumCount, EnumIter, EnumString, VariantNames};
 
 #[cfg(feature = "self-update")]
 use crate::self_update;
@@ -16,7 +16,9 @@ use crate::utils::hostname;
 
 pub const DEPRECATED_STEPS: [Step; 1] = [Step::NixHelper];
 
-#[derive(ValueEnum, EnumString, VariantNames, Debug, Clone, PartialEq, Eq, Deserialize, EnumIter, Copy, EnumCount)]
+#[derive(
+    ValueEnum, EnumString, VariantNames, Debug, Clone, PartialEq, Eq, Deserialize, EnumIter, Copy, EnumCount, Display,
+)]
 #[clap(rename_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -19,6 +19,11 @@ use crate::command::CommandExt;
 use crate::runner::StepResult;
 
 static TERMINAL: LazyLock<Mutex<Terminal>> = LazyLock::new(|| Mutex::new(Terminal::new()));
+static CURRENT_STEP_ID: LazyLock<Mutex<Option<String>>> = LazyLock::new(|| Mutex::new(None));
+
+pub fn set_current_step_id(id: Option<String>) {
+    *CURRENT_STEP_ID.lock().expect("Current step mutex poisoned") = id;
+}
 
 #[cfg(unix)]
 pub fn shell() -> String {
@@ -84,13 +89,18 @@ impl Terminal {
     }
 
     fn print_separator<P: AsRef<str>>(&mut self, message: P) {
+        let message = if let Some(step_id) = CURRENT_STEP_ID.lock().expect("Current step mutex poisoned").clone() {
+            format!("{} ({step_id})", message.as_ref())
+        } else {
+            message.as_ref().to_string()
+        };
+
         if self.set_title {
-            self.term
-                .set_title(format!("{}Topgrade - {}", self.prefix, message.as_ref()));
+            self.term.set_title(format!("{}Topgrade - {}", self.prefix, message));
         }
 
         if self.desktop_notification {
-            self.notify_desktop(message.as_ref(), Some(Duration::from_secs(5)));
+            self.notify_desktop(&message, Some(Duration::from_secs(5)));
         }
 
         let now = Local::now();
@@ -101,10 +111,10 @@ impl Terminal {
                 now.hour(),
                 now.minute(),
                 now.second(),
-                message.as_ref()
+                message
             )
         } else {
-            String::from(message.as_ref())
+            message
         };
 
         match self.width {


### PR DESCRIPTION
## What does this PR do

Shows the step ID (used for `--only` and `--disable` flags) alongside the display name in the execution separator. The output changes from:

```
── Sparkle ──────────────────
```

to:

```
── Sparkle (sparkle) ────────
```

This makes it easy to find the right step name when you want to skip or isolate a step. The step ID is the snake_case name that `--only` and `--disable` accept.

Implementation adds `strum::Display` to the Step enum and passes the current step ID from the runner to the separator via a static in `terminal.rs`.

Closes #1467

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [x] If this PR introduces new user-facing messages they are translated

### AI involvement

Used Claude for Rust syntax help with strum derives and mutex patterns. The implementation approach (storing step ID in terminal static, reading it in print_separator) was designed by me.