### PR TITLE
feat: passwordless reboot and shutdown using `system_shutdown`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3025,6 +3025,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "system_shutdown"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29396e5e1b637d102ec5037bf7fbb8da78264fa299101ced9ce827756b1bac02"
+dependencies = [
+ "windows 0.62.2",
+ "zbus",
+]
+
+[[package]]
 name = "tar"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3340,6 +3350,7 @@ dependencies = [
  "shellexpand",
  "strum",
  "sys-locale",
+ "system_shutdown",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,9 @@ assets = [
   ["deployment/deb/_topgrade", "usr/share/zsh/vendor-completions/", "644"],
 ]
 
+[target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))'.dependencies]
+system_shutdown = "4.1.0"
+
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.31", features = ["hostname", "signal", "user"] }
 rust-ini = "0.21"

--- a/locales/app.yml
+++ b/locales/app.yml
@@ -48,6 +48,14 @@ _version: 2
   zh_CN: "正在重新启动..."
   zh_TW: "正在重新啟動..."
   de: "Neustart..."
+"Shutting down...":
+  en: "Shutting down..."
+  lt: "Išjungiamas..."
+  es: "Apagando..."
+  fr: "Arrêt..."
+  zh_CN: "正在关机..."
+  zh_TW: "正在關機..."
+  de: "Herunterfahren..."
 "Plugins upgraded":
   en: "Plugins upgraded"
   lt: "Įskiepiai atnaujinti"
@@ -1159,15 +1167,15 @@ _version: 2
   zh_TW: "再試一次？ (y)是/(N)否/(s)Shell/(q)退出"
   de: "Wiederholen? (y) Ja / (n) Nein / (s) Shell / (q) Beenden"
 
-# 'R', 'S', 'Q'  have to stay the same throughout all translations. Eg German would look like "\n(R) Neustarten\n(S) Konsole\n(Q) Beenden"
-"\n(R)eboot\n(S)hell\n(Q)uit":
-  en: "\n(R)eboot\n(S)hell\n(Q)uit"
-  lt: "\n(R)perkrovimas\n(S)shell\n(Q)išeiti"
-  es: "\n(R) Reiniciar\n(S) Shell\n(Q) Salir"
-  fr: "\n(R) Redémarrer\n(S) Shell\n(Q) Quitter"
-  zh_CN: "\n(R)重启\n(S)Shell\n(Q)退出"
-  zh_TW: "\n(R)重新啟動\n(S)shell\n(Q)退出"
-  de: "\n(R) Neustarten\n(S)hell\n(Q)uit beenden"
+# 'R', 'P', 'S', 'Q' have to stay the same throughout all translations. Eg German would look like "\n(R) Neustarten\n(P) Herunterfahren\n(S) Konsole\n(Q) Beenden"
+"\n(R)eboot\n(P)oweroff\n(S)hell\n(Q)uit":
+  en: "\n(R)eboot\n(P)oweroff\n(S)hell\n(Q)uit"
+  lt: "\n(R)perkrovimas\n(P)risijungti\n(S)shell\n(Q)išeiti"
+  es: "\n(R) Reiniciar\n(P) Apagar\n(S) Shell\n(Q) Salir"
+  fr: "\n(R) Redémarrer\n(P) Éteindre\n(S) Shell\n(Q) Quitter"
+  zh_CN: "\n(R)重启\n(P)关机\n(S)Shell\n(Q)退出"
+  zh_TW: "\n(R)重新啟動\n(P)關機\n(S)shell\n(Q)退出"
+  de: "\n(R) Neustarten\n(P) Herunterfahren\n(S)hell\n(Q)uit beenden"
 
 "Continue?":
   en: "Continue?"

