### PR TITLE
feat(step): add vite+

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -356,6 +356,11 @@
 # version = "stable"
 
 
+[viteplus]
+# Use sudo if the Vite+ directory isn't owned by the current user
+# use_sudo = true
+
+
 [vim]
 # For `vim-plug`, execute `PlugUpdate!` instead of `PlugUpdate`
 # force_plug_update = true

--- a/src/config.rs
+++ b/src/config.rs
@@ -181,6 +181,14 @@ pub struct Yarn {
 #[derive(Deserialize, Default, Debug, Merge)]
 #[serde(deny_unknown_fields)]
 #[allow(clippy::upper_case_acronyms)]
+pub struct VitePlus {
+    #[merge(strategy = merge::option::overwrite_none)]
+    use_sudo: Option<bool>,
+}
+
+#[derive(Deserialize, Default, Debug, Merge)]
+#[serde(deny_unknown_fields)]
+#[allow(clippy::upper_case_acronyms)]
 pub struct NPM {
     #[merge(strategy = merge::option::overwrite_none)]
     use_sudo: Option<bool>,
@@ -679,6 +687,9 @@ pub struct ConfigFile {
 
     #[merge(strategy = crate::utils::merge_strategies::inner_merge_opt)]
     pkgfile: Option<Pkgfile>,
+
+    #[merge(strategy = crate::utils::merge_strategies::inner_merge_opt)]
+    viteplus: Option<VitePlus>,
 }
 
 fn config_directory() -> PathBuf {
@@ -1998,6 +2009,14 @@ impl Config {
             .yarn
             .as_ref()
             .and_then(|yarn| yarn.use_sudo)
+            .unwrap_or(false)
+    }
+    #[cfg(target_os = "linux")]
+    pub fn viteplus_use_sudo(&self) -> bool {
+        self.config_file
+            .viteplus
+            .as_ref()
+            .and_then(|viteplus| viteplus.use_sudo)
             .unwrap_or(false)
     }
 

--- a/src/step.rs
+++ b/src/step.rs
@@ -171,6 +171,7 @@ pub enum Step {
     Vagrant,
     Vcpkg,
     Vim,
+    VitePlus,
     VoltaPackages,
     Vscode,
     VscodeInsiders,
@@ -691,6 +692,7 @@ impl Step {
                 runner.execute(*self, "The Ultimate vimrc", || vim::upgrade_ultimate_vimrc(ctx))?;
                 runner.execute(*self, "voom", || vim::run_voom(ctx))?
             }
+            VitePlus => runner.execute(*self, "viteplus", || node::run_viteplus_upgrade(ctx))?,
             VoltaPackages => runner.execute(*self, "volta packages", || node::run_volta_packages_upgrade(ctx))?,
             Vscode => runner.execute(*self, "Visual Studio Code extensions", || {
                 generic::run_vscode_extensions_update(ctx)
@@ -858,6 +860,7 @@ pub(crate) fn default_steps() -> Vec<Step> {
         Yarn,
         Pnpm,
         VoltaPackages,
+        VitePlus,
         Containers,
         Deno,
         Composer,

--- a/src/steps/node.rs
+++ b/src/steps/node.rs
@@ -258,13 +258,81 @@ impl Deno {
     }
 }
 
+struct VitePlus {
+    command: PathBuf,
+}
+
+impl VitePlus {
+    fn new(command: PathBuf) -> Self {
+        Self { command }
+    }
+
+    fn self_upgrade(&self, ctx: &ExecutionContext, use_sudo: bool) -> Result<()> {
+        let mut args = vec!["upgrade"];
+
+        if ctx.run_type().dry() {
+            args.push("--check");
+        }
+
+        if use_sudo {
+            let sudo = ctx.require_sudo()?;
+            sudo.execute(ctx, &self.command)?.args(args).status_checked()?;
+        } else {
+            ctx.execute(&self.command).args(args).status_checked()?;
+        }
+
+        Ok(())
+    }
+
+    fn upgrade_packages(&self, ctx: &ExecutionContext, use_sudo: bool) -> Result<()> {
+        let args = ["update", "--global"];
+
+        if use_sudo {
+            let sudo = ctx.require_sudo()?;
+            sudo.execute(ctx, &self.command)?.args(args).status_checked()?;
+        } else {
+            ctx.execute(&self.command).args(args).status_checked()?;
+        }
+
+        Ok(())
+    }
+
+    #[cfg(target_os = "linux")]
+    pub fn should_use_sudo(&self, _ctx: &ExecutionContext) -> Result<bool> {
+        let vp_home = match std::env::var_os("VP_HOME") {
+            None => return Ok(false),
+            Some(s) if s.is_empty() => return Ok(false),
+            Some(s) => s,
+        };
+
+        let uid = Uid::effective();
+        let metadata = std::fs::metadata(&vp_home)?;
+
+        Ok(metadata.uid() != uid.as_raw() && metadata.uid() == 0)
+    }
+}
+
 #[cfg(target_os = "linux")]
 fn should_use_sudo(npm: &NPM, ctx: &ExecutionContext) -> Result<bool> {
     if npm.should_use_sudo(ctx)? {
         if ctx.config().npm_use_sudo() {
             Ok(true)
         } else {
-            Err(SkipStep("NPM root is owned by another user which is not the current user. Set use_sudo = true under the NPM section in your configuration to run NPM as sudo".to_string())
+            Err(SkipStep(format!("{} root is owned by another user which is not the current user. Set use_sudo = true under the [npm] section in your configuration to run {} as sudo", npm.variant, npm.variant))
+                .into())
+        }
+    } else {
+        Ok(false)
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn should_use_sudo_viteplus(viteplus: &VitePlus, ctx: &ExecutionContext) -> Result<bool> {
+    if viteplus.should_use_sudo(ctx)? {
+        if ctx.config().viteplus_use_sudo() {
+            Ok(true)
+        } else {
+            Err(SkipStep("Vite+ root is owned by another user which is not the current user. Set use_sudo = true under the [viteplus] section in your configuration to run Vite+ as sudo".to_string())
                 .into())
         }
     } else {
@@ -278,7 +346,7 @@ fn should_use_sudo_yarn(yarn: &Yarn, ctx: &ExecutionContext) -> Result<bool> {
         if ctx.config().yarn_use_sudo() {
             Ok(true)
         } else {
-            Err(SkipStep("NPM root is owned by another user which is not the current user. Set use_sudo = true under the NPM section in your configuration to run NPM as sudo".to_string())
+            Err(SkipStep("Yarn root is owned by another user which is not the current user. Set use_sudo = true under the [yarn] section in your configuration to run Yarn as sudo".to_string())
                 .into())
         }
     } else {
@@ -316,6 +384,30 @@ pub fn run_pnpm_upgrade(ctx: &ExecutionContext) -> Result<()> {
     {
         pnpm.upgrade(ctx, false)
     }
+}
+
+pub fn run_viteplus_upgrade(ctx: &ExecutionContext) -> Result<()> {
+    let viteplus = require("vp").map(VitePlus::new)?;
+
+    // This is upstream's preferred branding for the tool
+    print_separator("Vite+");
+
+    let use_sudo;
+
+    #[cfg(target_os = "linux")]
+    {
+        use_sudo = should_use_sudo_viteplus(&viteplus, ctx)?;
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        use_sudo = false;
+    }
+
+    viteplus.self_upgrade(ctx, use_sudo)?;
+    viteplus.upgrade_packages(ctx, use_sudo)?;
+
+    Ok(())
 }
 
 pub fn run_yarn_upgrade(ctx: &ExecutionContext) -> Result<()> {


### PR DESCRIPTION
## What does this PR do
Add step to support the vite+ webdev toolchain. (https://viteplus.dev/guide/)

This step will trigger both the 'vp upgrade' self-update and the 'vp update -g' global package updater. Except for the exe name and args, it acts like all the other Node pms.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [x] If this PR introduces new user-facing messages they are translated

### AI involvement
Used Cursor to diag/fix rustc outputs.

## For new steps
- [x] *Optional:* Topgrade skips this step where needed
- [x] *Optional:* The `--dry-run` option works with this step
- [x] *Optional:* The `--yes` option works with this step if it is supported by
  the underlying command


```
── 12:50:43 - Vite Plus ────────────────────────────────────────────────────────
info: checking for updates...
info: found vite-plus@0.1.16 (current: 0.1.16)

✓ Already up to date (0.1.16)
Installing @openai/codex globally...
Installed @openai/codex v0.120.0
Binaries: codex

tip: Available short aliases: i = install, rm = remove, un = uninstall, up = update, ls = list, ln = link
```


<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
