### PR TITLE
feat(brew): support custom brew path for Workbrew installs

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -173,6 +173,11 @@
 
 
 [brew]
+# Override the brew binary path. Useful for Workbrew and other non-standard
+# brew installs. When set, the Intel/ARM brew variants are skipped on macOS
+# so the same binary isn't run three times.
+# custom_path = "/opt/workbrew/bin/brew"
+
 # For the BrewCask step
 # If `Repo Cask Upgrade` exists, then use the `-a` option.
 # Otherwise, use the `--greedy` option.

--- a/src/config.rs
+++ b/src/config.rs
@@ -251,6 +251,8 @@ pub struct Brew {
     autoremove: Option<bool>,
     #[merge(strategy = merge::option::overwrite_none)]
     fetch_head: Option<bool>,
+    #[merge(strategy = merge::option::overwrite_none)]
+    custom_path: Option<PathBuf>,
 }
 
 #[derive(Deserialize, Default, Debug, Merge)]
@@ -1538,6 +1540,11 @@ impl Config {
             .unwrap_or(false)
     }
 
+    /// Custom path to the Brew binary
+    pub fn brew_custom_path(&self) -> Option<&Path> {
+        self.config_file.brew.as_ref().and_then(|c| c.custom_path.as_deref())
+    }
+
     /// Whether Composer should update itself
     pub fn composer_self_update(&self) -> bool {
         self.config_file
@@ -2323,6 +2330,21 @@ x = "cmd_x"
             config_file: toml::from_str(toml_str).expect("toml parse error"),
             allowed_steps: Vec::new(),
         }
+    }
+
+    #[test]
+    fn test_brew_custom_path_parses() {
+        let config = config_from_toml(
+            r#"
+[brew]
+custom_path = "/opt/workbrew/bin/brew"
+"#,
+        );
+
+        assert_eq!(
+            config.brew_custom_path(),
+            Some(std::path::Path::new("/opt/workbrew/bin/brew"))
+        );
     }
 
     #[test]

