### PR TITLE
feat(vim): add opt-in vim.pack pruning

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -377,6 +377,8 @@
 [vim]
 # For `vim-plug`, execute `PlugUpdate!` instead of `PlugUpdate`
 # force_plug_update = true
+# For Neovim's `vim.pack`, remove inactive packages before updating
+# vim_pack_prune = true
 
 
 [firmware]

--- a/src/config.rs
+++ b/src/config.rs
@@ -392,6 +392,9 @@ pub struct Composer {
 pub struct Vim {
     #[merge(strategy = merge::option::overwrite_none)]
     force_plug_update: Option<bool>,
+
+    #[merge(strategy = merge::option::overwrite_none)]
+    vim_pack_prune: Option<bool>,
 }
 
 #[derive(Deserialize, Default, Debug, Merge)]
@@ -1575,6 +1578,15 @@ impl Config {
             .unwrap_or(false)
     }
 
+    /// Whether to prune inactive `vim.pack` packages in Neovim
+    pub fn vim_pack_prune(&self) -> bool {
+        self.config_file
+            .vim
+            .as_ref()
+            .and_then(|c| c.vim_pack_prune)
+            .unwrap_or(false)
+    }
+
     /// Binaries to exclude from `gup update`
     pub fn gup_exclude(&self) -> &[String] {
         self.config_file
@@ -2382,6 +2394,23 @@ x = "cmd_x"
             config_file: toml::from_str(toml_str).expect("toml parse error"),
             allowed_steps: Vec::new(),
         }
+    }
+
+    #[test]
+    fn test_vim_pack_prune_defaults_to_false() {
+        assert!(!config().vim_pack_prune());
+    }
+
+    #[test]
+    fn test_vim_pack_prune_can_be_enabled() {
+        let config = config_from_toml(
+            r#"
+        [vim]
+        vim_pack_prune = true
+        "#,
+        );
+
+        assert!(config.vim_pack_prune());
     }
 
     #[test]

--- a/src/steps/upgrade.vim
+++ b/src/steps/upgrade.vim
@@ -12,7 +12,14 @@ if exists(":AstroUpdate")
 endif
 
 if has("nvim")
-    lua if vim.pack and next(vim.pack.get(nil, { info = false })) ~= nil then vim.pack.update(nil, { force = true }) end
+    lua << EOF
+if vim.pack and next(vim.pack.get(nil, { info = false })) ~= nil then
+    if vim.env.TOPGRADE_VIM_PACK_PRUNE == "true" and vim.fn.exists(":packdel") ~= 0 then
+        vim.cmd("packdel ++all")
+    end
+    vim.pack.update(nil, { force = true })
+end
+EOF
 endif
 
 if exists(":MasonUpdate")

--- a/src/steps/vim.rs
+++ b/src/steps/vim.rs
@@ -65,6 +65,9 @@ fn upgrade(command: &mut Executor, ctx: &ExecutionContext) -> Result<()> {
     if ctx.config().force_vim_plug_update() {
         command.env("TOPGRADE_FORCE_PLUGUPDATE", "true");
     }
+    if ctx.config().vim_pack_prune() {
+        command.env("TOPGRADE_VIM_PACK_PRUNE", "true");
+    }
 
     let output = command.output()?;
 
@@ -156,4 +159,27 @@ pub fn run_voom(ctx: &ExecutionContext) -> Result<()> {
     print_separator("voom");
 
     ctx.execute(voom).arg("update").status_checked()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::UPGRADE_VIM;
+
+    #[test]
+    fn vim_pack_update_can_prune_before_updating() {
+        let prune = "vim.env.TOPGRADE_VIM_PACK_PRUNE == \"true\"";
+        let packdel = "vim.cmd(\"packdel ++all\")";
+        let update = "vim.pack.update(nil, { force = true })";
+
+        let prune_pos = UPGRADE_VIM
+            .find(prune)
+            .expect("vim.pack prune gate should be controlled by env");
+        let packdel_pos = UPGRADE_VIM
+            .find(packdel)
+            .expect("vim.pack prune gate should call packdel ++all");
+        let update_pos = UPGRADE_VIM.find(update).expect("vim.pack update should still run");
+
+        assert!(prune_pos < packdel_pos);
+        assert!(packdel_pos < update_pos);
+    }
 }


### PR DESCRIPTION
## Summary
- add a disabled-by-default `[vim] vim_pack_prune` option
- forward `TOPGRADE_VIM_PACK_PRUNE=true` to the Vim upgrade script when enabled
- prune inactive Neovim `vim.pack` packages with `packdel ++all` before `vim.pack.update`

This stays opt-in because inactive `vim.pack` packages may be intentionally kept around by users.

Closes #2042

## Test Plan
- `cargo test test_default_config`
- `cargo test vim_pack_prune`
- `cargo test steps::vim`
- `cargo test`