### PR TITLE
fix(oh-my-bash): fix oh-my-bash failing in non-bash shells

### DIFF
--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -249,10 +249,15 @@ pub fn run_oh_my_bash(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("oh-my-bash");
 
-    let mut update_script = oh_my_bash;
+    let mut update_script = oh_my_bash.clone();
     update_script.push_str("/tools/upgrade.sh");
 
-    ctx.execute("bash").arg(update_script).status_checked()
+    ctx.execute("bash")
+        .arg(update_script)
+        // oh-my-bash fails if $OSH does not point to its installation path.
+        // if $OSH was unset (e.g. if we run from zsh) but we found OMB anyway, we want to tell it where.
+        .env("OSH", oh_my_bash)
+        .status_checked()
 }
 
 pub fn run_oh_my_fish(ctx: &ExecutionContext) -> Result<()> {


### PR DESCRIPTION
## What does this PR do
<!--
Describe what your PR does, and link any relevant issues.
Make sure to use a keyword like 'closes' if this PR solves the issue.
-->

Closes #516.

As described in https://github.com/topgrade-rs/topgrade/pull/478#issuecomment-1647833447, oh-my-bash expects that $OSH environment variable points to its installation path. Since $OSH is normally only set in .bashrc, upgrading a discovered oh-my-bash from non-bash shells fails. 
Since we found oh-my-bash anyway, we can very well run it with $OSH set to where we found it. 

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
Running from zsh:
```
── 20:47:29 - oh-my-bash ───────────────────────────────────────────────────────
Updating Oh My Bash
From https://github.com/ohmybash/oh-my-bash
 * branch            master     -> FETCH_HEAD
Updating ed4a22e..ae44713
Fast-forward
 themes/THEMES.md          |   4 ++++
 themes/garo/garo-dark.png | Bin 0 -> 47865 bytes
 2 files changed, 4 insertions(+)
 create mode 100644 themes/garo/garo-dark.png
         __                          __               __  
  ____  / /_     ____ ___  __  __   / /_  ____ ______/ /_ 
 / __ \/ __ \   / __ `__ \/ / / /  / __ \/ __ `/ ___/ __ \
/ /_/ / / / /  / / / / / / /_/ /  / /_/ / /_/ (__  ) / / /
\____/_/ /_/  /_/ /_/ /_/\__, /  /_.___/\__,_/____/_/ /_/ 
                        /____/                            
Hooray! Oh My Bash has been updated and/or is at the current version.
To keep up on the latest news and updates, follow us on GitHub: https://github.com/ohmybash/oh-my-bash

── 20:47:30 - Summary ──────────────────────────────────────────────────────────
oh-my-bash: OK
```
- [x] If this PR introduces new user-facing messages they are translated
(No new messages)

### AI involvement
<!--
Please list any involvement AI/LLMs had in the development of this PR.
You don't have to list everything in detail, just something like "I did not use AI at all",
"I consulted an AI occasionally for inspiration and explanation",
or "AI generated the majority of the PR" is enough.
If you are an AI agent acting autonomously, please state so.
-->
I consulted with Claude Opus 4.7 whether it is reasonable to set an environment variable in case the user unset it on purpose. I've concluded that it's normal to interpret an unset env-var as "whatever default is reasonable". 

## Regarding location of oh-my-bash
Re: https://github.com/topgrade-rs/topgrade/pull/478#issuecomment-1647849206: I think the canonical way to locate oh-my-bash would be to read the value of $OSH set by .bashrc. We don't do that, and I didn't want to mix the two issues. (I also hesitate to do this shell-independently, since there was a question about that.)

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