--- a/src/main.rs
+++ b/src/main.rs
@@ -281,7 +281,7 @@ fn run() -> Result<()> {
     }
 
     if config.keep_at_end() {
-        print_info(t!("\n(R)eboot\n(S)hell\n(Q)uit"));
+        print_info(t!("\n(R)eboot\n(P)oweroff\n(S)hell\n(Q)uit"));
         loop {
             match get_key() {
                 Ok(Key::Char('s' | 'S')) => {
@@ -290,6 +290,10 @@ fn run() -> Result<()> {
                 Ok(Key::Char('r' | 'R')) => {
                     println!("{}", t!("Rebooting..."));
                     reboot(&ctx).context("Failed to reboot")?;
+                }
+                Ok(Key::Char('p' | 'P')) => {
+                    println!("{}", t!("Shutting down..."));
+                    shutdown(&ctx).context("Failed to shut down")?;
                 }
                 Ok(Key::Char('q' | 'Q')) => (),
                 _ => {

--- a/src/steps/os/mod.rs
+++ b/src/steps/os/mod.rs
@@ -18,7 +18,7 @@ pub mod unix;
 pub mod windows;
 
 #[cfg(windows)]
-pub use windows::reboot;
+pub use windows::{reboot, shutdown};
 
 #[cfg(unix)]
-pub use unix::reboot;
+pub use unix::{reboot, shutdown};

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -1097,7 +1097,7 @@ pub fn shutdown(ctx: &ExecutionContext) -> Result<()> {
         return Ok(());
     }
     match ctx.sudo() {
-        Some(sudo) => sudo.execute(ctx, "shutdown")?.args(["-h", "now"]).status_checked(),
-        None => ctx.execute("shutdown").args(["-h", "now"]).status_checked(),
+        Some(sudo) => sudo.execute(ctx, "shutdown")?.args(["now"]).status_checked(),
+        None => ctx.execute("shutdown").args(["now"]).status_checked(),
     }
 }

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -1081,8 +1081,23 @@ pub fn run_atuin(ctx: &ExecutionContext) -> Result<()> {
 }
 
 pub fn reboot(ctx: &ExecutionContext) -> Result<()> {
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    if let Ok(()) = system_shutdown::reboot() {
+        return Ok(());
+    }
     match ctx.sudo() {
         Some(sudo) => sudo.execute(ctx, "reboot")?.status_checked(),
         None => ctx.execute("reboot").status_checked(),
+    }
+}
+
+pub fn shutdown(ctx: &ExecutionContext) -> Result<()> {
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    if let Ok(()) = system_shutdown::shutdown() {
+        return Ok(());
+    }
+    match ctx.sudo() {
+        Some(sudo) => sudo.execute(ctx, "shutdown")?.args(["-h", "now"]).status_checked(),
+        None => ctx.execute("shutdown").args(["-h", "now"]).status_checked(),
     }
 }

--- a/src/steps/os/windows.rs
+++ b/src/steps/os/windows.rs
@@ -270,10 +270,12 @@ pub fn microsoft_store(ctx: &ExecutionContext) -> Result<()> {
     Ok(())
 }
 
-pub fn reboot(ctx: &ExecutionContext) -> Result<()> {
-    // If this works, it won't return, but if it doesn't work, it may return a useful error
-    // message.
-    ctx.execute("shutdown.exe").args(["/R", "/T", "0"]).status_checked()
+pub fn reboot(_ctx: &ExecutionContext) -> Result<()> {
+    system_shutdown::reboot().map_err(Into::into)
+}
+
+pub fn shutdown(_ctx: &ExecutionContext) -> Result<()> {
+    system_shutdown::shutdown().map_err(Into::into)
 }
 
 pub fn insert_startup_scripts(ctx: &ExecutionContext, git_repos: &mut RepoStep) -> Result<()> {


### PR DESCRIPTION
## What does this PR do
<!--
Describe what your PR does, and link any relevant issues.
Make sure to use a keyword like 'closes' if this PR solves the issue.
-->

Closes #861 
Closes #1810 

Replaces custom reboot implementation with `system_shutdown` crate (for Linux, macOS and Windows) and adds a new poweroff option.

- (P)oweroff option in the keep_at_end menu.
- Passwordless reboot on Linux/macOS.
- Windows: replaced `shutdown.exe /R /T 0` with `system_shutdown::reboot()` - the crate says Windows reboots are stable.
- BSD and others: no change; existing sudo fallback for reboot and shutdown.

Testers are welcome to try and give feedback!

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
	- not yet
- [x] If this PR introduces new user-facing messages they are translated

### AI involvement
<!--
Please list any involvement AI/LLMs had in the development of this PR.
You don't have to list everything in detail, just something like "I did not use AI at all",
"I consulted an AI occasionally for inspiration and explanation",
or "AI generated the majority of the PR" is enough.
If you are an AI agent acting autonomously, please state so.
-->

Claude only for review.

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
