### PR TITLE
ci: auto-fix cargo fmt and clippy on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,33 @@ defaults:
     shell: bash
 
 jobs:
+  auto-fix:
+    name: Auto-fix (cargo fmt & clippy --fix)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.TOKEN }}
+
+      - name: Run auto-fix
+        run: |
+          cargo fmt --all
+          cargo clippy --fix --allow-dirty --quiet
+
+      - name: Commit and push if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -u
+          if ! git diff --cached --quiet; then
+            git commit -m "chore: apply cargo fmt and clippy fixes"
+            git push
+          fi
+
   format:
     name: Format (cargo fmt)
     runs-on: ubuntu-latest
@@ -191,8 +218,6 @@ jobs:
       - name: Setup cross
         if: matrix.use_cross == true
         run: curl -fL --retry 3 "https://github.com/cross-rs/cross/releases/download/v${CROSS_VER}/cross-x86_64-unknown-linux-musl.tar.gz" | tar vxz -C /usr/local/bin
-
-      - run: rustup component add clippy
 
       - name: Print toolchain version
         run: rustc --version

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.95.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## What does this PR do
<!--
Describe what your PR does, and link any relevant issues.
Make sure to use a keyword like 'closes' if this PR solves the issue.
-->

Adds an auto-fix job to `ci.yml` that runs on every pull request. It runs `cargo fmt` and `cargo clippy --fix`, commits any changes back to the PR branch, which triggers a fresh CI run. Also adds rustfmt and clippy components to rust-toolchain.toml so they're available without an explicit rustup step (which is also removed in this PR).

There is one annoying thing about this tho - it needs a PAT (`secrets.TOKEN`) because GitHub blocks pushes made with `GITHUB_TOKEN` from re-triggering workflows (to prevent infinite loops). However, a PAT push is treated as a regular user push and does re-trigger CI. `secrets.TOKEN` should be a fine-grained PAT scoped to `contents: write` for this repo only.

I initially thought this could be done with a pre-commit hook that every contributor runs on their machine, but there were too many problems with that (requires setup, can be bypassed...). Doing it in CI guarantees the auto-fixes happen on every PR.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`

### AI involvement
<!--
Please list any involvement AI/LLMs had in the development of this PR.
You don't have to list everything in detail, just something like "I did not use AI at all",
"I consulted an AI occasionally for inspiration and explanation",
or "AI generated the majority of the PR" is enough.
If you are an AI agent acting autonomously, please state so.
-->

Claude (Code) for the majority of this, verified it myself before opening the PR.

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
