### PR TITLE
fix(powershell): handle unavailable Update-Module

### DIFF
--- a/locales/app.yml
+++ b/locales/app.yml
@@ -152,6 +152,14 @@ _version: 2
   zh_CN: "未安装 Powershell"
   zh_TW: "未安裝 Powershell"
   de: "Powershell ist nicht installiert"
+"PowerShellGet Update-Module is unavailable or could not be loaded. Skipping PowerShell module updates.":
+  en: "PowerShellGet Update-Module is unavailable or could not be loaded. Skipping PowerShell module updates."
+  lt: "PowerShellGet Update-Module nepasiekiama arba jos nepavyko įkelti. Praleidžiamas PowerShell modulių atnaujinimas."
+  es: "PowerShellGet Update-Module no está disponible o no se pudo cargar. Se omite la actualización de módulos de PowerShell."
+  fr: "PowerShellGet Update-Module n'est pas disponible ou n'a pas pu être chargé. Mise à jour des modules PowerShell ignorée."
+  zh_CN: "PowerShellGet Update-Module 不可用或无法加载。正在跳过 PowerShell 模块更新。"
+  zh_TW: "PowerShellGet Update-Module 無法使用或無法載入。正在略過 PowerShell 模組更新。"
+  de: "PowerShellGet Update-Module ist nicht verfügbar oder konnte nicht geladen werden. PowerShell-Modulaktualisierung wird übersprungen."
 "Error detecting current distribution: {error}":
   en: "Error detecting current distribution: %{error}"
   lt: "Klaida nustatant dabartinę distribuciją: %{error}"

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -1210,8 +1210,7 @@ pub fn run_powershell(ctx: &ExecutionContext) -> Result<()> {
     // For Windows PowerShell, use sudo (defaults to AllUsers scope).
     let use_sudo = !powershell.is_pwsh();
 
-    let check_use_sudo = use_sudo && !ctx.run_type().dry();
-    if !powershell.has_command(ctx, "Update-Module", check_use_sudo)? {
+    if !powershell.has_command(ctx, "Update-Module", use_sudo)? {
         let message = t!(
             "PowerShellGet Update-Module is unavailable or could not be loaded. Skipping PowerShell module updates."
         )

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -1210,7 +1210,8 @@ pub fn run_powershell(ctx: &ExecutionContext) -> Result<()> {
     // For Windows PowerShell, use sudo (defaults to AllUsers scope).
     let use_sudo = !powershell.is_pwsh();
 
-    if !ctx.run_type().dry() && !powershell_update_module_available(ctx, use_sudo)? {
+    let check_use_sudo = use_sudo && !ctx.run_type().dry();
+    if !powershell.has_command(ctx, "Update-Module", check_use_sudo)? {
         let message = t!(
             "PowerShellGet Update-Module is unavailable or could not be loaded. Skipping PowerShell module updates."
         )
@@ -1226,34 +1227,23 @@ pub fn run_powershell(ctx: &ExecutionContext) -> Result<()> {
     powershell.build_command(ctx, &cmd, use_sudo)?.status_checked()
 }
 
-fn powershell_update_module_available(ctx: &ExecutionContext, use_sudo: bool) -> Result<bool> {
-    let output = ctx
-        .require_powershell()?
-        .build_command(
-            ctx,
-            "if (Get-Command Update-Module -ErrorAction SilentlyContinue) { Write-Output 'true' }",
-            use_sudo,
-        )?
-        .output_checked_utf8()?;
-
-    Ok(output.stdout.trim().eq_ignore_ascii_case("true"))
-}
-
 fn powershell_update_modules_command(verbose: bool, assume_yes: bool) -> String {
-    let mut cmd = "$topgradeUpdateModuleParams = @{};".to_string();
-    cmd.push_str(" $topgradeUpdateModuleCommand = Get-Command Update-Module -ErrorAction Stop;");
+    let mut cmd = "$params = @{};".to_string();
+    cmd.push_str(" $updateModule = Get-Command Update-Module -ErrorAction Stop;");
 
     if verbose {
-        cmd.push_str(" $topgradeUpdateModuleParams['Verbose'] = $true;");
+        cmd.push_str(" $params['Verbose'] = $true;");
     }
     if assume_yes {
         // Avoid -Force here: PowerShellGet uses it to reinstall already-current modules,
         // which can lock PackageManagement in the running Windows PowerShell session.
-        cmd.push_str(" $topgradeUpdateModuleParams['Confirm'] = $false;");
-        cmd.push_str(" if ($topgradeUpdateModuleCommand.Parameters.ContainsKey('AcceptLicense')) { $topgradeUpdateModuleParams['AcceptLicense'] = $true; }");
+        cmd.push_str(" $params['Confirm'] = $false;");
+        cmd.push_str(
+            " if ($updateModule.Parameters.ContainsKey('AcceptLicense')) { $params['AcceptLicense'] = $true; }",
+        );
     }
 
-    cmd.push_str(" & $topgradeUpdateModuleCommand @topgradeUpdateModuleParams");
+    cmd.push_str(" & $updateModule @params");
     cmd
 }
 
@@ -1265,18 +1255,21 @@ mod powershell_tests {
     fn assume_yes_suppresses_confirmation_without_force() {
         let cmd = powershell_update_modules_command(false, true);
 
-        assert!(cmd.contains("$topgradeUpdateModuleParams['Confirm'] = $false"));
-        assert!(cmd.contains("AcceptLicense"));
+        assert!(cmd.contains("$params['Confirm'] = $false"));
+        assert!(cmd.contains("$updateModule.Parameters.ContainsKey('AcceptLicense')"));
+        assert!(cmd.contains("$params['AcceptLicense'] = $true"));
         assert!(cmd.contains("Get-Command Update-Module -ErrorAction Stop"));
+        assert!(cmd.contains("& $updateModule @params"));
         assert!(!cmd.contains("-Force"));
         assert!(!cmd.contains("exit 0"));
+        assert!(!cmd.contains("topgradeUpdateModule"));
     }
 
     #[test]
     fn verbose_sets_verbose_parameter() {
         let cmd = powershell_update_modules_command(true, false);
 
-        assert!(cmd.contains("$topgradeUpdateModuleParams['Verbose'] = $true"));
+        assert!(cmd.contains("$params['Verbose'] = $true"));
         assert!(!cmd.contains("AcceptLicense"));
     }
 }

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -1206,25 +1206,78 @@ pub fn run_powershell(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator(t!("Powershell Modules Update"));
 
-    let mut cmd = "Update-Module".to_string();
+    // For PowerShell Core, run without sudo (defaults to CurrentUser scope).
+    // For Windows PowerShell, use sudo (defaults to AllUsers scope).
+    let use_sudo = !powershell.is_pwsh();
 
-    if ctx.config().verbose() {
-        cmd.push_str(" -Verbose");
+    if !ctx.run_type().dry() && !powershell_update_module_available(ctx, use_sudo)? {
+        let message = t!(
+            "PowerShellGet Update-Module is unavailable or could not be loaded. Skipping PowerShell module updates."
+        )
+        .to_string();
+        print_warning(&message);
+        return Err(SkipStep(message).into());
     }
-    if ctx.config().yes(Step::Powershell) {
-        cmd.push_str(" -Force");
-    }
+
+    let cmd = powershell_update_modules_command(ctx.config().verbose(), ctx.config().yes(Step::Powershell));
 
     println!("{}", t!("Updating modules..."));
 
-    if powershell.is_pwsh() {
-        // For PowerShell Core, run Update-Module without sudo since it defaults to CurrentUser scope
-        // and Update-Module updates all modules regardless of their original installation scope
-        powershell.build_command(ctx, &cmd, false)?.status_checked()
-    } else {
-        // For (Windows) PowerShell, use sudo since it defaults to AllUsers scope
-        // and may need administrator privileges
-        powershell.build_command(ctx, &cmd, true)?.status_checked()
+    powershell.build_command(ctx, &cmd, use_sudo)?.status_checked()
+}
+
+fn powershell_update_module_available(ctx: &ExecutionContext, use_sudo: bool) -> Result<bool> {
+    let output = ctx
+        .require_powershell()?
+        .build_command(
+            ctx,
+            "if (Get-Command Update-Module -ErrorAction SilentlyContinue) { Write-Output 'true' }",
+            use_sudo,
+        )?
+        .output_checked_utf8()?;
+
+    Ok(output.stdout.trim().eq_ignore_ascii_case("true"))
+}
+
+fn powershell_update_modules_command(verbose: bool, assume_yes: bool) -> String {
+    let mut cmd = "$topgradeUpdateModuleParams = @{};".to_string();
+    cmd.push_str(" $topgradeUpdateModuleCommand = Get-Command Update-Module -ErrorAction Stop;");
+
+    if verbose {
+        cmd.push_str(" $topgradeUpdateModuleParams['Verbose'] = $true;");
+    }
+    if assume_yes {
+        // Avoid -Force here: PowerShellGet uses it to reinstall already-current modules,
+        // which can lock PackageManagement in the running Windows PowerShell session.
+        cmd.push_str(" $topgradeUpdateModuleParams['Confirm'] = $false;");
+        cmd.push_str(" if ($topgradeUpdateModuleCommand.Parameters.ContainsKey('AcceptLicense')) { $topgradeUpdateModuleParams['AcceptLicense'] = $true; }");
+    }
+
+    cmd.push_str(" & $topgradeUpdateModuleCommand @topgradeUpdateModuleParams");
+    cmd
+}
+
+#[cfg(test)]
+mod powershell_tests {
+    use super::powershell_update_modules_command;
+
+    #[test]
+    fn assume_yes_suppresses_confirmation_without_force() {
+        let cmd = powershell_update_modules_command(false, true);
+
+        assert!(cmd.contains("$topgradeUpdateModuleParams['Confirm'] = $false"));
+        assert!(cmd.contains("AcceptLicense"));
+        assert!(cmd.contains("Get-Command Update-Module -ErrorAction Stop"));
+        assert!(!cmd.contains("-Force"));
+        assert!(!cmd.contains("exit 0"));
+    }
+
+    #[test]
+    fn verbose_sets_verbose_parameter() {
+        let cmd = powershell_update_modules_command(true, false);
+
+        assert!(cmd.contains("$topgradeUpdateModuleParams['Verbose'] = $true"));
+        assert!(!cmd.contains("AcceptLicense"));
     }
 }
 

--- a/src/steps/powershell.rs
+++ b/src/steps/powershell.rs
@@ -58,6 +58,18 @@ impl Powershell {
         self.is_pwsh
     }
 
+    pub fn has_command(&self, ctx: &ExecutionContext, command_name: &str, use_sudo: bool) -> Result<bool> {
+        let cmd = has_command_script(command_name);
+
+        let output = if use_sudo {
+            self.build_command(ctx, &cmd, true)?.output_checked_utf8()?
+        } else {
+            self.build_command_internal(ctx, &cmd).output_checked_utf8()?
+        };
+
+        Ok(output.stdout.trim().eq_ignore_ascii_case("true"))
+    }
+
     /// Builds an "internal" powershell command
     pub fn build_command_internal(&self, ctx: &ExecutionContext, cmd: &str) -> Executor {
         let mut command = ctx.execute(&self.path).always();
@@ -155,5 +167,42 @@ impl Powershell {
             .output_checked()
             .map(|output| !output.stdout.trim_ascii().is_empty())
             .unwrap_or(false)
+    }
+}
+
+fn has_command_script(command_name: &str) -> String {
+    format!(
+        "if (Get-Command -Name {} -ErrorAction SilentlyContinue) {{ Write-Output 'true' }}",
+        powershell_single_quote(command_name)
+    )
+}
+
+fn powershell_single_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{has_command_script, powershell_single_quote};
+
+    #[test]
+    fn has_command_script_checks_quoted_command_name() {
+        assert_eq!(
+            has_command_script("Update-Module"),
+            "if (Get-Command -Name 'Update-Module' -ErrorAction SilentlyContinue) { Write-Output 'true' }"
+        );
+    }
+
+    #[test]
+    fn has_command_script_escapes_command_name_as_data() {
+        assert_eq!(
+            has_command_script("Bob's-Command"),
+            "if (Get-Command -Name 'Bob''s-Command' -ErrorAction SilentlyContinue) { Write-Output 'true' }"
+        );
+    }
+
+    #[test]
+    fn powershell_single_quote_escapes_single_quotes() {
+        assert_eq!(powershell_single_quote("Bob's-Command"), "'Bob''s-Command'");
     }
 }

--- a/src/steps/powershell.rs
+++ b/src/steps/powershell.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsStr;
 use std::path::PathBuf;
 
 use color_eyre::eyre::Result;
@@ -59,12 +60,15 @@ impl Powershell {
     }
 
     pub fn has_command(&self, ctx: &ExecutionContext, command_name: &str, use_sudo: bool) -> Result<bool> {
-        let cmd = has_command_script(command_name);
+        let cmd = has_command_script();
 
         let output = if use_sudo {
-            self.build_command(ctx, &cmd, true)?.output_checked_utf8()?
+            self.build_command_with_args(ctx, cmd, [command_name], true)?
+                .always()
+                .output_checked_utf8()?
         } else {
-            self.build_command_internal(ctx, &cmd).output_checked_utf8()?
+            self.build_command_internal_with_args(ctx, cmd, [command_name])
+                .output_checked_utf8()?
         };
 
         Ok(output.stdout.trim().eq_ignore_ascii_case("true"))
@@ -72,10 +76,24 @@ impl Powershell {
 
     /// Builds an "internal" powershell command
     pub fn build_command_internal(&self, ctx: &ExecutionContext, cmd: &str) -> Executor {
+        self.build_command_internal_with_args(ctx, cmd, std::iter::empty::<&str>())
+    }
+
+    /// Builds an "internal" powershell command with arguments passed after `-Command`
+    pub fn build_command_internal_with_args<S>(
+        &self,
+        ctx: &ExecutionContext,
+        cmd: &str,
+        args: impl IntoIterator<Item = S>,
+    ) -> Executor
+    where
+        S: AsRef<OsStr>,
+    {
         let mut command = ctx.execute(&self.path).always();
 
         command.args(["-NoProfile", "-Command"]);
         command.arg(cmd);
+        command.args(args);
 
         // If topgrade was run from pwsh, but we are trying to run powershell, then
         // the inherited PSModulePath breaks module imports
@@ -88,12 +106,20 @@ impl Powershell {
 
     /// Builds a "primary" powershell command (uses dry-run if required):
     /// {powershell} -NoProfile -Command {cmd}
-    pub fn build_command<'a>(
+    pub fn build_command(&self, ctx: &ExecutionContext, cmd: &str, use_sudo: bool) -> Result<Executor> {
+        self.build_command_with_args(ctx, cmd, std::iter::empty::<&str>(), use_sudo)
+    }
+
+    pub fn build_command_with_args<S>(
         &self,
-        ctx: &'a ExecutionContext,
+        ctx: &ExecutionContext,
         cmd: &str,
+        args: impl IntoIterator<Item = S>,
         use_sudo: bool,
-    ) -> Result<impl CommandExt + 'a> {
+    ) -> Result<Executor>
+    where
+        S: AsRef<OsStr>,
+    {
         let mut command = if use_sudo {
             let sudo = ctx.require_sudo()?;
             sudo.execute(ctx, &self.path)?
@@ -109,6 +135,7 @@ impl Powershell {
 
         command.args(["-NoProfile", "-Command"]);
         command.arg(cmd);
+        command.args(args);
 
         // If topgrade was run from pwsh, but we are trying to run powershell, then
         // the inherited PSModulePath breaks module imports
@@ -170,39 +197,24 @@ impl Powershell {
     }
 }
 
-fn has_command_script(command_name: &str) -> String {
-    format!(
-        "if (Get-Command -Name {} -ErrorAction SilentlyContinue) {{ Write-Output 'true' }}",
-        powershell_single_quote(command_name)
-    )
-}
-
-fn powershell_single_quote(value: &str) -> String {
-    format!("'{}'", value.replace('\'', "''"))
+fn has_command_script() -> &'static str {
+    "& { param($command); if (Get-Command -Name $command -ErrorAction SilentlyContinue) { Write-Output 'true' } }"
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{has_command_script, powershell_single_quote};
+    use super::has_command_script;
 
     #[test]
-    fn has_command_script_checks_quoted_command_name() {
+    fn has_command_script_checks_command_name_argument() {
         assert_eq!(
-            has_command_script("Update-Module"),
-            "if (Get-Command -Name 'Update-Module' -ErrorAction SilentlyContinue) { Write-Output 'true' }"
+            has_command_script(),
+            "& { param($command); if (Get-Command -Name $command -ErrorAction SilentlyContinue) { Write-Output 'true' } }"
         );
     }
 
     #[test]
-    fn has_command_script_escapes_command_name_as_data() {
-        assert_eq!(
-            has_command_script("Bob's-Command"),
-            "if (Get-Command -Name 'Bob''s-Command' -ErrorAction SilentlyContinue) { Write-Output 'true' }"
-        );
-    }
-
-    #[test]
-    fn powershell_single_quote_escapes_single_quotes() {
-        assert_eq!(powershell_single_quote("Bob's-Command"), "'Bob''s-Command'");
+    fn has_command_script_does_not_embed_specific_command_name() {
+        assert!(!has_command_script().contains("Update-Module"));
     }
 }

--- a/src/steps/powershell.rs
+++ b/src/steps/powershell.rs
@@ -60,7 +60,7 @@ impl Powershell {
     }
 
     pub fn has_command(&self, ctx: &ExecutionContext, command_name: &str, use_sudo: bool) -> Result<bool> {
-        let cmd = has_command_script();
+        let cmd = "& { param($command); if (Get-Command -Name $command -ErrorAction SilentlyContinue) { Write-Output 'true' } }";
 
         let output = if use_sudo {
             self.build_command_with_args(ctx, cmd, [command_name], true)?
@@ -194,27 +194,5 @@ impl Powershell {
             .output_checked()
             .map(|output| !output.stdout.trim_ascii().is_empty())
             .unwrap_or(false)
-    }
-}
-
-fn has_command_script() -> &'static str {
-    "& { param($command); if (Get-Command -Name $command -ErrorAction SilentlyContinue) { Write-Output 'true' } }"
-}
-
-#[cfg(test)]
-mod tests {
-    use super::has_command_script;
-
-    #[test]
-    fn has_command_script_checks_command_name_argument() {
-        assert_eq!(
-            has_command_script(),
-            "& { param($command); if (Get-Command -Name $command -ErrorAction SilentlyContinue) { Write-Output 'true' } }"
-        );
-    }
-
-    #[test]
-    fn has_command_script_does_not_embed_specific_command_name() {
-        assert!(!has_command_script().contains("Update-Module"));
     }
 }


### PR DESCRIPTION
## What does this PR do

Closes #1443.

This changes the PowerShell module update step to avoid passing `-Force` to `Update-Module` when `--yes` is used. Instead, it passes `-Confirm:$false` and conditionally adds `AcceptLicense` when the installed `Update-Module` supports it.

It also checks whether `PowerShellGet` can provide `Update-Module` before running the update. If `Update-Module` is unavailable or cannot be loaded, Topgrade now prints a warning and marks the step as skipped instead of failing with a command-not-found error or reporting `OK` after doing no update.

This helps Windows PowerShell 5.1 setups where `PowerShellGet`/`PackageManagement` are broken, blocked by cloud-backed module folders, or otherwise cannot be autoloaded.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [x] If this PR introduces new user-facing messages they are translated

### AI involvement

I used AI assistance while investigating the PowerShell behavior, drafting the code change, and running local checks. I reviewed the changes myself before submitting.


<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->