### PR TITLE
chore(deps): update rust crate merge to 0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1690,7 +1690,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,7 +202,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -237,7 +237,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -442,7 +442,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -659,7 +659,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -689,7 +689,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -741,7 +741,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -842,7 +842,7 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1046,7 +1046,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1693,9 +1693,9 @@ dependencies = [
 
 [[package]]
 name = "merge"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10bbef93abb1da61525bbc45eeaff6473a41907d19f8f9aa5168d214e10693e9"
+checksum = "56e520ba58faea3487f75df198b1d079644ec226ea3b0507d002c6fa4b8cf93a"
 dependencies = [
  "merge_derive",
  "num-traits",
@@ -1703,14 +1703,14 @@ dependencies = [
 
 [[package]]
 name = "merge_derive"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "209d075476da2e63b4b29e72a2ef627b840589588e71400a25e3565c4f849d07"
+checksum = "5c8f8ce6efff81cbc83caf4af0905c46e58cb46892f63ad3835e81b47eaf7968"
 dependencies = [
- "proc-macro-error",
+ "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -2030,7 +2030,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2043,27 +2043,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
+name = "proc-macro-error-attr2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
 dependencies = [
- "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
- "version_check",
 ]
 
 [[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
+name = "proc-macro-error2"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
 dependencies = [
+ "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "version_check",
+ "syn",
 ]
 
 [[package]]
@@ -2354,7 +2352,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2564,7 +2562,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2588,7 +2586,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2780,7 +2778,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2788,17 +2786,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"
@@ -2828,7 +2815,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2916,7 +2903,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2927,7 +2914,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3248,7 +3235,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3559,7 +3546,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -3798,7 +3785,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3809,7 +3796,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4131,7 +4118,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn 2.0.117",
+ "syn",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -4147,7 +4134,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -4230,7 +4217,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
@@ -4278,7 +4265,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "zbus_names",
  "zvariant",
  "zvariant_utils",
@@ -4312,7 +4299,7 @@ checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4332,7 +4319,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
@@ -4372,7 +4359,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4448,7 +4435,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "zvariant_utils",
 ]
 
@@ -4461,6 +4448,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.117",
+ "syn",
  "winnow 0.7.15",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ shell-words = "1.1"
 color-eyre = "0.6"
 tracing = { version = "0.1", features = ["attributes", "log"] }
 tracing-subscriber = { version = "0.3.20", features = ["env-filter", "time"] }
-merge = "0.1"
+merge = "0.2"
 regex-split = "0.1"
 notify-rust = "4.12.0"
 wildmatch = "2.3.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -58,20 +58,25 @@ pub struct Include {
 pub struct Containers {
     #[merge(strategy = crate::utils::merge_strategies::vec_prepend_opt)]
     ignored_containers: Option<Vec<String>>,
+    #[merge(strategy = merge::option::overwrite_none)]
     runtime: Option<ContainerRuntime>,
+    #[merge(strategy = merge::option::overwrite_none)]
     system_prune: Option<bool>,
+    #[merge(strategy = merge::option::overwrite_none)]
     use_sudo: Option<bool>,
 }
 
 #[derive(Deserialize, Default, Debug, Merge)]
 #[serde(deny_unknown_fields)]
 pub struct Mandb {
+    #[merge(strategy = merge::option::overwrite_none)]
     enable: Option<bool>,
 }
 
 #[derive(Deserialize, Default, Debug, Merge)]
 #[serde(deny_unknown_fields)]
 pub struct Git {
+    #[merge(strategy = merge::option::overwrite_none)]
     max_concurrency: Option<usize>,
 
     #[merge(strategy = crate::utils::merge_strategies::string_append_opt)]
@@ -80,8 +85,10 @@ pub struct Git {
     #[merge(strategy = crate::utils::merge_strategies::vec_prepend_opt)]
     repos: Option<Vec<String>>,
 
+    #[merge(strategy = merge::option::overwrite_none)]
     pull_predefined: Option<bool>,
 
+    #[merge(strategy = merge::option::overwrite_none)]
     fetch_only: Option<bool>,
 }
 
@@ -91,7 +98,9 @@ pub struct Vagrant {
     #[merge(strategy = crate::utils::merge_strategies::vec_prepend_opt)]
     directories: Option<Vec<String>>,
 
+    #[merge(strategy = merge::option::overwrite_none)]
     power_on: Option<bool>,
+    #[merge(strategy = merge::option::overwrite_none)]
     always_suspend: Option<bool>,
 }
 
@@ -107,23 +116,36 @@ pub enum UpdatesAutoReboot {
 #[derive(Deserialize, Default, Debug, Merge)]
 #[serde(deny_unknown_fields)]
 pub struct Windows {
+    #[merge(strategy = merge::option::overwrite_none)]
     accept_all_updates: Option<bool>,
+    #[merge(strategy = merge::option::overwrite_none)]
     updates_auto_reboot: Option<UpdatesAutoReboot>,
+    #[merge(strategy = merge::option::overwrite_none)]
     self_rename: Option<bool>,
+    #[merge(strategy = merge::option::overwrite_none)]
     open_remotes_in_new_terminal: Option<bool>,
+    #[merge(strategy = merge::option::overwrite_none)]
     wsl_update_pre_release: Option<bool>,
+    #[merge(strategy = merge::option::overwrite_none)]
     wsl_update_use_web_download: Option<bool>,
+    #[merge(strategy = merge::option::overwrite_none)]
     winget_silent_install: Option<bool>,
+    #[merge(strategy = merge::option::overwrite_none)]
     winget_use_sudo: Option<bool>,
 }
 
 #[derive(Deserialize, Default, Debug, Merge)]
 #[serde(deny_unknown_fields)]
 pub struct Python {
+    #[merge(strategy = merge::option::overwrite_none)]
     enable_pip_review: Option<bool>,
+    #[merge(strategy = merge::option::overwrite_none)]
     enable_pip_review_local: Option<bool>,
+    #[merge(strategy = merge::option::overwrite_none)]
     enable_pipupgrade: Option<bool>,
+    #[merge(strategy = merge::option::overwrite_none)]
     pipupgrade_arguments: Option<String>,
+    #[merge(strategy = merge::option::overwrite_none)]
     poetry_force_self_update: Option<bool>,
 }
 
@@ -141,6 +163,7 @@ pub struct Conda {
 #[serde(deny_unknown_fields)]
 #[allow(clippy::upper_case_acronyms)]
 pub struct Distrobox {
+    #[merge(strategy = merge::option::overwrite_none)]
     use_root: Option<bool>,
 
     #[merge(strategy = crate::utils::merge_strategies::vec_prepend_opt)]
@@ -151,6 +174,7 @@ pub struct Distrobox {
 #[serde(deny_unknown_fields)]
 #[allow(clippy::upper_case_acronyms)]
 pub struct Yarn {
+    #[merge(strategy = merge::option::overwrite_none)]
     use_sudo: Option<bool>,
 }
 
@@ -158,6 +182,7 @@ pub struct Yarn {
 #[serde(deny_unknown_fields)]
 #[allow(clippy::upper_case_acronyms)]
 pub struct NPM {
+    #[merge(strategy = merge::option::overwrite_none)]
     use_sudo: Option<bool>,
 }
 
@@ -165,6 +190,7 @@ pub struct NPM {
 #[serde(deny_unknown_fields)]
 #[allow(clippy::upper_case_acronyms)]
 pub struct Deno {
+    #[merge(strategy = merge::option::overwrite_none)]
     version: Option<String>,
 }
 
@@ -172,6 +198,7 @@ pub struct Deno {
 #[serde(deny_unknown_fields)]
 #[allow(clippy::upper_case_acronyms)]
 pub struct Chezmoi {
+    #[merge(strategy = merge::option::overwrite_none)]
     exclude_encrypted: Option<bool>,
 }
 
@@ -179,8 +206,11 @@ pub struct Chezmoi {
 #[serde(deny_unknown_fields)]
 #[allow(clippy::upper_case_acronyms)]
 pub struct Mise {
+    #[merge(strategy = merge::option::overwrite_none)]
     bump: Option<bool>,
+    #[merge(strategy = merge::option::overwrite_none)]
     interactive: Option<bool>,
+    #[merge(strategy = merge::option::overwrite_none)]
     jobs: Option<u32>,
 }
 
@@ -188,6 +218,7 @@ pub struct Mise {
 #[serde(deny_unknown_fields)]
 #[allow(clippy::upper_case_acronyms)]
 pub struct Firmware {
+    #[merge(strategy = merge::option::overwrite_none)]
     upgrade: Option<bool>,
 }
 
@@ -195,6 +226,7 @@ pub struct Firmware {
 #[serde(deny_unknown_fields)]
 #[allow(clippy::upper_case_acronyms)]
 pub struct Flatpak {
+    #[merge(strategy = merge::option::overwrite_none)]
     use_sudo: Option<bool>,
 }
 
@@ -202,16 +234,22 @@ pub struct Flatpak {
 #[serde(deny_unknown_fields)]
 #[allow(clippy::upper_case_acronyms)]
 pub struct Pixi {
+    #[merge(strategy = merge::option::overwrite_none)]
     include_release_notes: Option<bool>,
 }
 
 #[derive(Deserialize, Default, Debug, Merge)]
 #[serde(deny_unknown_fields)]
 pub struct Brew {
+    #[merge(strategy = merge::option::overwrite_none)]
     greedy_cask: Option<bool>,
+    #[merge(strategy = merge::option::overwrite_none)]
     greedy_latest: Option<bool>,
+    #[merge(strategy = merge::option::overwrite_none)]
     greedy_auto_updates: Option<bool>,
+    #[merge(strategy = merge::option::overwrite_none)]
     autoremove: Option<bool>,
+    #[merge(strategy = merge::option::overwrite_none)]
     fetch_head: Option<bool>,
 }
 
@@ -275,7 +313,9 @@ pub struct Linux {
 
     #[merge(strategy = crate::utils::merge_strategies::string_append_opt)]
     aura_pacman_arguments: Option<String>,
+    #[merge(strategy = merge::option::overwrite_none)]
     arch_package_manager: Option<ArchPackageManager>,
+    #[merge(strategy = merge::option::overwrite_none)]
     show_arch_news: Option<bool>,
 
     #[merge(strategy = crate::utils::merge_strategies::string_append_opt)]
@@ -305,10 +345,15 @@ pub struct Linux {
     #[merge(strategy = crate::utils::merge_strategies::string_append_opt)]
     apt_arguments: Option<String>,
 
+    #[merge(strategy = merge::option::overwrite_none)]
     enable_tlmgr: Option<bool>,
+    #[merge(strategy = merge::option::overwrite_none)]
     redhat_distro_sync: Option<bool>,
+    #[merge(strategy = merge::option::overwrite_none)]
     suse_dup: Option<bool>,
+    #[merge(strategy = merge::option::overwrite_none)]
     rpm_ostree: Option<bool>,
+    #[merge(strategy = merge::option::overwrite_none)]
     bootc: Option<bool>,
 
     #[merge(strategy = crate::utils::merge_strategies::string_append_opt)]
@@ -324,26 +369,33 @@ pub struct Linux {
 #[derive(Deserialize, Default, Debug, Merge)]
 #[serde(deny_unknown_fields)]
 pub struct Composer {
+    #[merge(strategy = merge::option::overwrite_none)]
     self_update: Option<bool>,
 }
 
 #[derive(Deserialize, Default, Debug, Merge)]
 #[serde(deny_unknown_fields)]
 pub struct Vim {
+    #[merge(strategy = merge::option::overwrite_none)]
     force_plug_update: Option<bool>,
 }
 
 #[derive(Deserialize, Default, Debug, Merge)]
 #[serde(deny_unknown_fields)]
 pub struct Misc {
+    #[merge(strategy = merge::option::overwrite_none)]
     allow_root: Option<bool>,
 
+    #[merge(strategy = merge::option::overwrite_none)]
     pre_sudo: Option<bool>,
 
+    #[merge(strategy = merge::option::overwrite_none)]
     sudo_loop: Option<bool>,
 
+    #[merge(strategy = merge::option::overwrite_none)]
     sudo_loop_interval: Option<u16>,
 
+    #[merge(strategy = merge::option::overwrite_none)]
     sudo_command: Option<SudoKind>,
 
     #[merge(strategy = crate::utils::merge_strategies::vec_prepend_opt)]
@@ -361,6 +413,7 @@ pub struct Misc {
     #[merge(strategy = crate::utils::merge_strategies::vec_prepend_opt)]
     remote_topgrades: Option<Vec<String>>,
 
+    #[merge(strategy = merge::option::overwrite_none)]
     remote_topgrade_path: Option<String>,
 
     #[merge(strategy = crate::utils::merge_strategies::string_append_opt)]
@@ -369,45 +422,63 @@ pub struct Misc {
     #[merge(strategy = crate::utils::merge_strategies::string_append_opt)]
     tmux_arguments: Option<String>,
 
+    #[merge(strategy = merge::option::overwrite_none)]
     set_title: Option<bool>,
 
+    #[merge(strategy = merge::option::overwrite_none)]
     display_time: Option<bool>,
 
+    #[merge(strategy = merge::option::overwrite_none)]
     assume_yes: Option<bool>,
 
+    #[merge(strategy = merge::option::overwrite_none)]
     ask_retry: Option<bool>,
 
+    #[merge(strategy = merge::option::overwrite_none)]
     auto_retry: Option<u16>,
 
     /// TODO: Remove this in favor of ask_retry = false
+    #[merge(strategy = merge::option::overwrite_none)]
     no_retry: Option<bool>,
 
+    #[merge(strategy = merge::option::overwrite_none)]
     show_skipped: Option<bool>,
 
+    #[merge(strategy = merge::option::overwrite_none)]
     run_in_tmux: Option<bool>,
 
+    #[merge(strategy = merge::option::overwrite_none)]
     tmux_session_mode: Option<TmuxSessionMode>,
 
+    #[merge(strategy = merge::option::overwrite_none)]
     cleanup: Option<bool>,
 
+    #[merge(strategy = merge::option::overwrite_none)]
     notify_each_step: Option<bool>,
 
     /// Deprecated: use `notify_end = "never"` instead
+    #[merge(strategy = merge::option::overwrite_none)]
     skip_notify: Option<bool>,
 
+    #[merge(strategy = merge::option::overwrite_none)]
     notify_end: Option<NotifyEnd>,
 
+    #[merge(strategy = merge::option::overwrite_none)]
     bashit_branch: Option<String>,
 
     #[merge(strategy = crate::utils::merge_strategies::vec_prepend_opt)]
     only: Option<Vec<Step>>,
 
+    #[merge(strategy = merge::option::overwrite_none)]
     no_self_update: Option<bool>,
 
+    #[merge(strategy = merge::option::overwrite_none)]
     log_filters: Option<Vec<String>>,
 
+    #[merge(strategy = merge::option::overwrite_none)]
     show_distribution_summary: Option<bool>,
 
+    #[merge(strategy = merge::option::overwrite_none)]
     nix_handler: Option<NixHandler>,
 }
 
@@ -442,52 +513,64 @@ pub struct TmuxConfig {
 #[derive(Deserialize, Default, Debug, Merge)]
 #[serde(deny_unknown_fields)]
 pub struct Lensfun {
+    #[merge(strategy = merge::option::overwrite_none)]
     use_sudo: Option<bool>,
 }
 
 #[derive(Deserialize, Default, Debug, Merge)]
 #[serde(deny_unknown_fields)]
 pub struct JuliaConfig {
+    #[merge(strategy = merge::option::overwrite_none)]
     startup_file: Option<bool>,
 }
 
 #[derive(Deserialize, Default, Debug, Merge)]
 #[serde(deny_unknown_fields)]
 pub struct Zigup {
+    #[merge(strategy = merge::option::overwrite_none)]
     target_versions: Option<Vec<String>>,
+    #[merge(strategy = merge::option::overwrite_none)]
     install_dir: Option<String>,
+    #[merge(strategy = merge::option::overwrite_none)]
     path_link: Option<String>,
+    #[merge(strategy = merge::option::overwrite_none)]
     cleanup: Option<bool>,
 }
 
 #[derive(Deserialize, Default, Debug, Merge)]
 #[serde(deny_unknown_fields)]
 pub struct VscodeConfig {
+    #[merge(strategy = merge::option::overwrite_none)]
     profile: Option<String>,
 }
 
 #[derive(Deserialize, Default, Debug, Merge)]
 #[serde(deny_unknown_fields)]
 pub struct DoomConfig {
+    #[merge(strategy = merge::option::overwrite_none)]
     aot: Option<bool>,
 }
 
 #[derive(Deserialize, Default, Debug, Merge)]
 #[serde(deny_unknown_fields)]
 pub struct Cargo {
+    #[merge(strategy = merge::option::overwrite_none)]
     git: Option<bool>,
+    #[merge(strategy = merge::option::overwrite_none)]
     quiet: Option<bool>,
 }
 
 #[derive(Deserialize, Default, Debug, Merge)]
 #[serde(deny_unknown_fields)]
 pub struct Rustup {
+    #[merge(strategy = merge::option::overwrite_none)]
     channels: Option<Vec<String>>,
 }
 
 #[derive(Deserialize, Default, Debug, Merge)]
 #[serde(deny_unknown_fields)]
 pub struct Pkgfile {
+    #[merge(strategy = merge::option::overwrite_none)]
     enable: Option<bool>,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -2204,6 +2204,33 @@ mod test {
 
     use crate::config::*;
     use color_eyre::eyre::eyre;
+    use merge::Merge;
+
+    /// Regression test: verify that `overwrite_none` merge strategy preserves
+    /// existing (left) values and only fills in `None` fields from right.
+    /// Guards against future `merge` crate upgrades changing config precedence.
+    #[test]
+    fn merge_overwrite_none_preserves_left_values() {
+        let mut left = Containers {
+            ignored_containers: None,
+            runtime: Some(ContainerRuntime::Podman),
+            system_prune: Some(false),
+            use_sudo: None,
+        };
+        let right = Containers {
+            ignored_containers: None,
+            runtime: Some(ContainerRuntime::Docker),
+            system_prune: None,
+            use_sudo: Some(true),
+        };
+        left.merge(right);
+
+        // Left Some is preserved even when right is also Some
+        assert!(matches!(left.runtime, Some(ContainerRuntime::Podman)));
+        assert_eq!(left.system_prune, Some(false));
+        // Left None is filled from right
+        assert_eq!(left.use_sudo, Some(true));
+    }
 
     /// Test the default configuration in `config.example.toml` is valid.
     #[test]


### PR DESCRIPTION
## What does this PR do

Updates the `merge` crate from 0.1 to 0.2 to resolve security advisory [RUSTSEC-2024-0370](https://rustsec.org/advisories/RUSTSEC-2024-0370.html).

fix #1558

`merge` 0.2 removed the blanket `impl Merge for Option<T>`. This PR adds explicit `#[merge(strategy = merge::option::overwrite_none)]` annotations to all bare `Option<T>` fields in config structs, preserving the exact same merge semantics (first-loaded config wins for scalar fields).

A regression test is included to guard against future merge crate upgrades silently changing config precedence.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [x] If this PR introduces new user-facing messages they are translated

### AI involvement

AI (Claude Code) was used to identify all ~79 bare `Option<T>` fields needing annotation and to draft the regression test. All changes were reviewed and verified by the author.

## For new steps

N/A — no new steps added.

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->