### PR TITLE
feat(firmware): hint user to run fwupdmgr update when updates are available

### DIFF
--- a/locales/app.yml
+++ b/locales/app.yml
@@ -566,6 +566,8 @@ _version: 2
   zh_CN: "固件升级"
   zh_TW: "韌體更新"
   de: "Firmware-Updates"
+"fwupdmgr found firmware updates, but applying these is disabled in the config. Run 'fwupdmgr update' to update firmware manually.":
+  en: "fwupdmgr found firmware updates, but applying these is disabled in the config. Run 'fwupdmgr update' to update firmware manually."
 "Flatpak System Packages":
   en: "Flatpak System Packages"
   lt: "Flatpak sistemos paketai"

--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -16,7 +16,7 @@ use crate::steps::generic::is_wsl;
 use crate::steps::os::archlinux;
 use crate::steps::unix::{NhSwitchArgs, can_nh_switch, nh_switch};
 use crate::sudo::SudoExecuteOpts;
-use crate::terminal::{print_separator, prompt_yesno};
+use crate::terminal::{print_separator, print_warning, prompt_yesno};
 use crate::utils::{PathExt, require, require_flatpak, require_one, which};
 
 static OS_RELEASE_PATH: &str = "/etc/os-release";
@@ -941,10 +941,33 @@ pub fn run_fwupdmgr(ctx: &ExecutionContext) -> Result<()> {
         if ctx.config().yes(Step::System) {
             updmgr.arg("-y");
         }
+        updmgr.status_checked_with_codes(&[2])
     } else {
         updmgr.arg("get-updates");
+
+        // Exit 0 from `fwupdmgr get-updates` means firmware updates are available.
+        // Exit 2 means no updates. When updates exist but `firmware_upgrade` is
+        // disabled, hint to the user that they can apply them manually.
+        let has_updates = std::cell::Cell::new(false);
+        updmgr.status_checked_with(|status| {
+            if status.success() {
+                has_updates.set(true);
+                Ok(())
+            } else if status.code() == Some(2) {
+                Ok(())
+            } else {
+                Err(())
+            }
+        })?;
+
+        if has_updates.get() {
+            print_warning(t!(
+                "fwupdmgr found firmware updates, but applying these is disabled in the config. Run 'fwupdmgr update' to update firmware manually."
+            ));
+        }
+
+        Ok(())
     }
-    updmgr.status_checked_with_codes(&[2])
 }
 
 pub fn run_flatpak(ctx: &ExecutionContext) -> Result<()> {


### PR DESCRIPTION
## What does this PR do

When `firmware_upgrade` is disabled (the default), topgrade runs `fwupdmgr get-updates` which lists available firmware updates but gives the user no hint about how to apply them.

This change inspects the exit code of `fwupdmgr get-updates`. Exit 0 means updates are available; exit 2 means none. When updates exist and `firmware_upgrade` is disabled, it prints a yellow warning after the command output:

```
fwupdmgr found firmware updates, but applying these is disabled in the config. Run 'fwupdmgr update' to update firmware manually.
```

Behavior when `firmware_upgrade = true` is unchanged. Behavior when no updates are found is unchanged.

Approach was discussed and approved by @GideonBear in the issue thread.

Closes #1651

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [x] If this PR introduces new user-facing messages they are translated

I did not exercise this on a real machine with pending firmware updates (would need matching hardware and an outstanding LVFS update). Happy to add manual test output if a reviewer with suitable hardware can try it, or to walk through the logic on request.

The new user-facing message is added to `locales/app.yml` with an English entry only, matching the pattern of recent PRs that add strings without translating to every locale.

### AI involvement

AI generated the majority of the code in this PR. I wrote a plan covering the exact change (file, function, helper pattern, i18n key), then handed it to Codex CLI (gpt-5.3-codex) to produce the diff. I reviewed the output, ran `cargo fmt --check`, `cargo clippy`, and `cargo test` locally, and wrote this PR description by hand.
