### PR TITLE
fix(terminal): only accept actual keypresses in menus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,9 +254,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -264,9 +264,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -450,9 +450,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.5"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
+checksum = "e3e962dae2b1e5007fe9e3db363ddc43a8bf25546d279f7a8a4401204690e80c"
 dependencies = [
  "clap",
 ]
@@ -1013,9 +1013,9 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.29"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+checksum = "2d5b2eef6fafbf69f877e55509ce5b11a760690ac9700a2921be067aa6afaef6"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1894,9 +1894,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.31.3"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
@@ -3339,7 +3339,7 @@ dependencies = [
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.3",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -3383,7 +3383,7 @@ dependencies = [
  "indexmap",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.3",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -3392,7 +3392,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.3",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -4374,9 +4374,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]
@@ -4549,7 +4549,7 @@ dependencies = [
  "uds_windows",
  "uuid",
  "windows-sys 0.61.2",
- "winnow 1.0.3",
+ "winnow 1.0.2",
  "zbus_macros",
  "zbus_names",
  "zvariant",
@@ -4577,7 +4577,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
 dependencies = [
  "serde",
- "winnow 1.0.3",
+ "winnow 1.0.2",
  "zvariant",
 ]
 
@@ -4603,9 +4603,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.8"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
@@ -4720,7 +4720,7 @@ dependencies = [
  "endi",
  "enumflags2",
  "serde",
- "winnow 1.0.3",
+ "winnow 1.0.2",
  "zvariant_derive",
  "zvariant_utils",
 ]
@@ -4748,5 +4748,5 @@ dependencies = [
  "quote",
  "serde",
  "syn",
- "winnow 1.0.3",
+ "winnow 1.0.2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -679,7 +679,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
  "bitflags 2.11.1",
- "crossterm_winapi",
  "document-features",
  "filedescriptor",
  "mio",
@@ -687,16 +686,6 @@ dependencies = [
  "rustix 1.1.4",
  "signal-hook",
  "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm_winapi"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
-dependencies = [
- "winapi",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,9 +254,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -264,9 +264,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -450,9 +450,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.4"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3e962dae2b1e5007fe9e3db363ddc43a8bf25546d279f7a8a4401204690e80c"
+checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
 dependencies = [
  "clap",
 ]
@@ -671,6 +671,33 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.11.1",
+ "crossterm_winapi",
+ "document-features",
+ "filedescriptor",
+ "mio",
+ "parking_lot",
+ "rustix 1.1.4",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crunchy"
@@ -974,10 +1001,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
-name = "filetime"
-version = "0.2.28"
+name = "filedescriptor"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d5b2eef6fafbf69f877e55509ce5b11a760690ac9700a2921be067aa6afaef6"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1754,6 +1792,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1840,15 +1887,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "nix"
-version = "0.31.2"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
@@ -2025,6 +2073,29 @@ name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link 0.2.1",
+]
 
 [[package]]
 name = "parse-changelog"
@@ -2308,6 +2379,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -2635,6 +2715,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2825,6 +2911,27 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -3232,7 +3339,7 @@ dependencies = [
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -3276,7 +3383,7 @@ dependencies = [
  "indexmap",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -3285,7 +3392,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -3311,6 +3418,7 @@ dependencies = [
  "clap_mangen",
  "color-eyre",
  "console",
+ "crossterm",
  "edit",
  "etcetera",
  "futures",
@@ -4266,9 +4374,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -4441,7 +4549,7 @@ dependencies = [
  "uds_windows",
  "uuid",
  "windows-sys 0.61.2",
- "winnow 1.0.2",
+ "winnow 1.0.3",
  "zbus_macros",
  "zbus_names",
  "zvariant",
@@ -4469,7 +4577,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
 dependencies = [
  "serde",
- "winnow 1.0.2",
+ "winnow 1.0.3",
  "zvariant",
 ]
 
@@ -4495,9 +4603,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
@@ -4612,7 +4720,7 @@ dependencies = [
  "endi",
  "enumflags2",
  "serde",
- "winnow 1.0.2",
+ "winnow 1.0.3",
  "zvariant_derive",
  "zvariant_utils",
 ]
@@ -4640,5 +4748,5 @@ dependencies = [
  "quote",
  "serde",
  "syn",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -679,6 +679,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
  "bitflags 2.11.1",
+ "crossterm_winapi",
  "document-features",
  "filedescriptor",
  "mio",
@@ -686,6 +687,16 @@ dependencies = [
  "rustix 1.1.4",
  "signal-hook",
  "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ clap_complete = "4.5"
 clap_mangen = "0.3"
 walkdir = "2.5"
 console = "0.16"
-crossterm = { version = "0.29", default-features = false, features = ["bracketed-paste", "events", "use-dev-tty", "windows"] }
+crossterm = { version = "0.29", default-features = false, features = ["bracketed-paste", "events", "use-dev-tty"] }
 chrono = "0.4"
 glob = "0.3"
 strum = { version = "0.28.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ clap_complete = "4.5"
 clap_mangen = "0.3"
 walkdir = "2.5"
 console = "0.16"
+crossterm = { version = "0.29", default-features = false, features = ["bracketed-paste", "events", "use-dev-tty", "windows"] }
 chrono = "0.4"
 glob = "0.3"
 strum = { version = "0.28.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ clap_complete = "4.5"
 clap_mangen = "0.3"
 walkdir = "2.5"
 console = "0.16"
-crossterm = { version = "0.29", default-features = false, features = ["bracketed-paste", "events", "use-dev-tty"] }
+crossterm = { version = "0.29", default-features = false, features = ["bracketed-paste", "events", "use-dev-tty", "windows"] }
 chrono = "0.4"
 glob = "0.3"
 strum = { version = "0.28.0", features = ["derive"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use clap::CommandFactory;
 use clap::{Parser, crate_version};
 use color_eyre::eyre::Context;
 use color_eyre::eyre::Result;
-use console::Key;
+use crossterm::event::KeyCode;
 #[cfg(windows)]
 use etcetera::base_strategy::Windows;
 #[cfg(unix)]
@@ -284,18 +284,18 @@ fn run() -> Result<()> {
         print_info(t!("\n(R)eboot\n(P)oweroff\n(S)hell\n(Q)uit"));
         loop {
             match get_key() {
-                Ok(Key::Char('s' | 'S')) => {
+                Ok(KeyCode::Char('s' | 'S')) => {
                     run_shell().context("Failed to execute shell")?;
                 }
-                Ok(Key::Char('r' | 'R')) => {
+                Ok(KeyCode::Char('r' | 'R')) => {
                     println!("{}", t!("Rebooting..."));
                     reboot(&ctx).context("Failed to reboot")?;
                 }
-                Ok(Key::Char('p' | 'P')) => {
+                Ok(KeyCode::Char('p' | 'P')) => {
                     println!("{}", t!("Shutting down..."));
                     shutdown(&ctx).context("Failed to shut down")?;
                 }
-                Ok(Key::Char('q' | 'Q')) => (),
+                Ok(KeyCode::Char('q' | 'Q')) => (),
                 _ => {
                     continue;
                 }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -9,6 +9,8 @@ use chrono::{Local, Timelike};
 use color_eyre::eyre;
 use color_eyre::eyre::Context;
 use console::{Key, Term, measure_text_width, style};
+use crossterm::event::{DisableBracketedPaste, EnableBracketedPaste, Event, KeyCode, KeyEventKind, read};
+use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
 use notify_rust::{Notification, Timeout};
 use rust_i18n::t;
 use tracing::{debug, error};
@@ -42,6 +44,26 @@ struct Terminal {
     set_title: bool,
     display_time: bool,
     desktop_notification: bool,
+}
+
+struct RawTerminalMode;
+
+impl RawTerminalMode {
+    fn enter() -> Result<Self, io::Error> {
+        enable_raw_mode()?;
+        if let Err(error) = crossterm::execute!(io::stdout(), EnableBracketedPaste) {
+            disable_raw_mode().ok();
+            return Err(error);
+        }
+        Ok(Self)
+    }
+}
+
+impl Drop for RawTerminalMode {
+    fn drop(&mut self) {
+        crossterm::execute!(io::stdout(), DisableBracketedPaste).ok();
+        disable_raw_mode().ok();
+    }
 }
 
 impl Terminal {
@@ -195,9 +217,9 @@ impl Terminal {
             .ok();
 
         loop {
-            match self.term.read_char()? {
-                'y' | 'Y' => break Ok(true),
-                'n' | 'N' | '\r' | '\n' => break Ok(false),
+            match self.get_char()? {
+                Key::Char('y' | 'Y') => break Ok(true),
+                Key::Char('n' | 'N') | Key::Enter => break Ok(false),
                 _ => (),
             }
         }
@@ -222,7 +244,7 @@ impl Terminal {
 
         let answer = loop {
             self.term.write_fmt(format_args!("\n{prompt_inner}")).ok();
-            match self.term.read_key() {
+            match self.get_char() {
                 Ok(Key::Char('y' | 'Y')) => break Ok(ShouldRetry::Yes),
                 Ok(Key::Char('s' | 'S')) => {
                     println!(
@@ -258,7 +280,19 @@ impl Terminal {
     }
 
     fn get_char(&self) -> Result<Key, io::Error> {
-        self.term.read_key()
+        let _terminal_mode = RawTerminalMode::enter()?;
+        loop {
+            match read()? {
+                Event::Key(key) if key.kind == KeyEventKind::Press => {
+                    break Ok(match key.code {
+                        KeyCode::Char(c) => Key::Char(c),
+                        KeyCode::Enter => Key::Enter,
+                        _ => Key::Unknown,
+                    });
+                }
+                _ => (),
+            }
+        }
     }
 }
 

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -49,7 +49,7 @@ struct Terminal {
 struct RawTerminalMode;
 
 impl RawTerminalMode {
-    fn enter() -> Result<Self, io::Error> {
+    fn enter() -> io::Result<Self> {
         enable_raw_mode()?;
         let guard = Self;
         crossterm::execute!(io::stdout(), EnableBracketedPaste)?;
@@ -278,18 +278,17 @@ impl Terminal {
     }
 
     fn get_char(&self) -> Result<Key, io::Error> {
-        let _terminal_mode = RawTerminalMode::enter()?;
+        let _raw_mode_guard = RawTerminalMode::enter()?;
         loop {
-            match read()? {
-                Event::Key(key) if key.kind == KeyEventKind::Press => {
-                    break Ok(match key.code {
-                        KeyCode::Char(c) => Key::Char(c),
-                        KeyCode::Enter => Key::Enter,
-                        _ => Key::Unknown,
-                    });
-                }
-                _ => (),
+            let Event::Key(key) = read()? else { continue };
+            if key.kind != KeyEventKind::Press {
+                continue;
             }
+            break Ok(match key.code {
+                KeyCode::Char(c) => Key::Char(c),
+                KeyCode::Enter => Key::Enter,
+                _ => Key::Unknown,
+            });
         }
     }
 }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -59,8 +59,8 @@ impl RawTerminalMode {
 
 impl Drop for RawTerminalMode {
     fn drop(&mut self) {
-        crossterm::execute!(io::stdout(), DisableBracketedPaste).ok();
-        disable_raw_mode().ok();
+        crossterm::execute!(io::stdout(), DisableBracketedPaste).unwrap();
+        disable_raw_mode().unwrap();
     }
 }
 

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -51,11 +51,9 @@ struct RawTerminalMode;
 impl RawTerminalMode {
     fn enter() -> Result<Self, io::Error> {
         enable_raw_mode()?;
-        if let Err(error) = crossterm::execute!(io::stdout(), EnableBracketedPaste) {
-            disable_raw_mode().ok();
-            return Err(error);
-        }
-        Ok(Self)
+        let guard = Self;
+        crossterm::execute!(io::stdout(), EnableBracketedPaste)?;
+        Ok(guard)
     }
 }
 

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use chrono::{Local, Timelike};
 use color_eyre::eyre;
 use color_eyre::eyre::Context;
-use console::{Key, Term, measure_text_width, style};
+use console::{Term, measure_text_width, style};
 use crossterm::event::{DisableBracketedPaste, EnableBracketedPaste, Event, KeyCode, KeyEventKind, read};
 use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
 use notify_rust::{Notification, Timeout};
@@ -216,8 +216,8 @@ impl Terminal {
 
         loop {
             match self.get_char()? {
-                Key::Char('y' | 'Y') => break Ok(true),
-                Key::Char('n' | 'N') | Key::Enter => break Ok(false),
+                KeyCode::Char('y' | 'Y') => break Ok(true),
+                KeyCode::Char('n' | 'N') | KeyCode::Enter => break Ok(false),
                 _ => (),
             }
         }
@@ -243,8 +243,8 @@ impl Terminal {
         let answer = loop {
             self.term.write_fmt(format_args!("\n{prompt_inner}")).ok();
             match self.get_char() {
-                Ok(Key::Char('y' | 'Y')) => break Ok(ShouldRetry::Yes),
-                Ok(Key::Char('s' | 'S')) => {
+                Ok(KeyCode::Char('y' | 'Y')) => break Ok(ShouldRetry::Yes),
+                Ok(KeyCode::Char('s' | 'S')) => {
                     println!(
                         "\n\n{}\n",
                         t!("Dropping you to shell. Fix what you need and then exit the shell.")
@@ -255,7 +255,7 @@ impl Terminal {
                         break Ok(ShouldRetry::Yes);
                     }
                 }
-                Ok(Key::Char('n' | 'N') | Key::Enter) => break Ok(ShouldRetry::No),
+                Ok(KeyCode::Char('n' | 'N') | KeyCode::Enter) => break Ok(ShouldRetry::No),
                 Err(e) => {
                     if let io::ErrorKind::Interrupted = e.kind() {
                         println!();
@@ -265,7 +265,7 @@ impl Terminal {
                     error!("Error reading from terminal: {}", e);
                     break Ok(ShouldRetry::No);
                 }
-                Ok(Key::Char('q' | 'Q')) => {
+                Ok(KeyCode::Char('q' | 'Q')) => {
                     break Ok(ShouldRetry::Quit);
                 }
                 _ => (),
@@ -277,18 +277,14 @@ impl Terminal {
         answer
     }
 
-    fn get_char(&self) -> Result<Key, io::Error> {
+    fn get_char(&self) -> io::Result<KeyCode> {
         let _raw_mode_guard = RawTerminalMode::enter()?;
         loop {
             let Event::Key(key) = read()? else { continue };
             if key.kind != KeyEventKind::Press {
                 continue;
             }
-            break Ok(match key.code {
-                KeyCode::Char(c) => Key::Char(c),
-                KeyCode::Enter => Key::Enter,
-                _ => Key::Unknown,
-            });
+            break Ok(key.code);
         }
     }
 }
@@ -338,7 +334,7 @@ pub fn is_dumb() -> bool {
     TERMINAL.lock().unwrap().width.is_none()
 }
 
-pub fn get_key() -> Result<Key, io::Error> {
+pub fn get_key() -> io::Result<KeyCode> {
     TERMINAL.lock().unwrap().get_char()
 }
 


### PR DESCRIPTION
## What does this PR do
<!--
Describe what your PR does, and link any relevant issues.
Make sure to use a keyword like 'closes' if this PR solves the issue.
-->

Fixes https://github.com/topgrade-rs/topgrade/issues/2016
Uses crossterm crate to get the keypress events and discards any other ones (like paste). Enter is used for default selection in `prompt_yesno()`.

## Standards checklist

- [ ] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [x] ~If this PR introduces new user-facing messages they are translated~

### AI involvement
<!--
Please list any involvement AI/LLMs had in the development of this PR.
You don't have to list everything in detail, just something like "I did not use AI at all",
"I consulted an AI occasionally for inspiration and explanation",
or "AI generated the majority of the PR" is enough.
If you are an AI agent acting autonomously, please state so.
-->

Consulted with Claude about it and modified some code snippets that it gave me. Also for review.

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