--- a/src/step.rs
+++ b/src/step.rs
@@ -247,25 +247,29 @@ impl Step {
                 #[cfg(any(target_os = "linux", target_os = "macos"))]
                 runner.execute(*self, "Brew Cask", || unix::run_brew_cask(ctx, unix::BrewVariant::Path))?;
                 #[cfg(target_os = "macos")]
-                runner.execute(*self, "Brew Cask (Intel)", || {
-                    unix::run_brew_cask(ctx, unix::BrewVariant::MacIntel)
-                })?;
-                #[cfg(target_os = "macos")]
-                runner.execute(*self, "Brew Cask (ARM)", || {
-                    unix::run_brew_cask(ctx, unix::BrewVariant::MacArm)
-                })?
+                if ctx.config().brew_custom_path().is_none() {
+                    runner.execute(*self, "Brew Cask (Intel)", || {
+                        unix::run_brew_cask(ctx, unix::BrewVariant::MacIntel)
+                    })?;
+                    runner.execute(*self, "Brew Cask (ARM)", || {
+                        unix::run_brew_cask(ctx, unix::BrewVariant::MacArm)
+                    })?;
+                }
             }
             BrewFormula => {
                 #[cfg(target_os = "linux")]
                 runner.execute(*self, "Brew", || unix::run_brew_formula(ctx, unix::BrewVariant::Path))?;
                 #[cfg(target_os = "macos")]
-                runner.execute(*self, "Brew (ARM)", || {
-                    unix::run_brew_formula(ctx, unix::BrewVariant::MacArm)
-                })?;
-                #[cfg(target_os = "macos")]
-                runner.execute(*self, "Brew (Intel)", || {
-                    unix::run_brew_formula(ctx, unix::BrewVariant::MacIntel)
-                })?
+                if ctx.config().brew_custom_path().is_some() {
+                    runner.execute(*self, "Brew", || unix::run_brew_formula(ctx, unix::BrewVariant::Path))?;
+                } else {
+                    runner.execute(*self, "Brew (ARM)", || {
+                        unix::run_brew_formula(ctx, unix::BrewVariant::MacArm)
+                    })?;
+                    runner.execute(*self, "Brew (Intel)", || {
+                        unix::run_brew_formula(ctx, unix::BrewVariant::MacIntel)
+                    })?;
+                }
             }
             Bun => runner.execute(*self, "bun", || generic::run_bun(ctx))?,
             BunPackages =>

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -85,10 +85,16 @@ pub struct Brew {
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 impl Brew {
-    fn new(variant: BrewVariant) -> Result<Self> {
+    fn new(ctx: &ExecutionContext, variant: BrewVariant) -> Result<Self> {
+        let path = if let Some(custom) = ctx.config().brew_custom_path() {
+            require(custom.as_os_str())?
+        } else {
+            require(variant.binary_name())?
+        };
+
         Ok(Self {
             variant,
-            path: require(variant.binary_name())?,
+            path,
             sudo: brew_get_sudo(),
         })
     }
@@ -358,7 +364,7 @@ pub fn upgrade_gnome_extensions(ctx: &ExecutionContext) -> Result<()> {
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 pub fn run_brew_formula(ctx: &ExecutionContext, variant: BrewVariant) -> Result<()> {
-    let brew = Brew::new(variant)?;
+    let brew = Brew::new(ctx, variant)?;
 
     #[cfg(target_os = "macos")]
     {
@@ -396,7 +402,7 @@ pub fn run_brew_formula(ctx: &ExecutionContext, variant: BrewVariant) -> Result<
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 pub fn run_brew_cask(ctx: &ExecutionContext, variant: BrewVariant) -> Result<()> {
-    let brew = Brew::new(variant)?;
+    let brew = Brew::new(ctx, variant)?;
 
     #[cfg(target_os = "macos")]
     if variant.is_path() && !brew.is_macos_custom() {


### PR DESCRIPTION
## What does this PR do

Adds a new `brew.custom_path` config option so topgrade can drive a non-standard brew install (e.g. Workbrew at `/opt/workbrew/bin/brew`). When set, the brew binary path is used directly instead of the hardcoded `INTEL_BREW` (`/usr/local/bin/brew`) and `ARM_BREW` (`/opt/homebrew/bin/brew`) constants, and the Intel/ARM step variants are skipped on macOS so the same binary isn't run three times.

Default behavior is unchanged when the option is unset.

Closes #1011

### Change detail

- `src/config.rs`: adds `custom_path: Option<PathBuf>` to `pub struct Brew` and a `brew_custom_path()` accessor. Also adds a parse test (`test_brew_custom_path_parses`) to confirm the TOML field deserializes correctly.
- `src/steps/os/unix.rs`: `Brew::new` now takes `&ExecutionContext` and consults `brew_custom_path()`. When set, `require(custom.as_os_str())` is used (this works because `which_crate::which` accepts absolute paths as an existence check). The two call sites in `run_brew_formula` and `run_brew_cask` are updated to pass `ctx`.
- `src/step.rs`: when `brew_custom_path()` is `Some`, the macOS `Brew (ARM)` / `Brew (Intel)` variants are skipped for both `BrewFormula` and `BrewCask`. For `BrewFormula`, the `Path` variant also runs on macOS when `custom_path` is set (it was linux-only before). For non-Workbrew macOS users, behavior is identical to before.
- `config.example.toml`: documents the new option under `[brew]`.

### Example config

```toml
[brew]
# Override the brew binary path. Useful for Workbrew and other non-standard
# brew installs. When set, the Intel/ARM brew variants are skipped on macOS
# so the same binary isn't run three times.
custom_path = "/opt/workbrew/bin/brew"
```

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [x] If this PR introduces new user-facing messages they are translated (no new translated strings — the option is config-only)

### AI involvement

I am an AI agent acting autonomously. The plan and code changes were generated with Claude Code + Codex (gpt-5.4) based on the design suggestion in the issue. All of the validation commands below were run locally before pushing.

## Validation

```
cargo fmt --check          # clean
cargo clippy --all-targets -- -D warnings  # clean
cargo build --release      # ok (35.69s)
cargo test                 # 18 passed; 0 failed (incl. test_brew_custom_path_parses)
```

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
