### PR TITLE
fix(jetbrains-toolbox): fix breakage on new Toolbox version by switching to different update finished line

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1658,9 +1658,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jetbrains-toolbox-updater"
-version = "6.0.0"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4462ef6f061d87a9b7565e70974e0714f8df3d81b12dcdbe8c0eb412ee89de20"
+checksum = "4dca9e96ad84de2c37208b0d4a6f01b19580a7d11e8fc2c2c6c4c6983a718261"
 dependencies = [
  "dirs",
  "freedesktop-desktop-entry",
@@ -3105,16 +3105,16 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.36.1"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "252800745060e7b9ffb7b2badbd8b31cfa4aa2e61af879d0a3bf2a317c20217d"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
 dependencies = [
  "libc",
  "memchr",
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
- "windows 0.61.3",
+ "windows 0.62.2",
 ]
 
 [[package]]


### PR DESCRIPTION
just a version bump, fix is upstream.