### PR TITLE
feat(mise): add options for quiet, silent, verbose, and add assume_yes support

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -336,6 +336,22 @@
 # (default: false)
 # interactive = false
 
+# Suppress non-error messages
+# (default: false)
+# quiet = false
+
+# Suppress all task output and mise non-error messages
+# (default: false)
+# silent = false
+
+# Show extra output
+# (default: false)
+# verbose = false
+
+# Answer yes to all confirmation prompts
+# (default: false)
+# yes = false
+
 [go]
 # Exclude specified binaries from `gup update`
 # gup_exclude = ["kind", "pkgsite"]

--- a/config.example.toml
+++ b/config.example.toml
@@ -348,9 +348,6 @@
 # (default: false)
 # verbose = false
 
-# Answer yes to all confirmation prompts
-# (default: false)
-# yes = false
 
 [go]
 # Exclude specified binaries from `gup update`

--- a/src/config.rs
+++ b/src/config.rs
@@ -2216,14 +2216,6 @@ impl Config {
             .unwrap_or(false)
     }
 
-    pub fn mise_yes(&self) -> bool {
-        self.config_file
-            .mise
-            .as_ref()
-            .and_then(|mise| mise.yes)
-            .unwrap_or(false)
-    }
-
     pub fn mise_silent(&self) -> bool {
         self.config_file
             .mise

--- a/src/config.rs
+++ b/src/config.rs
@@ -220,6 +220,14 @@ pub struct Mise {
     interactive: Option<bool>,
     #[merge(strategy = merge::option::overwrite_none)]
     jobs: Option<u32>,
+    #[merge(strategy = merge::option::overwrite_none)]
+    verbose: Option<bool>,
+    #[merge(strategy = merge::option::overwrite_none)]
+    quiet: Option<bool>,
+    #[merge(strategy = merge::option::overwrite_none)]
+    silent: Option<bool>,
+    #[merge(strategy = merge::option::overwrite_none)]
+    yes: Option<bool>,
 }
 
 #[derive(Deserialize, Default, Debug, Merge)]
@@ -2197,6 +2205,38 @@ impl Config {
             .mise
             .as_ref()
             .and_then(|mise| mise.interactive)
+            .unwrap_or(false)
+    }
+
+    pub fn mise_quiet(&self) -> bool {
+        self.config_file
+            .mise
+            .as_ref()
+            .and_then(|mise| mise.quiet)
+            .unwrap_or(false)
+    }
+
+    pub fn mise_yes(&self) -> bool {
+        self.config_file
+            .mise
+            .as_ref()
+            .and_then(|mise| mise.yes)
+            .unwrap_or(false)
+    }
+
+    pub fn mise_silent(&self) -> bool {
+        self.config_file
+            .mise
+            .as_ref()
+            .and_then(|mise| mise.silent)
+            .unwrap_or(false)
+    }
+
+    pub fn mise_verbose(&self) -> bool {
+        self.config_file
+            .mise
+            .as_ref()
+            .and_then(|mise| mise.verbose)
             .unwrap_or(false)
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -226,8 +226,6 @@ pub struct Mise {
     quiet: Option<bool>,
     #[merge(strategy = merge::option::overwrite_none)]
     silent: Option<bool>,
-    #[merge(strategy = merge::option::overwrite_none)]
-    yes: Option<bool>,
 }
 
 #[derive(Deserialize, Default, Debug, Merge)]

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -907,7 +907,7 @@ pub fn run_mise(ctx: &ExecutionContext) -> Result<()> {
     }
 
     if ctx.config().mise_verbose() {
-        cmd.arg("--quiet");
+        cmd.arg("--verbose");
     }
 
     if ctx.config().yes(Step::Mise) {

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -898,6 +898,22 @@ pub fn run_mise(ctx: &ExecutionContext) -> Result<()> {
         cmd.arg("--bump");
     }
 
+    if ctx.config().mise_silent() {
+        cmd.arg("--silent");
+    }
+
+    if ctx.config().mise_quiet() {
+        cmd.arg("--quiet");
+    }
+
+    if ctx.config().mise_verbose() {
+        cmd.arg("--quiet");
+    }
+
+    if ctx.config().mise_yes() {
+        cmd.arg("--yes");
+    }
+
     if ctx.config().mise_jobs() != 4 {
         cmd.args(["--jobs", &ctx.config().mise_jobs().to_string()]);
     }

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -910,7 +910,7 @@ pub fn run_mise(ctx: &ExecutionContext) -> Result<()> {
         cmd.arg("--quiet");
     }
 
-    if ctx.config().mise_yes() {
+    if ctx.config().yes(Step::Mise) {
         cmd.arg("--yes");
     }
 


### PR DESCRIPTION

## What does this PR do
<!--
Describe what your PR does, and link any relevant issues.
Make sure to use a keyword like 'closes' if this PR solves the issue.
-->

add options for quiet, silent, verbose, and yes in Mise step


<img width="1401" height="941" alt="image" src="https://github.com/user-attachments/assets/49bec838-e27f-471e-8c36-a0e84813064a" />


## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [ ] If this PR introduces new user-facing messages they are translated

### AI involvement
<!--
Please list any involvement AI/LLMs had in the development of this PR.
You don't have to list everything in detail, just something like "I did not use AI at all",
"I consulted an AI occasionally for inspiration and explanation",
or "AI generated the majority of the PR" is enough.
If you are an AI agent acting autonomously, please state so.
-->

## For new steps

<!-- This section can be deleted if you are not adding a new step. -->

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [x] *Optional:* The `--yes` option works with this step if it is supported by
  the underlying command

<!-- If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here. -->

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
