### PR TITLE
feat(cargo): add locked option for cargo install-update

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -566,6 +566,8 @@ pub struct Cargo {
     git: Option<bool>,
     #[merge(strategy = merge::option::overwrite_none)]
     quiet: Option<bool>,
+    #[merge(strategy = merge::option::overwrite_none)]
+    locked: Option<bool>,
 }
 
 #[derive(Deserialize, Default, Debug, Merge)]
@@ -1875,6 +1877,14 @@ impl Config {
             .cargo
             .as_ref()
             .and_then(|cargo| cargo.quiet)
+            .unwrap_or(false)
+    }
+
+    pub fn cargo_update_locked(&self) -> bool {
+        self.config_file
+            .cargo
+            .as_ref()
+            .and_then(|cargo| cargo.locked)
             .unwrap_or(false)
     }
 

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -80,6 +80,9 @@ pub fn run_cargo_update(ctx: &ExecutionContext) -> Result<()> {
     if ctx.config().cargo_update_quiet() {
         command.arg("--quiet");
     }
+    if ctx.config().cargo_update_locked() {
+        command.arg("--locked");
+    }
     command.status_checked()?;
 
     if ctx.config().cleanup() {


### PR DESCRIPTION

## What does this PR do

Some packages fail to compile with updated dependencies (e.g. `harper-ls` or `prek`)  and I need do manual `cargo install --locked`;  Change adds `locked = true/false` to `[cargo]` section. Default behavior is the same.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [ ] If this PR introduces new user-facing messages they are translated

Test:

Default:

```
% cargo run -- --dry-run  --only cargo | grep Dry
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.14s
     Running `target/debug/topgrade --dry-run --only cargo`
Dry running: /home/benner/.cargo/bin/cargo-install-update install-update --all --git
```

With `locked=true`:

```
% cargo run -- --dry-run  --only cargo | grep Dry
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.14s
     Running `target/debug/topgrade --dry-run --only cargo`
Dry running: /home/benner/.cargo/bin/cargo-install-update install-update --all --git --locked
```

### AI involvement

 AI scanned issues, generated the majority of the PR. 

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
