### PR TITLE
fix(install-release): remove ir alias to avoid conflict with mono-mdk

### DIFF
--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -1125,7 +1125,7 @@ pub fn shutdown(ctx: &ExecutionContext) -> Result<()> {
 
 /// See: <https://github.com/Rishang/install-release>
 pub fn run_install_release(ctx: &ExecutionContext) -> Result<()> {
-    let ir = require_one(["ir", "install-release"])?;
+    let ir = require("install-release")?;
 
     print_separator("Install Release");
 


### PR DESCRIPTION
The install-release step probed for 'ir' before 'install-release'. On macOS, wine-hq's mono-mdk provides its own 'ir' binary, causing topgrade to invoke the wrong tool. Require 'install-release' directly.

Closes #2034

## What does this PR do
It fixes a binary-name collision in the `install-release` step.

**Before** (src/steps/os/unix.rs:1128):
```rust
let ir = require_one(["ir", "install-release"])?;
```
Topgrade looked for `ir` first, falling back to `install-release`. The `ir` alias is shipped by [[Rishang/install-release](https://github.com/Rishang/install-release)](https://github.com/Rishang/install-release).

**Problem**: On macOS, wine-hq's `mono-mdk` package also installs an `ir` binary (Microsoft's IL disassembler/related tool). If a user has `mono-mdk` installed, topgrade picks up *that* `ir` and runs `ir upgrade --pkg`, which either fails or does something unrelated.

**After**:
```rust
let ir = require("install-release")?;
```
Require the unambiguous full name `install-release` only. No more collision. Users who had only the `ir` alias on their PATH will need the full binary installed, but the upstream tool installs both names by default, so this is essentially a no-op for them.

One-line diff, no behavior change beyond removing the bad probe.

```zsh
$ cargo run --release -- --only install_release --dry-run -v
...
DEBUG Step "Install Release"
 ―― Summary ――
Install Release: SKIPPED: Cannot find "install-release" in PATH
```

## Standards checklist

- [X] The PR title is descriptive
- [X] I have read `CONTRIBUTING.md`
- [X] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [ ] If this PR introduces new user-facing messages they are translated

### AI involvement
- Used as a tool to summarise some patterns in the repo.

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
