### PR TITLE
fix(tmux): update path to tpm update script

### DIFF
--- a/src/steps/tmux.rs
+++ b/src/steps/tmux.rs
@@ -18,7 +18,7 @@ const TPM_PATH: &str = "plugins/tpm";
 pub fn run_tpm(ctx: &ExecutionContext) -> Result<()> {
     let tpm = match env::var("TMUX_PLUGIN_MANAGER_PATH") {
         // Use `$TMUX_PLUGIN_MANAGER_PATH` if set,
-        Ok(var) => PathBuf::from(var).join(UPDATE_PLUGINS),
+        Ok(var) => PathBuf::from(var).join("tpm").join(UPDATE_PLUGINS),
         Err(_) => {
             // otherwise, use the default XDG location `~/.config/tmux`
             #[cfg(unix)]


### PR DESCRIPTION
## What does this PR do

Match the path that tpm sets to the env var

Closes #2049 

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [ ] If this PR introduces new user-facing messages they are translated

<pre>
── tmux plugins ────────────────────────────────────────────────────────────────
Dry running: /Users/snikoletopoulos/.config/tmux/plugins/tpm/bin/update_plugins all

── Summary ─────────────────────────────────────────────────────────────────────
tmux: OK
</pre>


### AI involvement

None

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
