### PR TITLE
feat: pass -v to remote, toolbx, and vagrant Topgrade invocations

### DIFF
--- a/src/steps/remote/ssh.rs
+++ b/src/steps/remote/ssh.rs
@@ -14,6 +14,7 @@ pub fn ssh_step(ctx: &ExecutionContext, hostname: &str) -> Result<()> {
     let ssh = utils::require("ssh")?;
 
     let topgrade = ctx.config().remote_topgrade_path();
+    let verbose = ctx.config().verbose();
     let mut args = vec!["-t", hostname];
 
     if let Some(ssh_arguments) = ctx.config().ssh_arguments() {
@@ -22,6 +23,9 @@ pub fn ssh_step(ctx: &ExecutionContext, hostname: &str) -> Result<()> {
 
     let env = format!("TOPGRADE_PREFIX={hostname}");
     args.extend(["env", &env, "$SHELL", "-lc", topgrade]);
+    if verbose {
+        args.push("-v");
+    }
 
     #[cfg(unix)]
     if ctx.config().run_in_tmux() && !ctx.run_type().dry() {
@@ -43,6 +47,9 @@ pub fn ssh_step(ctx: &ExecutionContext, hostname: &str) -> Result<()> {
 
         let env = format!("TOPGRADE_PREFIX={hostname}");
         args.extend(["env", &env, "$SHELL", "-lc", topgrade]);
+        if verbose {
+            args.push("-v");
+        }
 
         print_separator(format!("Remote ({hostname})"));
         println!("{}", t!("Connecting to {hostname}...", hostname = hostname));

--- a/src/steps/remote/vagrant.rs
+++ b/src/steps/remote/vagrant.rs
@@ -200,6 +200,9 @@ pub fn topgrade_vagrant_box(ctx: &ExecutionContext, vagrant_box: &VagrantBox) ->
     if ctx.config().yes(Step::Vagrant) {
         command.push_str(" -y");
     }
+    if ctx.config().verbose() {
+        command.push_str(" -v");
+    }
 
     ctx.execute(&vagrant.path)
         .current_dir(&vagrant_box.path)

--- a/src/steps/toolbx.rs
+++ b/src/steps/toolbx.rs
@@ -61,6 +61,9 @@ pub fn run_toolbx(ctx: &ExecutionContext) -> Result<()> {
         if ctx.config().yes(Step::Toolbx) {
             args.push("--yes");
         }
+        if ctx.config().verbose() {
+            args.push("-v");
+        }
 
         ctx.execute(&toolbx).args(&args).status_checked()?;
     }


### PR DESCRIPTION
Closes #557.

#521 fixed this for WSL — when you run \`topgrade -v\`, the WSL-launched topgrade also gets \`-v\`. The same wasn't happening for SSH remotes, toolbx, or vagrant. This applies the same pattern in those three places:

- \`src/steps/remote/ssh.rs\`: append \`-v\` to the ssh command args (in both the tmux/async branch and the normal branch)
- \`src/steps/toolbx.rs\`: append \`-v\` to the toolbox \`run\` args
- \`src/steps/remote/vagrant.rs\`: append \` -v\` to the shell command string

Distrobox is skipped on purpose since \`run_distrobox_update\` calls \`distrobox upgrade\` directly rather than launching a nested topgrade, so there's no inner verbose flag to forward.

## Test plan

\`\`\`
cargo build
cargo test
\`\`\`

Existing tests still pass. The change is gated on \`ctx.config().verbose()\`, so the default (no \`-v\` on host) is unchanged.