### PR TITLE
feat(firmware): hint user to run fwupdmgr update when updates are available

### DIFF
--- a/locales/app.yml
+++ b/locales/app.yml
@@ -566,6 +566,14 @@ _version: 2
   zh_CN: "固件升级"
   zh_TW: "韌體更新"
   de: "Firmware-Updates"
+"fwupdmgr found firmware updates, but applying these is disabled in the config. Run 'fwupdmgr update' to update firmware manually.":
+  en: "fwupdmgr found firmware updates, but applying these is disabled in the config. Run 'fwupdmgr update' to update firmware manually."
+  lt: "fwupdmgr rado programinės aparatinės įrangos atnaujinimų, tačiau jų taikymas išjungtas konfigūracijoje. Paleiskite 'fwupdmgr update', kad atnaujintumėte rankiniu būdu."
+  es: "fwupdmgr encontró actualizaciones de firmware, pero su aplicación está deshabilitada en la configuración. Ejecute 'fwupdmgr update' para actualizar el firmware manualmente."
+  fr: "fwupdmgr a trouvé des mises à jour du firmware, mais leur application est désactivée dans la configuration. Exécutez 'fwupdmgr update' pour mettre à jour le firmware manuellement."
+  zh_CN: "fwupdmgr 找到了固件更新，但配置中已禁用自动应用。运行 'fwupdmgr update' 手动更新固件。"
+  zh_TW: "fwupdmgr 找到了韌體更新，但設定中已停用自動套用。執行 'fwupdmgr update' 手動更新韌體。"
+  de: "fwupdmgr hat Firmware-Updates gefunden, aber deren Anwendung ist in der Konfiguration deaktiviert. Führen Sie 'fwupdmgr update' aus, um die Firmware manuell zu aktualisieren."
 "Flatpak System Packages":
   en: "Flatpak System Packages"
   lt: "Flatpak sistemos paketai"

--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -16,7 +16,7 @@ use crate::steps::generic::is_wsl;
 use crate::steps::os::archlinux;
 use crate::steps::unix::{NhSwitchArgs, can_nh_switch, nh_switch};
 use crate::sudo::SudoExecuteOpts;
-use crate::terminal::{print_separator, prompt_yesno};
+use crate::terminal::{print_separator, print_warning, prompt_yesno};
 use crate::utils::{PathExt, require, require_flatpak, require_one, which};
 
 static OS_RELEASE_PATH: &str = "/etc/os-release";
@@ -941,10 +941,33 @@ pub fn run_fwupdmgr(ctx: &ExecutionContext) -> Result<()> {
         if ctx.config().yes(Step::System) {
             updmgr.arg("-y");
         }
+        updmgr.status_checked_with_codes(&[2])
     } else {
         updmgr.arg("get-updates");
+
+        // Exit 0 from `fwupdmgr get-updates` means firmware updates are available.
+        // Exit 2 means no updates. When updates exist but `firmware_upgrade` is
+        // disabled, hint to the user that they can apply them manually.
+        let has_updates = std::cell::Cell::new(false);
+        updmgr.status_checked_with(|status| {
+            if status.success() {
+                has_updates.set(true);
+                Ok(())
+            } else if status.code() == Some(2) {
+                Ok(())
+            } else {
+                Err(())
+            }
+        })?;
+
+        if has_updates.get() {
+            print_warning(t!(
+                "fwupdmgr found firmware updates, but applying these is disabled in the config. Run 'fwupdmgr update' to update firmware manually."
+            ));
+        }
+
+        Ok(())
     }
-    updmgr.status_checked_with_codes(&[2])
 }
 
 pub fn run_flatpak(ctx: &ExecutionContext) -> Result<()> {


### PR DESCRIPTION
## What does this PR do

When `firmware_upgrade` is disabled (the default), topgrade runs `fwupdmgr get-updates` which lists available firmware updates but gives the user no hint about how to apply them.

This change inspects the exit code of `fwupdmgr get-updates`. Exit 0 means updates are available; exit 2 means none. When updates exist and `firmware_upgrade` is disabled, print a yellow warning after the command output:

```
fwupdmgr found firmware updates, but applying these is disabled in the config. Run 'fwupdmgr update' to update firmware manually.
```

Behavior when `firmware_upgrade = true` is unchanged. Behavior when no updates are found is unchanged.

Approach was discussed and approved by @GideonBear in the issue thread (#1651).

Closes #1651

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [x] If this PR introduces new user-facing messages they are translated

I did not exercise this against a machine with pending firmware updates (would need matching hardware + an outstanding LVFS update). Happy to add manual test output if a reviewer with suitable hardware can try it, or to walk through the logic on request.

The new user-facing message is translated across all locales (en, lt, es, fr, zh_CN, zh_TW, de). `topgrade_i18n_locale_checker` passes locally.

### AI involvement

Used Claude for Rust syntax help (the `Cell<bool>` + `status_checked_with` closure pattern). The approach came from @GideonBear's walkthrough in #1651. I reviewed every line, ran `cargo fmt --check`, `cargo clippy`, `cargo test`, and `topgrade_i18n_locale_checker` locally, and wrote this description by hand.

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
