### PR TITLE
chore(deps): update rustls-webpki to 0.103.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2624,9 +2624,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## What does this PR do

Update `rustls-webpki` from 0.103.11 to 0.103.12 to fix RUSTSEC-2026-0098 and RUSTSEC-2026-0099.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself, with the relevant tools installed.
- [x] If this PR introduces new user-facing messages they are translated

### AI involvement

I consulted an AI occasionally for inspiration and explanation.

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->