### PR TITLE
refactor: improve path handling in config, node steps, and build

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -9,9 +9,6 @@ fn main() {
 
 fn breaking_changes() {
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-    let out_dir = out_dir
-        .canonicalize()
-        .expect("OUT_DIR must exist and be canonicalizable");
     let version_str = env::var("CARGO_PKG_VERSION").unwrap();
     let changelog = parse_changelog::parse(include_str!("CHANGELOG.md")).expect("Invalid CHANGELOG.md");
     let release = changelog

--- a/build.rs
+++ b/build.rs
@@ -9,9 +9,6 @@ fn main() {
 
 fn breaking_changes() {
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-    if !out_dir.is_absolute() {
-        panic!("OUT_DIR must be an absolute path");
-    }
     let out_dir = out_dir
         .canonicalize()
         .expect("OUT_DIR must exist and be canonicalizable");

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::PathBuf;
 use std::{env, fs};
 
 fn main() {
@@ -8,8 +8,11 @@ fn main() {
 }
 
 fn breaking_changes() {
-    let out_dir_s = &env::var("OUT_DIR").unwrap();
-    let out_dir = Path::new(out_dir_s);
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+    if !out_dir.is_absolute() {
+        panic!("OUT_DIR must be an absolute path");
+    }
+    let out_dir = out_dir.canonicalize().expect("OUT_DIR must exist and be canonicalizable");
     let version_str = env::var("CARGO_PKG_VERSION").unwrap();
     let changelog = parse_changelog::parse(include_str!("CHANGELOG.md")).expect("Invalid CHANGELOG.md");
     let release = changelog

--- a/build.rs
+++ b/build.rs
@@ -12,7 +12,9 @@ fn breaking_changes() {
     if !out_dir.is_absolute() {
         panic!("OUT_DIR must be an absolute path");
     }
-    let out_dir = out_dir.canonicalize().expect("OUT_DIR must exist and be canonicalizable");
+    let out_dir = out_dir
+        .canonicalize()
+        .expect("OUT_DIR must exist and be canonicalizable");
     let version_str = env::var("CARGO_PKG_VERSION").unwrap();
     let changelog = parse_changelog::parse(include_str!("CHANGELOG.md")).expect("Invalid CHANGELOG.md");
     let release = changelog

--- a/src/config.rs
+++ b/src/config.rs
@@ -2475,30 +2475,4 @@ last = ["cargo"]
         assert!(config.steps().is_err());
     }
 
-    #[test]
-    fn test_ensure_misc_safe_path_accepts_absolute_paths() {
-        // The path safety check must accept normal absolute paths
-        // (they contain RootDir / Prefix components).
-        let unix_path = PathBuf::from("/home/user/.config/topgrade.toml");
-        assert!(unix_path.components().all(|c| matches!(
-            c,
-            Component::Normal(_) | Component::CurDir | Component::RootDir | Component::Prefix(_)
-        )));
-
-        let windows_path = PathBuf::from(r"C:\Users\user\topgrade.toml");
-        assert!(windows_path.components().all(|c| matches!(
-            c,
-            Component::Normal(_) | Component::CurDir | Component::RootDir | Component::Prefix(_)
-        )));
-    }
-
-    #[test]
-    fn test_ensure_misc_safe_path_rejects_traversal() {
-        // Paths with ParentDir (..) must be rejected.
-        let traversal_path = PathBuf::from("/home/user/../../etc/shadow");
-        assert!(!traversal_path.components().all(|c| matches!(
-            c,
-            Component::Normal(_) | Component::CurDir | Component::RootDir | Component::Prefix(_)
-        )));
-    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -766,11 +766,11 @@ impl ConfigFile {
             fs::create_dir_all(&dir_to_search)?;
         }
 
+        // codeql[rust/path-injection] False positive: User-provided local config files in topgrade.d
         for entry in fs::read_dir(&dir_to_search)? {
             let entry = entry?;
             let entry_path = entry.path();
 
-            // codeql[rust/path-injection] False positive: User-provided local config files in topgrade.d
             if entry_path.is_file() {
                 debug!(
                     "Found additional (directory) configuration file at {}",
@@ -885,17 +885,7 @@ impl ConfigFile {
             debug!("Adding [misc] section to {}", path.display());
             string_prepend_str(contents, "[misc]\n");
 
-            let is_safe_path = path.components().all(|component| {
-                matches!(
-                    component,
-                    Component::Normal(_) | Component::CurDir | Component::RootDir | Component::Prefix(_)
-                )
-            });
-            if !is_safe_path {
-                error!("Refusing to auto-migrate config for unsafe path: {}", path.display());
-                return;
-            }
-
+            // codeql[rust/path-injection] False positive: User-provided local config file
             File::create(path)
                 .and_then(|mut f| f.write_all(contents.as_bytes()))
                 .expect("Tried to auto-migrate the config file, unable to write to config file.\nPlease add \"[misc]\" section manually to the first line of the file.\nError");

--- a/src/config.rs
+++ b/src/config.rs
@@ -2474,4 +2474,31 @@ last = ["cargo"]
         );
         assert!(config.steps().is_err());
     }
+
+    #[test]
+    fn test_ensure_misc_safe_path_accepts_absolute_paths() {
+        // The path safety check must accept normal absolute paths
+        // (they contain RootDir / Prefix components).
+        let unix_path = PathBuf::from("/home/user/.config/topgrade.toml");
+        assert!(unix_path.components().all(|c| matches!(
+            c,
+            Component::Normal(_) | Component::CurDir | Component::RootDir | Component::Prefix(_)
+        )));
+
+        let windows_path = PathBuf::from(r"C:\Users\user\topgrade.toml");
+        assert!(windows_path.components().all(|c| matches!(
+            c,
+            Component::Normal(_) | Component::CurDir | Component::RootDir | Component::Prefix(_)
+        )));
+    }
+
+    #[test]
+    fn test_ensure_misc_safe_path_rejects_traversal() {
+        // Paths with ParentDir (..) must be rejected.
+        let traversal_path = PathBuf::from("/home/user/../../etc/shadow");
+        assert!(!traversal_path.components().all(|c| matches!(
+            c,
+            Component::Normal(_) | Component::CurDir | Component::RootDir | Component::Prefix(_)
+        )));
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,7 +3,7 @@
 use std::collections::HashSet;
 use std::fs::{File, write};
 use std::io::Write;
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 use std::{env, fmt, fs};
 
 use clap::{Parser, ValueEnum};

--- a/src/config.rs
+++ b/src/config.rs
@@ -912,9 +912,12 @@ impl ConfigFile {
             debug!("Adding [misc] section to {}", path.display());
             string_prepend_str(contents, "[misc]\n");
 
-            let is_safe_path = path
-                .components()
-                .all(|component| matches!(component, Component::Normal(_) | Component::CurDir));
+            let is_safe_path = path.components().all(|component| {
+                matches!(
+                    component,
+                    Component::Normal(_) | Component::CurDir | Component::RootDir | Component::Prefix(_)
+                )
+            });
             if !is_safe_path {
                 error!("Refusing to auto-migrate config for unsafe path: {}", path.display());
                 return;

--- a/src/config.rs
+++ b/src/config.rs
@@ -2437,5 +2437,4 @@ last = ["cargo"]
         );
         assert!(config.steps().is_err());
     }
-
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -798,12 +798,31 @@ impl ConfigFile {
             The Function was called without a config_path, we need
             to read the include directory before returning the main config path
             */
+            let include_base_dir = path
+                .parent()
+                .map(|p| p.join("topgrade.d"))
+                .ok_or_eyre("Unable to determine configuration directory for include validation")?;
+            let include_base_dir = include_base_dir
+                .canonicalize()
+                .wrap_err("Unable to canonicalize include base directory")?;
+
             for include in dir_include {
-                let include_contents = fs::read_to_string(&include).inspect_err(|_| {
-                    error!("Unable to read {}", include.display());
+                let include_canonical = include
+                    .canonicalize()
+                    .wrap_err_with(|| format!("Unable to canonicalize {}", include.display()))?;
+
+                if !include_canonical.starts_with(&include_base_dir) {
+                    return Err(color_eyre::eyre::eyre!(
+                        "Refusing to read include outside topgrade.d: {}",
+                        include.display()
+                    ));
+                }
+
+                let include_contents = fs::read_to_string(&include_canonical).inspect_err(|_| {
+                    error!("Unable to read {}", include_canonical.display());
                 })?;
                 let include_contents_parsed = toml::from_str(include_contents.as_str()).inspect_err(|_| {
-                    error!("Failed to deserialize {}", include.display());
+                    error!("Failed to deserialize {}", include_canonical.display());
                 })?;
 
                 result.merge(include_contents_parsed);
@@ -817,6 +836,10 @@ impl ConfigFile {
             // If empty, Self:: ensure() would have created the default config.
             return Ok(result);
         }
+
+        let config_path = config_path
+            .canonicalize()
+            .wrap_err_with(|| format!("Unable to canonicalize {}", config_path.display()))?;
 
         let mut contents_non_split = fs::read_to_string(&config_path).inspect_err(|_| {
             error!("Unable to read {}", config_path.display());

--- a/src/config.rs
+++ b/src/config.rs
@@ -766,10 +766,8 @@ impl ConfigFile {
             fs::create_dir_all(&dir_to_search)?;
         }
 
-        // codeql[rust/path-injection] False positive: User-provided local config files in topgrade.d
         for entry in fs::read_dir(&dir_to_search)? {
-            let entry = entry?;
-            let entry_path = entry.path();
+            let entry_path = entry?.path();
 
             if entry_path.is_file() {
                 debug!(
@@ -801,7 +799,6 @@ impl ConfigFile {
             to read the include directory before returning the main config path
             */
             for include in dir_include {
-                // codeql[rust/path-injection] False positive: User-provided local config file
                 let include_contents = fs::read_to_string(&include).inspect_err(|_| {
                     error!("Unable to read {}", include.display());
                 })?;
@@ -821,7 +818,6 @@ impl ConfigFile {
             return Ok(result);
         }
 
-        // codeql[rust/path-injection] False positive: User-provided local config file
         let mut contents_non_split = fs::read_to_string(&config_path).inspect_err(|_| {
             error!("Unable to read {}", config_path.display());
         })?;
@@ -885,7 +881,6 @@ impl ConfigFile {
             debug!("Adding [misc] section to {}", path.display());
             string_prepend_str(contents, "[misc]\n");
 
-            // codeql[rust/path-injection] False positive: User-provided local config file
             File::create(path)
                 .and_then(|mut f| f.write_all(contents.as_bytes()))
                 .expect("Tried to auto-migrate the config file, unable to write to config file.\nPlease add \"[misc]\" section manually to the first line of the file.\nError");

--- a/src/config.rs
+++ b/src/config.rs
@@ -766,23 +766,17 @@ impl ConfigFile {
             fs::create_dir_all(&dir_to_search)?;
         }
 
-        let canonical_dir_to_search = dir_to_search.canonicalize()?;
-
-        for entry in fs::read_dir(&canonical_dir_to_search)? {
+        for entry in fs::read_dir(&dir_to_search)? {
             let entry = entry?;
             let entry_path = entry.path();
-            let canonical_entry_path = match entry_path.canonicalize() {
-                Ok(path) => path,
-                Err(_) => continue,
-            };
 
-            // Ensure resolved path stays inside topgrade.d, then accept regular files.
-            if canonical_entry_path.starts_with(&canonical_dir_to_search) && canonical_entry_path.is_file() {
+            // codeql[rust/path-injection] False positive: User-provided local config files in topgrade.d
+            if entry_path.is_file() {
                 debug!(
                     "Found additional (directory) configuration file at {}",
-                    canonical_entry_path.display()
+                    entry_path.display()
                 );
-                res.push(canonical_entry_path);
+                res.push(entry_path);
             }
         }
 
@@ -806,31 +800,13 @@ impl ConfigFile {
             The Function was called without a config_path, we need
             to read the include directory before returning the main config path
             */
-            let include_base_dir = path
-                .parent()
-                .map(|p| p.join("topgrade.d"))
-                .ok_or_eyre("Unable to determine configuration directory for include validation")?;
-            let include_base_dir = include_base_dir
-                .canonicalize()
-                .wrap_err("Unable to canonicalize include base directory")?;
-
             for include in dir_include {
-                let include_canonical = include
-                    .canonicalize()
-                    .wrap_err_with(|| format!("Unable to canonicalize {}", include.display()))?;
-
-                if !include_canonical.starts_with(&include_base_dir) {
-                    return Err(color_eyre::eyre::eyre!(
-                        "Refusing to read include outside topgrade.d: {}",
-                        include.display()
-                    ));
-                }
-
-                let include_contents = fs::read_to_string(&include_canonical).inspect_err(|_| {
-                    error!("Unable to read {}", include_canonical.display());
+                // codeql[rust/path-injection] False positive: User-provided local config file
+                let include_contents = fs::read_to_string(&include).inspect_err(|_| {
+                    error!("Unable to read {}", include.display());
                 })?;
                 let include_contents_parsed = toml::from_str(include_contents.as_str()).inspect_err(|_| {
-                    error!("Failed to deserialize {}", include_canonical.display());
+                    error!("Failed to deserialize {}", include.display());
                 })?;
 
                 result.merge(include_contents_parsed);
@@ -845,10 +821,7 @@ impl ConfigFile {
             return Ok(result);
         }
 
-        let config_path = config_path
-            .canonicalize()
-            .wrap_err_with(|| format!("Unable to canonicalize {}", config_path.display()))?;
-
+        // codeql[rust/path-injection] False positive: User-provided local config file
         let mut contents_non_split = fs::read_to_string(&config_path).inspect_err(|_| {
             error!("Unable to read {}", config_path.display());
         })?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,7 +3,7 @@
 use std::collections::HashSet;
 use std::fs::{File, write};
 use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::{env, fmt, fs};
 
 use clap::{Parser, ValueEnum};
@@ -880,6 +880,15 @@ impl ConfigFile {
         if !contents.contains("[misc]") {
             debug!("Adding [misc] section to {}", path.display());
             string_prepend_str(contents, "[misc]\n");
+
+            let is_safe_path = path.components().all(|component| matches!(component, Component::Normal(_) | Component::CurDir));
+            if !is_safe_path {
+                error!(
+                    "Refusing to auto-migrate config for unsafe path: {}",
+                    path.display()
+                );
+                return;
+            }
 
             File::create(path)
                 .and_then(|mut f| f.write_all(contents.as_bytes()))

--- a/src/config.rs
+++ b/src/config.rs
@@ -761,24 +761,32 @@ impl ConfigFile {
         let mut res = Vec::new();
         let dir_to_search = config_directory.join("topgrade.d");
 
-        if dir_to_search.exists() {
-            for entry in fs::read_dir(dir_to_search)? {
-                let entry = entry?;
-                // Use `Path::is_file()` here to traverse symbolic links.
-                // `DirEntry::file_type()` and `FileType::is_file()` will not traverse symbolic links.
-                if entry.path().is_file() {
-                    debug!(
-                        "Found additional (directory) configuration file at {}",
-                        entry.path().display()
-                    );
-                    res.push(entry.path());
-                }
-            }
-            res.sort();
-        } else {
+        if !dir_to_search.exists() {
             debug!("No additional configuration directory exists, creating one");
             fs::create_dir_all(&dir_to_search)?;
         }
+
+        let canonical_dir_to_search = dir_to_search.canonicalize()?;
+
+        for entry in fs::read_dir(&canonical_dir_to_search)? {
+            let entry = entry?;
+            let entry_path = entry.path();
+            let canonical_entry_path = match entry_path.canonicalize() {
+                Ok(path) => path,
+                Err(_) => continue,
+            };
+
+            // Ensure resolved path stays inside topgrade.d, then accept regular files.
+            if canonical_entry_path.starts_with(&canonical_dir_to_search) && canonical_entry_path.is_file() {
+                debug!(
+                    "Found additional (directory) configuration file at {}",
+                    canonical_entry_path.display()
+                );
+                res.push(canonical_entry_path);
+            }
+        }
+
+        res.sort();
 
         Ok(res)
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -912,12 +912,11 @@ impl ConfigFile {
             debug!("Adding [misc] section to {}", path.display());
             string_prepend_str(contents, "[misc]\n");
 
-            let is_safe_path = path.components().all(|component| matches!(component, Component::Normal(_) | Component::CurDir));
+            let is_safe_path = path
+                .components()
+                .all(|component| matches!(component, Component::Normal(_) | Component::CurDir));
             if !is_safe_path {
-                error!(
-                    "Refusing to auto-migrate config for unsafe path: {}",
-                    path.display()
-                );
+                error!("Refusing to auto-migrate config for unsafe path: {}", path.display());
                 return;
             }
 

--- a/src/self_renamer.rs
+++ b/src/self_renamer.rs
@@ -11,8 +11,8 @@ impl SelfRenamer {
     pub fn create() -> Result<Self> {
         let tempdir = tempfile::tempdir()?;
         let temp_path = tempdir.path().join("topgrade.exe");
+        // codeql[rust/path-injection] False positive: current_exe() returns a trusted system path
         let exe_path = current_exe()?;
-        let exe_path = exe_path.canonicalize()?;
 
         debug!("Current exe in {:?}. Moving it to {:?}", exe_path, temp_path);
 

--- a/src/self_renamer.rs
+++ b/src/self_renamer.rs
@@ -1,5 +1,4 @@
 use color_eyre::eyre::Result;
-use std::path::Component;
 use std::{env::current_exe, fs, path::PathBuf};
 use tracing::{debug, error};
 
@@ -14,15 +13,6 @@ impl SelfRenamer {
         let temp_path = tempdir.path().join("topgrade.exe");
         let exe_path = current_exe()?;
         let exe_path = exe_path.canonicalize()?;
-
-        // Reject paths with traversal components after canonicalization
-        // (shouldn't happen, but defense in depth)
-        if exe_path.components().any(|c| matches!(c, Component::ParentDir)) {
-            return Err(color_eyre::eyre::eyre!(
-                "Refusing to operate on exe path with traversal: {}",
-                exe_path.display()
-            ));
-        }
 
         debug!("Current exe in {:?}. Moving it to {:?}", exe_path, temp_path);
 

--- a/src/self_renamer.rs
+++ b/src/self_renamer.rs
@@ -11,7 +11,6 @@ impl SelfRenamer {
     pub fn create() -> Result<Self> {
         let tempdir = tempfile::tempdir()?;
         let temp_path = tempdir.path().join("topgrade.exe");
-        // codeql[rust/path-injection] False positive: current_exe() returns a trusted system path
         let exe_path = current_exe()?;
 
         debug!("Current exe in {:?}. Moving it to {:?}", exe_path, temp_path);

--- a/src/self_renamer.rs
+++ b/src/self_renamer.rs
@@ -17,10 +17,7 @@ impl SelfRenamer {
 
         // Reject paths with traversal components after canonicalization
         // (shouldn't happen, but defense in depth)
-        if exe_path
-            .components()
-            .any(|c| matches!(c, Component::ParentDir))
-        {
+        if exe_path.components().any(|c| matches!(c, Component::ParentDir)) {
             return Err(color_eyre::eyre::eyre!(
                 "Refusing to operate on exe path with traversal: {}",
                 exe_path.display()

--- a/src/self_renamer.rs
+++ b/src/self_renamer.rs
@@ -1,4 +1,5 @@
 use color_eyre::eyre::Result;
+use std::path::Component;
 use std::{env::current_exe, fs, path::PathBuf};
 use tracing::{debug, error};
 
@@ -12,6 +13,19 @@ impl SelfRenamer {
         let tempdir = tempfile::tempdir()?;
         let temp_path = tempdir.path().join("topgrade.exe");
         let exe_path = current_exe()?;
+        let exe_path = exe_path.canonicalize()?;
+
+        // Reject paths with traversal components after canonicalization
+        // (shouldn't happen, but defense in depth)
+        if exe_path
+            .components()
+            .any(|c| matches!(c, Component::ParentDir))
+        {
+            return Err(color_eyre::eyre::eyre!(
+                "Refusing to operate on exe path with traversal: {}",
+                exe_path.display()
+            ));
+        }
 
         debug!("Current exe in {:?}. Moving it to {:?}", exe_path, temp_path);
 

--- a/src/steps/node.rs
+++ b/src/steps/node.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 #[cfg(target_os = "linux")]
 use std::os::unix::fs::MetadataExt;
-use std::path::PathBuf;
+use std::path::{Component, PathBuf};
 
 use crate::HOME_DIR;
 use color_eyre::eyre::Result;
@@ -302,8 +302,16 @@ impl VitePlus {
         let vp_home = match std::env::var_os("VP_HOME") {
             None => return Ok(false),
             Some(s) if s.is_empty() => return Ok(false),
-            Some(s) => s,
+            Some(s) => PathBuf::from(s),
         };
+
+        if !vp_home.is_absolute()
+            || vp_home
+                .components()
+                .any(|component| matches!(component, Component::ParentDir))
+        {
+            return Ok(false);
+        }
 
         let uid = Uid::effective();
         let metadata = std::fs::metadata(&vp_home)?;

--- a/src/steps/node.rs
+++ b/src/steps/node.rs
@@ -307,14 +307,6 @@ impl VitePlus {
             Some(s) => PathBuf::from(s),
         };
 
-        if !vp_home.is_absolute()
-            || vp_home
-                .components()
-                .any(|component| matches!(component, Component::ParentDir))
-        {
-            return Ok(false);
-        }
-
         let uid = Uid::effective();
         let metadata = std::fs::metadata(&vp_home)?;
 

--- a/src/steps/node.rs
+++ b/src/steps/node.rs
@@ -1,8 +1,6 @@
 use std::fmt::Display;
 #[cfg(target_os = "linux")]
 use std::os::unix::fs::MetadataExt;
-#[cfg(target_os = "linux")]
-use std::path::Component;
 use std::path::PathBuf;
 
 use crate::HOME_DIR;

--- a/src/steps/node.rs
+++ b/src/steps/node.rs
@@ -1,7 +1,9 @@
 use std::fmt::Display;
 #[cfg(target_os = "linux")]
 use std::os::unix::fs::MetadataExt;
-use std::path::{Component, PathBuf};
+use std::path::PathBuf;
+#[cfg(target_os = "linux")]
+use std::path::Component;
 
 use crate::HOME_DIR;
 use color_eyre::eyre::Result;

--- a/src/steps/node.rs
+++ b/src/steps/node.rs
@@ -1,9 +1,9 @@
 use std::fmt::Display;
 #[cfg(target_os = "linux")]
 use std::os::unix::fs::MetadataExt;
-use std::path::PathBuf;
 #[cfg(target_os = "linux")]
 use std::path::Component;
+use std::path::PathBuf;
 
 use crate::HOME_DIR;
 use color_eyre::eyre::Result;


### PR DESCRIPTION
### What does this PR do

Improves code quality and readability by refactoring path handling across several modules to be more idiomatic.

*Note: This PR originally started as an attempt to resolve CodeQL path traversal alerts using AI autofixes. After maintainer review, we determined those alerts were false positives given the threat model of a local CLI tool. The overly defensive security checks and suppressions were removed, and the PR was repurposed to focus purely on structural code health.*

### Key Changes:

* **`src/config.rs`**: Flattened the directory traversal logic to reduce unnecessary rightward drift and cached `entry.path()` to avoid redundant calls inside the loop.
* **`src/steps/node.rs`**: Refactored to use more idiomatic `PathBuf` handling.
* **`build.rs`**: Cleaned up the `OUT_DIR` path parsing logic to use safe, owned `PathBuf` representations.
* Removed redundant path component validation checks and tests that were unnecessarily testing the Rust standard library.

### Standards checklist

* [x] The PR title is descriptive
* [x] I have read `CONTRIBUTING.md`
* [ ] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.

### AI involvement

Initial overly defensive fixes were generated by GitHub Copilot. The final implementation was refined manually based on maintainer feedback to focus on standard Rust refactoring rather than security suppressions.


<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
