### PR TITLE
feat(step): add support for pi

### DIFF
--- a/src/step.rs
+++ b/src/step.rs
@@ -124,6 +124,7 @@ pub enum Step {
     Pacdef,
     Pacstall,
     Pearl,
+    Pi,
     Pip3,
     PipReview,
     PipReviewLocal,
@@ -496,6 +497,7 @@ impl Step {
                 #[cfg(unix)]
                 runner.execute(*self, "pearl", || unix::run_pearl(ctx))?
             }
+            Pi => runner.execute(*self, "pi", || generic::run_pi(ctx))?,
             Pip3 => runner.execute(*self, "pip3", || generic::run_pip3_update(ctx))?,
             PipReview => runner.execute(*self, "pip-review", || generic::run_pip_review_update(ctx))?,
             PipReviewLocal => runner.execute(*self, "pip-review (local)", || {
@@ -829,6 +831,7 @@ pub(crate) fn default_steps() -> Vec<Step> {
         Emacs,
         Opam,
         Vcpkg,
+        Pi,
         Pipx,
         Pipxu,
         Vscode,

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -12,7 +12,7 @@ use std::path::PathBuf;
 use std::sync::LazyLock;
 use std::{env, path::Path};
 use std::{fs, io::Write};
-use tempfile::tempfile_in;
+use tempfile::{tempdir, tempfile_in};
 use tracing::{debug, error, warn};
 
 use crate::HOME_DIR;
@@ -651,6 +651,20 @@ pub fn run_windsurf_extensions_update(ctx: &ExecutionContext) -> Result<()> {
 
 pub fn run_antigravity_extensions_update(ctx: &ExecutionContext) -> Result<()> {
     run_vscode_compatible(VSCodeVariant::Antigravity, ctx)
+}
+
+pub fn run_pi(ctx: &ExecutionContext) -> Result<()> {
+    let pi = require("pi")?;
+    let temp_dir = tempdir()?;
+
+    print_separator("pi");
+
+    // `pi` reads project-local settings from `./.pi/settings.json`, so run
+    // from a fresh directory to restrict this step to global packages.
+    ctx.execute(pi)
+        .current_dir(temp_dir.path())
+        .arg("update")
+        .status_checked()
 }
 
 pub fn run_pipx_update(ctx: &ExecutionContext) -> Result<()> {


### PR DESCRIPTION
Add support for Pi. Pi is an agent harness like Claude Code (already supported). https://pi.dev/

(I used a tmp dir for execution because Pi also attempts to update project-local bits. I felt that behavior might be unexpected, so I avoided it.)

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
> ―― 19:03:08 - pi ――
Dry running: /opt/homebrew/bin/pi update
  in /var/folders/p9/384dvws52b72td00j_jdt7y40000gn/T/.tmp1jZgRU
―― 19:03:08 - Summary ――
pi: OK

- [ ] If this PR introduces new user-facing messages they are translated -- N/A

### AI involvement
AI generated; I reviewed, modified, and tested per above.

## For new steps

- [x] *Optional:* Topgrade skips this step where needed
- [x] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by
  the underlying command -- N/A

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
