### PR TITLE
fix(mise): handle all self-update errors

### DIFF
--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -875,7 +875,7 @@ pub fn run_mise(ctx: &ExecutionContext) -> Result<()> {
         .code()
         .ok_or_eyre("Couldn't get status code (terminated by signal)")?;
     let stderr = std::str::from_utf8(&output.stderr).wrap_err("Expected output to be valid UTF-8")?;
-    if stderr.contains("mise is installed via a package manager") && status_code == 1 {
+    if stderr.contains("cannot update") && status_code == 1 {
         debug!("Mise self-update not available")
     } else {
         // Write the output


### PR DESCRIPTION
## What does this PR do

mise errors with a different error message when the `self_update` feature was disabled at build time (as is the case for e.g. the [conda-forge package](https://anaconda.org/conda-forge/mise)) than when it has only been soft-disabled (e.g. by setting an env var). In both cases, the error message [ends with the words `cannot update`](https://github.com/search?q=repo%3Ajdx%2Fmise%20%2Fcannot%20update%2F&type=code), so let's just check for that.
## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [ ] If this PR introduces new user-facing messages they are translated

### AI involvement

None.

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
