### PR TITLE
feat: support neovim vim.pack updates

### DIFF
--- a/src/steps/upgrade.vim
+++ b/src/steps/upgrade.vim
@@ -11,6 +11,10 @@ if exists(":AstroUpdate")
     finish
 endif
 
+if has("nvim")
+    lua if vim.pack and next(vim.pack.get(nil, { info = false })) ~= nil then vim.pack.update(nil, { force = true }) end
+endif
+
 if exists(":MasonUpdate")
 	echo "MasonUpdate"
 	MasonUpdate

--- a/src/steps/vim.rs
+++ b/src/steps/vim.rs
@@ -157,3 +157,54 @@ pub fn run_voom(ctx: &ExecutionContext) -> Result<()> {
 
     ctx.execute(voom).arg("update").status_checked()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn upgrade_script_contents() -> String {
+        let script = upgrade_script().expect("upgrade script should be written");
+        fs::read_to_string(script.path()).expect("upgrade script should be readable")
+    }
+
+    #[test]
+    fn upgrade_script_updates_vim_pack_managed_packages() {
+        let script = upgrade_script_contents();
+
+        assert!(script.contains("if has(\"nvim\")"));
+        assert!(script.contains("vim.pack"));
+        assert!(script.contains("vim.pack.get(nil, { info = false })"));
+        assert!(script.contains("vim.pack.update(nil, { force = true })"));
+    }
+
+    #[test]
+    fn upgrade_script_runs_vim_pack_before_other_neovim_package_managers() {
+        let script = upgrade_script_contents();
+        let vim_pack = script
+            .find("vim.pack.update(nil, { force = true })")
+            .expect("vim.pack update should be present");
+        let lazy = script
+            .find("if exists(\":Lazy\")")
+            .expect("Lazy branch should be present");
+        let packer = script
+            .find("if exists(':PackerSync')")
+            .expect("Packer branch should be present");
+
+        assert!(vim_pack < lazy);
+        assert!(vim_pack < packer);
+    }
+
+    #[test]
+    fn upgrade_script_does_not_finish_after_vim_pack_update() {
+        let script = upgrade_script_contents();
+        let vim_pack = script
+            .find("vim.pack.update(nil, { force = true })")
+            .expect("vim.pack update should be present");
+        let lazy = script
+            .find("if exists(\":Lazy\")")
+            .expect("Lazy branch should be present");
+
+        assert!(!script[vim_pack..lazy].contains("finish"));
+    }
+}


### PR DESCRIPTION
## What does this PR do

Closes #2001.

Adds support for Neovim 0.12 native package management by running `vim.pack.update(nil, { force = true })` when `vim.pack` exists and has managed packages. The script keeps going afterward so configs that use `vim.pack` to bootstrap another manager still run later branches such as Lazy or Packer.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [x] If this PR introduces new user-facing messages they are translated

Tested with:

```shell
cargo test upgrade_script
cargo fmt --all -- --check
cargo test
cargo clippy --all-targets --locked -- -D warnings
```

Also tested with a stubbed Neovim 0.12 headless smoke test:

```text
PACK_GET info=false | PACK_UPDATE force=true | LAZY bang=! args=sync
```

### AI involvement

AI agent generated the implementation, tests, verification, and PR draft under user direction.

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
