### PR TITLE
feat(protonplus): support flatpak installation of ProtonPlus

### DIFF
--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -1259,18 +1259,31 @@ pub fn run_cinnamon_spices_updater(ctx: &ExecutionContext) -> Result<()> {
 }
 
 pub fn run_protonplus_update(ctx: &ExecutionContext) -> Result<()> {
-    let protonplus = require("protonplus")?;
+    let (program, flatpak) = match require("protonplus") {
+        Ok(protonplus) => (protonplus, false),
+        Err(_) => {
+            require_flatpak(ctx, "com.vysp3r.ProtonPlus")?;
+            (require("flatpak")?, true)
+        }
+    };
+    let cmd = || {
+        let mut cmd = ctx.execute(&program);
+        if flatpak {
+            cmd.args(["run", "com.vysp3r.ProtonPlus"]);
+        }
+        cmd
+    };
 
-    if let Err(e) = ctx.execute(&protonplus).args(["invalidarg67"]).output_checked()
+    if let Err(e) = cmd().args(["invalidarg67"]).output_checked()
         && let Some(TopgradeError::ProcessFailedWithOutput(_, _, stderr)) = e.downcast_ref()
         && stderr.contains("This application can not open files")
     {
         return Err(SkipStep("Updates unsupported for ProtonPlus versions under v0.5.17".to_string()).into());
     }
 
-    print_separator("ProtonPlus");
+    print_separator(if flatpak { "ProtonPlus (Flatpak)" } else { "ProtonPlus" });
 
-    ctx.execute(&protonplus).args(["update", "all"]).status_checked()
+    cmd().args(["update", "all"]).status_checked()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What does this PR do
<!--
Describe what your PR does, and link any relevant issues.
Make sure to use a keyword like 'closes' if this PR solves the issue.
-->

Adds support for updating ProtonPlus installed with flatpak.

Closes https://github.com/topgrade-rs/topgrade/issues/2005

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
```
     Running `target/debug/topgrade --only protonplus`

── 14:38:42 - Sudo ─────────────────────────────────────────────────────────────
[sudo] password for uwuclxdy: 

── 14:38:58 - ProtonPlus ───────────────────────────────────────────────────────
Updating all runners...
Already up to date: Proton-GE
Already up to date: DW-Proton

── 14:38:59 - Summary ──────────────────────────────────────────────────────────
ProtonPlus: OK
```
```
      Running `target/debug/topgrade --only protonplus`

── 14:39:36 - Sudo ─────────────────────────────────────────────────────────────

── 14:39:37 - ProtonPlus (Flatpak) ─────────────────────────────────────────────
F: Not sharing "/usr/share/icons" with sandbox: Path "/usr" is reserved by Flatpak

** (process:3263397): WARNING **: 14:39:37.874: Error writing credentials to socket: Error sending message: Broken pipe
Updating all runners...
Already up to date: Proton-GE
Already up to date: DW-Proton

── 14:39:38 - Summary ──────────────────────────────────────────────────────────
ProtonPlus: OK
```
- [ ] ~If this PR introduces new user-facing messages they are translated~

### AI involvement
<!--
Please list any involvement AI/LLMs had in the development of this PR.
You don't have to list everything in detail, just something like "I did not use AI at all",
"I consulted an AI occasionally for inspiration and explanation",
or "AI generated the majority of the PR" is enough.
If you are an AI agent acting autonomously, please state so.
-->

nonee :3
well only for review but it said its perfect

<!-- If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here. -->

@DSDV can you test pls, it works for me
<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
