### PR TITLE
fix(jetbrains-toolbox): skip step when Toolbox is not installed, but remotely managed IDEs are installed

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -1879,6 +1879,12 @@ pub fn run_jetbrains_toolbox(ctx: &ExecutionContext) -> Result<()> {
             // Skip
             Err(SkipStep(format!("{}", t!("No JetBrains Toolbox installation found"))).into())
         }
+        Err(FindError::NoDesktopFile(_)) => {
+            // Skip: the JetBrains/Toolbox directory exists but no Toolbox binary or desktop
+            // file is present. This can happen when Toolbox running on another machine remotely
+            // installed an IDE here, leaving the directory behind without a local Toolbox.
+            Err(SkipStep(format!("{}", t!("No JetBrains Toolbox installation found"))).into())
+        }
         Err(FindError::UnsupportedOS(os)) => {
             // Skip
             Err(SkipStep(format!("{}", t!("Unsupported operating system {os}", os = os))).into())


### PR DESCRIPTION

## What does this PR do
Closes #2033.

Maps `FindError::NoDesktopFile` to a `SkipStep` in `run_jetbrains_toolbox`, matching the existing handling of `FindError::NotFound`.

The bug: when JetBrains Toolbox running on machine A remotely installs an IDE onto machine B over SSH, it drops `~/.local/share/JetBrains/Toolbox/` on machine B without there being any local Toolbox install. `jetbrains-toolbox-updater`'s `find_jetbrains_toolbox` treats the directory's existence as evidence Toolbox is present, then returns `NoDesktopFile` once it fails to locate `bin/jetbrains-toolbox` or `jetbrains-toolbox.desktop`. Topgrade previously surfaced this as a step failure even though the host has nothing to update.

Per the maintainer's [comment](https://github.com/topgrade-rs/topgrade/issues/2033#issuecomment-) on the issue, the fix is applied on the Topgrade side rather than upstream so we don't throw away useful error info for genuinely broken installs.

The skip message reuses the existing translation key `"No JetBrains Toolbox installation found"`, so no `locales/app.yml` changes are needed.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [ ] If this PR introduces new user-facing messages they are translated

### AI involvement
AI generated the 3 codelines and the 3 lines of comment, based on my instructions and the issue. I reviewed it to the best of my ability (not a rust developer)

## For new steps

<!-- If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here. -->

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
