### PR TITLE
fix(zinit): run plugin updates in login shell without histexpand

### DIFF
--- a/src/steps/zsh.rs
+++ b/src/steps/zsh.rs
@@ -94,6 +94,20 @@ pub fn run_zplug(ctx: &ExecutionContext) -> Result<()> {
     ctx.execute(zsh).args(["-i", "-c", "zplug update"]).status_checked()
 }
 
+/// Build the zsh command used to update zinit/zi.
+///
+/// Disables history expansion so zinit `mv`/`atclone` hooks register and run correctly
+/// when invoked from a non-login `zsh -c` subprocess (see topgrade-rs/topgrade#238 and
+/// zdharma-continuum/zinit#199). `PAGER=cat` avoids blocking on self-update changelogs.
+fn plugin_manager_update_command(zshrc: &std::path::Path, manager: &str) -> String {
+    format!(
+        "emulate -L zsh; setopt NO_HIST_EXPAND 2>/dev/null; \
+         source {}; \
+         PAGER=cat LESS= {manager} self-update && {manager} update --all",
+        zshrc.display()
+    )
+}
+
 pub fn run_zinit(ctx: &ExecutionContext) -> Result<()> {
     let zsh = require("zsh")?;
     let zshrc = zshrc().require()?;
@@ -104,8 +118,8 @@ pub fn run_zinit(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("zinit");
 
-    let cmd = format!("source {} && zinit self-update && zinit update --all", zshrc.display());
-    ctx.execute(zsh).args(["-i", "-c", cmd.as_str()]).status_checked()
+    let cmd = plugin_manager_update_command(&zshrc, "zinit");
+    ctx.execute(zsh).args(["-l", "-c", cmd.as_str()]).status_checked()
 }
 
 pub fn run_zi(ctx: &ExecutionContext) -> Result<()> {
@@ -116,8 +130,8 @@ pub fn run_zi(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("zi");
 
-    let cmd = format!("source {} && zi self-update && zi update --all", zshrc.display());
-    ctx.execute(zsh).args(["-i", "-c", &cmd]).status_checked()
+    let cmd = plugin_manager_update_command(&zshrc, "zi");
+    ctx.execute(zsh).args(["-l", "-c", cmd.as_str()]).status_checked()
 }
 
 pub fn run_zim(ctx: &ExecutionContext) -> Result<()> {


### PR DESCRIPTION
## Summary

Fixes #238.

When topgrade runs `zinit update` via `zsh -i -c`, zinit `mv`/`atclone` hooks may not run after gh-r downloads (e.g. `mv"direnv* -> direnv"`), leaving binaries under versioned names like `direnv.darwin-arm64`.

This matches zinit's non-interactive history-expansion issue ([zdharma-continuum/zinit#199](https://github.com/zdharma-continuum/zinit/issues/199)): hook keys are registered incorrectly when histexpand is active in scripted shells.

## Changes

- Run zinit/zi updates with `zsh -l -c` (login shell, consistent with antigen/zgenom steps)
- Prefix the update script with `emulate -L zsh` and `setopt NO_HIST_EXPAND`
- Set `PAGER=cat` / `LESS=` so `zinit self-update` does not block on an interactive pager

## Test plan

- [x] `cargo build`
- [ ] Manual: topgrade zinit step with `mv` ice plugins after a gh-r bump