### PR TITLE
build: add rustfmt and clippy to toolchain components

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.95.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## What does this PR do

This PR adds `rustfmt` and `clippy` to the `components` list in `rust-toolchain.toml`.

Because `CONTRIBUTING.md` requires contributors to run `cargo fmt` and `cargo clippy` locally before submitting a PR, adding them to the toolchain configuration ensures that anyone working on the project will automatically have the correct tools installed via `rustup`. This improves developer experience without relying on auto-fixing CI or external dependencies.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [ ] If this PR introduces new user-facing messages they are translated

### AI involvement

I consulted an AI assistant to discuss the security implications of auto-fixing formatting in CI. After discovering that CI auto-fixes with PATs introduce security vulnerabilities for outside contributors, the AI suggested making this clean, local toolchain change instead. 

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->