### PR TITLE
chore: remove stale skip_notify deprecation TODO

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1415,7 +1415,6 @@ impl Config {
             .and_then(|misc| misc.notify_end)
             .unwrap_or(self.opt.notify_end);
 
-        // TODO: deprecate skip_notify
         if skip_notify {
             return NotifyEnd::Never;
         }


### PR DESCRIPTION
## Summary

Removes the outdated `// TODO: deprecate skip_notify` in `Config::notify_end()`. `skip_notify` was already deprecated in favor of `notify_end` (#1760); the TODO no longer tracks open work.

Part of #1961 (one row in the tracking table).

## Test plan

- [x] Comment-only change; no behavior change