### PR TITLE
fix(skills): skip npx update prompt with assume_yes

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -2087,5 +2087,12 @@ pub fn run_skills(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("Skills");
 
-    ctx.execute(npx).args(["--yes", "skills", "update"]).status_checked()
+    let mut command = ctx.execute(npx);
+
+    if ctx.config().yes(Step::Skills) {
+        command.arg("--yes");
+    }
+    command.args(["skills", "update"]);
+
+    command.status_checked()
 }

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -2087,5 +2087,5 @@ pub fn run_skills(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("Skills");
 
-    ctx.execute(npx).args(["skills", "update"]).status_checked()
+    ctx.execute(npx).args(["--yes", "skills", "update"]).status_checked()
 }


### PR DESCRIPTION
## What does this PR do

Every time `skills` releases a new version, this step gets stuck waiting for a user input:
```
❯ npx skills update
Need to install the following packages:
skills@1.4.9
Ok to proceed? (y)
```

This PR changes to automatically install new versions

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [ ] If this PR introduces new user-facing messages they are translated

### AI involvement


## For new steps

<!-- This section can be deleted if you are not adding a new step. -->

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by
  the underlying command

<!-- If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here. -->
