### PR TITLE
feat(step): add install-release

### DIFF
--- a/src/step.rs
+++ b/src/step.rs
@@ -82,6 +82,7 @@ pub enum Step {
     Helm,
     HomeManager,
     Hyprpm,
+    InstallRelease,
     // These names are miscapitalized on purpose, so the CLI name is
     //  `jetbrains_pycharm` instead of `jet_brains_py_charm`.
     JetbrainsAqua,
@@ -386,6 +387,11 @@ impl Step {
             {
                 #[cfg(unix)]
                 runner.execute(*self, "hyprpm", || unix::run_hyprpm(ctx))?
+            }
+            InstallRelease =>
+            {
+                #[cfg(unix)]
+                runner.execute(*self, "Install Release", || unix::run_install_release(ctx))?
             }
             JetbrainsAqua => runner.execute(*self, "JetBrains Aqua Plugins", || generic::run_jetbrains_aqua(ctx))?,
             JetbrainsClion => runner.execute(*self, "JetBrains CL", || generic::run_jetbrains_clion(ctx))?,
@@ -930,5 +936,6 @@ pub(crate) fn default_steps() -> Vec<Step> {
         CustomCommands,
         Vagrant,
         Typst,
+        InstallRelease,
     ]
 }

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -1117,3 +1117,25 @@ pub fn shutdown(ctx: &ExecutionContext) -> Result<()> {
         None => ctx.execute("shutdown").args(["now"]).status_checked(),
     }
 }
+
+/// See: <https://github.com/Rishang/install-release>
+pub fn run_install_release(ctx: &ExecutionContext) -> Result<()> {
+    let ir = require_one(["ir", "install-release"])?;
+
+    print_separator("Install Release");
+
+    let mut command = ctx.execute(&ir);
+    command.args(["upgrade", "--pkg"]);
+    if ctx.config().yes(Step::InstallRelease) {
+        command.arg("-y");
+    }
+    command.status_checked()?;
+
+    let mut command = ctx.execute(&ir);
+    command.arg("upgrade");
+    if ctx.config().yes(Step::InstallRelease) {
+        command.arg("-y");
+    }
+    command.status_checked()?;
+    Ok(())
+}


### PR DESCRIPTION
## What does this PR do
<!--
Describe what your PR does, and link any relevant issues.
Make sure to use a keyword like 'closes' if this PR solves the issue.
-->
Adds a step for the [install-release](https://github.com/Rishang/install-release) tool. Closes #1789.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself, with the relevant tools installed. 
NB: out of the box, install-release didn't let me download an outdated version and set it as upgradable. I used a local build of install-release with a fix; the fix [landed](https://github.com/Rishang/install-release/pull/304) in master and should be in the latest release (7.6).

Test environment setup:
- get install-release
- `ir get` not-latest versions of a plain package and a system-installed (`--pkg`) package; tell `ir` that they should not be held back:
```sh
ir get https://github.com/denoland/deno/releases --tag v2.7.13 -y \
  && ir hold --unset deno \
  && ir get https://github.com/redis/RedisInsight --pkg --tag 3.4.1 -y \
  && ir hold --unset redisinsight
```
- `topgrade --only install_release -y`
Example output:
```
── 17:20:04 - Install Release ──────────────────────────────────────────────────
Fetching: https://github.com/redis/RedisInsight#redisinsight
All tools are onto latest version
Fetching: https://github.com/redis/RedisInsight#redisinsight
Fetching: https://github.com/denoland/deno#deno

Following tool will get upgraded.

deno

Updating: deno, v2.7.13 => v2.7.14
 INFO     Downloaded: 'deno-x86_64-unknown-linux-gnu.zip' at        utils.py:183
          /tmp/dn_deno_o77k8fdw                                                 
 INFO     install /tmp/dn_deno_o77k8fdw/deno /home/mrkun/bin/deno  install.py:48
 INFO     Installed: deno                                          install.py:53
Upgrading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:03

── 17:20:10 - Summary ──────────────────────────────────────────────────────────
Install Release: OK
```

- [ ] If this PR introduces new user-facing messages they are translated

### AI involvement
<!--
Please list any involvement AI/LLMs had in the development of this PR.
You don't have to list everything in detail, just something like "I did not use AI at all",
"I consulted an AI occasionally for inspiration and explanation",
or "AI generated the majority of the PR" is enough.
If you are an AI agent acting autonomously, please state so.
-->
I have not used AI/LLMs.

## For new steps

<!-- This section can be deleted if you are not adding a new step. -->

- [ ] *Optional:* Topgrade skips this step where needed
Not sure what this means exactly? 
- [ ] *Optional:* The `--dry-run` option works with this step
No `--dry-run` option.
- [x] *Optional:* The `--yes` option works with this step if it is supported by
  the underlying command

## Commentary
The original issue mentions that this tool does need `sudo` when it manages system-installed packages. In my setup, it prompts for sudo capabilities itself when it needs them, which topgrade transparently forwards. On the other hand, if run as `sudo ir` naively, `ir` doesn't look for packages to upgrade in the usual place, resulting in nothing being done (successfully). I'm sure there's some config i could pass to fix this, but not running it with sudo in the first place seemed easier. (Also, this way, sudo is not required if there's nothing to do.)

I chose to run `ir upgrade --pkg` first; otherwise, `ir` mentions packages upgradable with `--pkg` right before we tell it to upgrade them.

NB: there is an issue with `ir`'s confirmation prompt: it capitalizes Y, suggesting that upgrading is a default choice, but actually does nothing by default (i.e. if supplied with an empty string). This is awkward, but an upstream problem. (I'm planning to submit a fix for it, too.)

NB2: unfortunately, `ir` is not itself very graceful about sudo-prompts, and occasionally overwrites the prompt to enter the password with its `Upgrading...` line. Likewise, an upstream problem, but awkward.

<!-- If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here. -->

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
