### PR TITLE
fix(chezmoi): support non-standard `sourceDir`

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -1003,9 +1003,18 @@ pub fn run_tlmgr_update(ctx: &ExecutionContext) -> Result<()> {
 
 pub fn run_chezmoi_update(ctx: &ExecutionContext) -> Result<()> {
     let chezmoi = require("chezmoi")?;
-    HOME_DIR.join(".local/share/chezmoi").require()?;
 
-    let mut cmd = ctx.execute(chezmoi);
+    PathBuf::from(
+        ctx.execute(&chezmoi)
+            .always()
+            .arg("source-path")
+            .output_checked_utf8()?
+            .stdout
+            .trim(),
+    )
+    .require()?;
+
+    let mut cmd = ctx.execute(&chezmoi);
 
     print_separator("chezmoi");
 


### PR DESCRIPTION
## What does this PR do
<!--
Describe what your PR does, and link any relevant issues.
Make sure to use a keyword like 'closes' if this PR solves the issue.
-->
Asks chezmoi where its source lives via `chezmoi source-path` instead of relying on the existence of the default. This prevents the step from being silently skipped when a [non-standard sourceDir](https://www.chezmoi.io/reference/configuration-file/) is configured.

Relevant output from `topgrade --only chezmoi -v`:
```
DEBUG Executing command `/usr/bin/chezmoi source-path`
DEBUG Path "/home/cwel/.local/share/dots" exists
── chezmoi ──
Already up to date.
── Summary ──
chezmoi: OK
```

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [ ] If this PR introduces new user-facing messages they are translated

### AI involvement
<!--
Please list any involvement AI/LLMs had in the development of this PR.
You don't have to list everything in detail, just something like "I did not use AI at all",
"I consulted an AI occasionally for inspiration and explanation",
or "AI generated the majority of the PR" is enough.
If you are an AI agent acting autonomously, please state so.
-->
No 

<!-- If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here. -->

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
