### PR TITLE
refactor: remove dead bun.rs file and eliminate unreachable! macro in ssh.rs

### DIFF
--- a/src/steps/remote/ssh.rs
+++ b/src/steps/remote/ssh.rs
@@ -23,17 +23,14 @@ pub fn ssh_step(ctx: &ExecutionContext, hostname: &str) -> Result<()> {
     let env = format!("TOPGRADE_PREFIX={hostname}");
     args.extend(["env", &env, "$SHELL", "-lc", topgrade]);
 
+    #[cfg(unix)]
     if ctx.config().run_in_tmux() && !ctx.run_type().dry() {
-        #[cfg(unix)]
-        {
-            prepare_async_ssh_command(&mut args);
-            crate::tmux::run_command(ctx, hostname, &shell_words::join(args))?;
-            Err(SkipStep(String::from(t!("Remote Topgrade launched in Tmux"))).into())
-        }
+        prepare_async_ssh_command(&mut args);
+        crate::tmux::run_command(ctx, hostname, &shell_words::join(args))?;
+        return Err(SkipStep(String::from(t!("Remote Topgrade launched in Tmux"))).into());
+    }
 
-        #[cfg(not(unix))]
-        unreachable!("Tmux execution is only implemented in Unix");
-    } else if ctx.config().open_remotes_in_new_terminal() && !ctx.run_type().dry() && cfg!(windows) {
+    if ctx.config().open_remotes_in_new_terminal() && !ctx.run_type().dry() && cfg!(windows) {
         prepare_async_ssh_command(&mut args);
         ctx.execute("wt").args(&args).spawn()?;
         Err(SkipStep(String::from(t!("Remote Topgrade launched in an external terminal"))).into())


### PR DESCRIPTION
## What does this PR do

Remove dead code that was causing CodeQL extraction warnings:

- Delete empty `src/steps/bun.rs` file that was not included as a module, triggering "semantic analyzer unavailable" warnings
- Simplify `src/steps/remote/ssh.rs` by removing the `unreachable!` macro and restructuring the `#[cfg(unix)]` guard to use an early return pattern, fixing the "macro expansion failed for `$crate::const_format_args`" warning

Closes #1624

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [x] If this PR introduces new user-facing messages they are translated

### AI involvement

I consulted an AI occasionally for identifying the dead code and suggesting the refactor approach.

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->