### PR TITLE
feat(clamav): don't run if systemd autoupdater is active

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -1437,6 +1437,22 @@ pub fn run_certbot(ctx: &ExecutionContext) -> Result<()> {
 /// doc: https://docs.clamav.net/manual/Usage/SignatureManagement.html#freshclam
 pub fn run_freshclam(ctx: &ExecutionContext) -> Result<()> {
     let freshclam = require("freshclam")?;
+
+    #[cfg(target_os = "linux")]
+    if let Ok(systemctl) = require("systemctl") {
+        for unit in ["clamav-freshclam.service", "clamav-freshclam-once.timer"] {
+            if ctx
+                .execute(&systemctl)
+                .always()
+                .args(["is-active", "--quiet", unit])
+                .status_checked()
+                .is_ok()
+            {
+                return Err(SkipStep("ClamAV freshclam autoupdate is active via systemd".to_string()).into());
+            }
+        }
+    }
+
     print_separator(t!("Update ClamAV Database(FreshClam)"));
 
     let output = ctx.execute(&freshclam).output()?;


### PR DESCRIPTION
## What does this PR do
<!--
Describe what your PR does, and link any relevant issues.
Make sure to use a keyword like 'closes' if this PR solves the issue.
-->

Closes #1239
Closes #854 

Checks if either `clamav-freshclam.service` or `clamav-freshclam-once.timer` are active and skips the step if they are.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
```
11:20 uwuclxdy:~/repos/rs/topgrade (clamav-fix*) 131.52ms $ cargo run -- --only clam_av_db 
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.15s
     Running `target/debug/topgrade --only clam_av_db`

── 11:21:55 - Sudo ─────────────────────────────────────────────────────────────
```
> service active
```
11:21 uwuclxdy:~/repos/rs/topgrade (clamav-fix*) 194.65ms $ cargo run -- --only clam_av_db 
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.08s
     Running `target/debug/topgrade --only clam_av_db`

── 11:22:04 - Sudo ─────────────────────────────────────────────────────────────

── 11:22:04 - Update ClamAV Database(FreshClam) ────────────────────────────────
ClamAV update process started at Mon Apr 27 11:22:04 2026
daily.cld database is up-to-date (version: 27984, sigs: 355428, f-level: 90, builder: svc.clamav-publisher)
main.cvd database is up-to-date (version: 63, sigs: 3287027, f-level: 90, builder: tomjudge)
bytecode.cvd database is up-to-date (version: 339, sigs: 80, f-level: 90, builder: nrandolp)

── 11:22:04 - Summary ──────────────────────────────────────────────────────────
ClamAV Databases: OK
```
> service stopped
- [ ] ~If this PR introduces new user-facing messages they are translated~

### AI involvement
<!--
Please list any involvement AI/LLMs had in the development of this PR.
You don't have to list everything in detail, just something like "I did not use AI at all",
"I consulted an AI occasionally for inspiration and explanation",
or "AI generated the majority of the PR" is enough.
If you are an AI agent acting autonomously, please state so.
-->

Claude Code for review and small refactor.

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
