### PR TITLE
feat(pnpm): use self-update for standalone installs

### DIFF
--- a/src/steps/node.rs
+++ b/src/steps/node.rs
@@ -99,20 +99,28 @@ impl NPM {
         Ok(())
     }
 
-    /// Detects whether pnpm was installed as a standalone binary, i.e. the only
-    /// globally installed "package" is `@pnpm/exe` itself.
+    /// Detects whether pnpm's global registry is in the fragile/broken state
+    /// produced by the standalone `curl | sh` installer.
     ///
-    /// The official `curl | sh` installer extracts the standalone binary into a
-    /// `mktemp` directory and then runs `pnpm add -g @pnpm/exe@<version>` from
-    /// there, so the global manifest registers `@pnpm/exe` as a `file:` link
-    /// into that temp dir. Once the temp dir is cleaned up (e.g. on reboot),
-    /// `pnpm update -g` can no longer resolve the dangling link and fails with
-    /// `ERR_PNPM_LINKED_PKG_DIR_NOT_FOUND`. For such installs `pnpm self-update`
-    /// is the correct tool. Corepack-managed installs do not register
-    /// `@pnpm/exe` as a global package, so they are unaffected by this check.
+    /// That installer extracts the standalone binary into a `mktemp` directory
+    /// and then runs `pnpm add -g @pnpm/exe@<version>` from there, so the global
+    /// manifest registers `@pnpm/exe` as a `file:` link into that temp dir.
+    /// While the temp dir still exists `pnpm update -g` happens to work, but once
+    /// it is cleaned up (e.g. on reboot) the dangling link makes `pnpm update -g`
+    /// fail outright with `ERR_PNPM_LINKED_PKG_DIR_NOT_FOUND`. Running
+    /// `pnpm self-update` re-registers `@pnpm/exe` against a stable,
+    /// registry-resolved version, permanently repairing the manifest so that a
+    /// subsequent `pnpm update -g` can run normally again.
+    ///
+    /// We detect this by the `file:` version specifier that `pnpm list -g --json`
+    /// reports for `@pnpm/exe` (a healthy install reports a plain semver
+    /// version). `pnpm list -g --json` itself keeps working in the broken state,
+    /// so this probe is reliable. Corepack-managed installs do not register
+    /// `@pnpm/exe` as a global package at all, so they are unaffected (and
+    /// `pnpm self-update` does not support them anyway).
     ///
     /// See <https://github.com/topgrade-rs/topgrade/issues/632>.
-    fn is_standalone_pnpm(&self, ctx: &ExecutionContext) -> bool {
+    fn pnpm_global_registry_is_broken(&self, ctx: &ExecutionContext) -> bool {
         if !matches!(self.variant, NPMVariant::Pnpm) {
             return false;
         }
@@ -125,13 +133,15 @@ impl NPM {
         let stdout = match output {
             Ok(output) => output.stdout,
             Err(err) => {
-                debug!("Could not list global pnpm packages, assuming a non-standalone install: {err}");
+                debug!("Could not list global pnpm packages, assuming a healthy install: {err}");
                 return false;
             }
         };
 
         // `pnpm list -g --json` prints an array of project objects, each with a
-        // `dependencies` map keyed by package name.
+        // `dependencies` map keyed by package name. The standalone installer
+        // registers `@pnpm/exe` with a `file:` version specifier pointing into a
+        // temp dir; a healthy registry install reports a plain semver version.
         let parsed: serde_json::Value = match serde_json::from_str(&stdout) {
             Ok(parsed) => parsed,
             Err(err) => {
@@ -140,16 +150,16 @@ impl NPM {
             }
         };
 
-        let global_packages: Vec<&str> = parsed
+        parsed
             .as_array()
             .into_iter()
             .flatten()
             .filter_map(|project| project.get("dependencies"))
             .filter_map(|dependencies| dependencies.as_object())
-            .flat_map(|dependencies| dependencies.keys().map(String::as_str))
-            .collect();
-
-        global_packages == ["@pnpm/exe"]
+            .filter_map(|dependencies| dependencies.get("@pnpm/exe"))
+            .filter_map(|exe| exe.get("version"))
+            .filter_map(|version| version.as_str())
+            .any(|version| version.starts_with("file:"))
     }
 
     /// Update a standalone pnpm binary via `pnpm self-update`.
@@ -434,11 +444,15 @@ pub fn run_pnpm_upgrade(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator(t!("Performant Node Package Manager"));
 
-    // For a standalone pnpm install, `pnpm update -g` is the wrong tool and can
-    // fail outright, so update the binary itself instead. See `is_standalone_pnpm`.
-    if pnpm.is_standalone_pnpm(ctx) {
-        debug!("Detected a standalone pnpm install, using `pnpm self-update`");
-        return pnpm.self_update(ctx);
+    // A standalone (`curl | sh`) pnpm install registers `@pnpm/exe` as a `file:`
+    // link into a temp dir, which eventually breaks `pnpm update -g`. Repair the
+    // registry with `pnpm self-update` first, then fall through to the normal
+    // `pnpm update -g` so every global package (including pnpm itself) is still
+    // updated, which is this step's original purpose. See
+    // `pnpm_global_registry_is_broken`.
+    if pnpm.pnpm_global_registry_is_broken(ctx) {
+        debug!("Detected a broken standalone pnpm registry; running `pnpm self-update` to repair it");
+        pnpm.self_update(ctx)?;
     }
 
     #[cfg(target_os = "linux")]

--- a/src/steps/node.rs
+++ b/src/steps/node.rs
@@ -99,6 +99,65 @@ impl NPM {
         Ok(())
     }
 
+    /// Detects whether pnpm was installed as a standalone binary, i.e. the only
+    /// globally installed "package" is `@pnpm/exe` itself.
+    ///
+    /// The official `curl | sh` installer extracts the standalone binary into a
+    /// `mktemp` directory and then runs `pnpm add -g @pnpm/exe@<version>` from
+    /// there, so the global manifest registers `@pnpm/exe` as a `file:` link
+    /// into that temp dir. Once the temp dir is cleaned up (e.g. on reboot),
+    /// `pnpm update -g` can no longer resolve the dangling link and fails with
+    /// `ERR_PNPM_LINKED_PKG_DIR_NOT_FOUND`. For such installs `pnpm self-update`
+    /// is the correct tool. Corepack-managed installs do not register
+    /// `@pnpm/exe` as a global package, so they are unaffected by this check.
+    ///
+    /// See <https://github.com/topgrade-rs/topgrade/issues/632>.
+    fn is_standalone_pnpm(&self, ctx: &ExecutionContext) -> bool {
+        if !matches!(self.variant, NPMVariant::Pnpm) {
+            return false;
+        }
+
+        let output = ctx
+            .execute(&self.command)
+            .always()
+            .args(["list", "-g", "--depth=0", "--json"])
+            .output_checked_utf8();
+        let stdout = match output {
+            Ok(output) => output.stdout,
+            Err(err) => {
+                debug!("Could not list global pnpm packages, assuming a non-standalone install: {err}");
+                return false;
+            }
+        };
+
+        // `pnpm list -g --json` prints an array of project objects, each with a
+        // `dependencies` map keyed by package name.
+        let parsed: serde_json::Value = match serde_json::from_str(&stdout) {
+            Ok(parsed) => parsed,
+            Err(err) => {
+                debug!("Could not parse `pnpm list -g --json` output: {err}");
+                return false;
+            }
+        };
+
+        let global_packages: Vec<&str> = parsed
+            .as_array()
+            .into_iter()
+            .flatten()
+            .filter_map(|project| project.get("dependencies"))
+            .filter_map(|dependencies| dependencies.as_object())
+            .flat_map(|dependencies| dependencies.keys().map(String::as_str))
+            .collect();
+
+        global_packages == ["@pnpm/exe"]
+    }
+
+    /// Update a standalone pnpm binary via `pnpm self-update`.
+    fn self_update(&self, ctx: &ExecutionContext) -> Result<()> {
+        ctx.execute(&self.command).arg("self-update").status_checked()?;
+        Ok(())
+    }
+
     #[cfg(target_os = "linux")]
     pub fn should_use_sudo(&self, ctx: &ExecutionContext) -> Result<bool> {
         let npm_root = self.root(ctx)?;
@@ -374,6 +433,13 @@ pub fn run_pnpm_upgrade(ctx: &ExecutionContext) -> Result<()> {
     let pnpm = require("pnpm").map(|b| NPM::new(b, NPMVariant::Pnpm))?;
 
     print_separator(t!("Performant Node Package Manager"));
+
+    // For a standalone pnpm install, `pnpm update -g` is the wrong tool and can
+    // fail outright, so update the binary itself instead. See `is_standalone_pnpm`.
+    if pnpm.is_standalone_pnpm(ctx) {
+        debug!("Detected a standalone pnpm install, using `pnpm self-update`");
+        return pnpm.self_update(ctx);
+    }
 
     #[cfg(target_os = "linux")]
     {

--- a/src/steps/node.rs
+++ b/src/steps/node.rs
@@ -661,7 +661,7 @@ mod pnpm_registry_tests {
         assert!(!pnpm_global_registry_is_broken_from_list_json("[]"));
     }
 
-    /// Unparseable output is treated as healthy (we don't want to self-update on
+    /// Unparsable output is treated as healthy (we don't want to self-update on
     /// a transient/garbled response).
     #[test]
     fn malformed_json_is_not_broken() {

--- a/src/steps/node.rs
+++ b/src/steps/node.rs
@@ -105,19 +105,19 @@ impl NPM {
     /// That installer extracts the standalone binary into a `mktemp` directory
     /// and then runs `pnpm add -g @pnpm/exe@<version>` from there, so the global
     /// manifest registers `@pnpm/exe` as a `file:` link into that temp dir.
-    /// While the temp dir still exists `pnpm update -g` happens to work, but once
+    /// While the temp dir exists, `pnpm update -g` continues to work, but once
     /// it is cleaned up (e.g. on reboot) the dangling link makes `pnpm update -g`
     /// fail outright with `ERR_PNPM_LINKED_PKG_DIR_NOT_FOUND`. Running
     /// `pnpm self-update` re-registers `@pnpm/exe` against a stable,
     /// registry-resolved version, permanently repairing the manifest so that a
     /// subsequent `pnpm update -g` can run normally again.
     ///
-    /// We detect this by the `file:` version specifier that `pnpm list -g --json`
-    /// reports for `@pnpm/exe` (a healthy install reports a plain semver
-    /// version). `pnpm list -g --json` itself keeps working in the broken state,
-    /// so this probe is reliable. Corepack-managed installs do not register
-    /// `@pnpm/exe` as a global package at all, so they are unaffected (and
-    /// `pnpm self-update` does not support them anyway).
+    /// The below detects this by the `file:` version specifier that
+    /// `pnpm list -g --json` reports for `@pnpm/exe` (a healthy install reports
+    /// a plain semver version). `pnpm list -g --json` itself keeps working in
+    /// the broken state, so this probe is reliable. Corepack-managed installs do
+    /// not register `@pnpm/exe` as a global package at all, so they are
+    /// unaffected (and `pnpm self-update` does not support them anyway).
     ///
     /// See <https://github.com/topgrade-rs/topgrade/issues/632>.
     fn pnpm_global_registry_is_broken(&self, ctx: &ExecutionContext) -> bool {
@@ -138,28 +138,7 @@ impl NPM {
             }
         };
 
-        // `pnpm list -g --json` prints an array of project objects, each with a
-        // `dependencies` map keyed by package name. The standalone installer
-        // registers `@pnpm/exe` with a `file:` version specifier pointing into a
-        // temp dir; a healthy registry install reports a plain semver version.
-        let parsed: serde_json::Value = match serde_json::from_str(&stdout) {
-            Ok(parsed) => parsed,
-            Err(err) => {
-                debug!("Could not parse `pnpm list -g --json` output: {err}");
-                return false;
-            }
-        };
-
-        parsed
-            .as_array()
-            .into_iter()
-            .flatten()
-            .filter_map(|project| project.get("dependencies"))
-            .filter_map(|dependencies| dependencies.as_object())
-            .filter_map(|dependencies| dependencies.get("@pnpm/exe"))
-            .filter_map(|exe| exe.get("version"))
-            .filter_map(|version| version.as_str())
-            .any(|version| version.starts_with("file:"))
+        pnpm_global_registry_is_broken_from_list_json(&stdout)
     }
 
     /// Update a standalone pnpm binary via `pnpm self-update`.
@@ -180,6 +159,36 @@ impl NPM {
 
         Ok(metadata.uid() != uid.as_raw() && metadata.uid() == 0)
     }
+}
+
+/// Parses the output of `pnpm list -g --depth=0 --json` and returns whether the
+/// global registry is broken, i.e. `@pnpm/exe` is registered with a `file:`
+/// version specifier (the signature of the standalone `curl | sh` installer).
+///
+/// `pnpm list -g --json` prints an array of project objects, each with a
+/// `dependencies` map keyed by package name. The standalone installer registers
+/// `@pnpm/exe` with a `file:` version pointing into a temp dir; a healthy
+/// registry install reports a plain semver version. Anything we can't parse or
+/// recognize is treated as healthy.
+fn pnpm_global_registry_is_broken_from_list_json(list_json: &str) -> bool {
+    let parsed: serde_json::Value = match serde_json::from_str(list_json) {
+        Ok(parsed) => parsed,
+        Err(err) => {
+            debug!("Could not parse `pnpm list -g --json` output: {err}");
+            return false;
+        }
+    };
+
+    parsed
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|project| project.get("dependencies"))
+        .filter_map(|dependencies| dependencies.as_object())
+        .filter_map(|dependencies| dependencies.get("@pnpm/exe"))
+        .filter_map(|exe| exe.get("version"))
+        .filter_map(|version| version.as_str())
+        .any(|version| version.starts_with("file:"))
 }
 
 struct Yarn {
@@ -448,8 +457,7 @@ pub fn run_pnpm_upgrade(ctx: &ExecutionContext) -> Result<()> {
     // link into a temp dir, which eventually breaks `pnpm update -g`. Repair the
     // registry with `pnpm self-update` first, then fall through to the normal
     // `pnpm update -g` so every global package (including pnpm itself) is still
-    // updated, which is this step's original purpose. See
-    // `pnpm_global_registry_is_broken`.
+    // updated, which is this step's original purpose.
     if pnpm.pnpm_global_registry_is_broken(ctx) {
         debug!("Detected a broken standalone pnpm registry; running `pnpm self-update` to repair it");
         pnpm.self_update(ctx)?;
@@ -564,4 +572,114 @@ pub fn run_volta_packages_upgrade(ctx: &ExecutionContext) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod pnpm_registry_tests {
+    use super::pnpm_global_registry_is_broken_from_list_json;
+
+    /// A healthy standalone install (post `pnpm self-update`) reports `@pnpm/exe`
+    /// with a plain semver version, so it is not considered broken.
+    #[test]
+    fn healthy_standalone_install_is_not_broken() {
+        let list_json = r#"[
+            {
+                "path": "/home/user/.local/share/pnpm/global/v11",
+                "private": true,
+                "dependencies": {
+                    "@pnpm/exe": {
+                        "from": "@pnpm/exe",
+                        "version": "11.4.0",
+                        "path": "/home/user/.local/share/pnpm/global/v11/abc/node_modules/@pnpm/exe"
+                    }
+                }
+            }
+        ]"#;
+        assert!(!pnpm_global_registry_is_broken_from_list_json(list_json));
+    }
+
+    /// The `curl | sh` installer registers `@pnpm/exe` with a `file:` version
+    /// pointing into a temp dir, which is the broken state we must repair.
+    #[test]
+    fn standalone_install_with_file_version_is_broken() {
+        let list_json = r#"[
+            {
+                "path": "/home/user/.local/share/pnpm/global/v11",
+                "private": true,
+                "dependencies": {
+                    "@pnpm/exe": {
+                        "from": "@pnpm/exe",
+                        "version": "file:/tmp/tmp.xmRqYYgq7B",
+                        "path": "/home/user/.local/share/pnpm/global/v11/abc/node_modules/@pnpm/exe"
+                    }
+                }
+            }
+        ]"#;
+        assert!(pnpm_global_registry_is_broken_from_list_json(list_json));
+    }
+
+    /// A broken `@pnpm/exe` alongside other global packages is still broken.
+    #[test]
+    fn file_version_mixed_with_other_packages_is_broken() {
+        let list_json = r#"[
+            {
+                "path": "/home/user/.local/share/pnpm/global/v11",
+                "dependencies": {
+                    "@pnpm/exe": { "from": "@pnpm/exe", "version": "file:../tmp.cIve4D5zno" },
+                    "prettier": { "from": "prettier", "version": "3.2.5" }
+                }
+            }
+        ]"#;
+        assert!(pnpm_global_registry_is_broken_from_list_json(list_json));
+    }
+
+    /// Corepack-managed installs do not register `@pnpm/exe` at all, so a global
+    /// list of ordinary packages is not broken.
+    #[test]
+    fn corepack_install_without_pnpm_exe_is_not_broken() {
+        let list_json = r#"[
+            {
+                "path": "/home/user/Library/pnpm/global/5",
+                "dependencies": {
+                    "prettier": { "from": "prettier", "version": "3.2.5" }
+                }
+            }
+        ]"#;
+        assert!(!pnpm_global_registry_is_broken_from_list_json(list_json));
+    }
+
+    /// No global packages at all (no `dependencies` key) is not broken.
+    #[test]
+    fn empty_global_install_is_not_broken() {
+        let list_json = r#"[{ "path": "/home/user/.local/share/pnpm/global/v11", "private": true }]"#;
+        assert!(!pnpm_global_registry_is_broken_from_list_json(list_json));
+    }
+
+    /// An empty project array is not broken.
+    #[test]
+    fn empty_array_is_not_broken() {
+        assert!(!pnpm_global_registry_is_broken_from_list_json("[]"));
+    }
+
+    /// Unparseable output is treated as healthy (we don't want to self-update on
+    /// a transient/garbled response).
+    #[test]
+    fn malformed_json_is_not_broken() {
+        assert!(!pnpm_global_registry_is_broken_from_list_json("not json at all"));
+        assert!(!pnpm_global_registry_is_broken_from_list_json(""));
+    }
+
+    /// A version that merely contains "file:" later in the string (not a `file:`
+    /// specifier) is not treated as broken.
+    #[test]
+    fn semver_version_is_not_broken() {
+        let list_json = r#"[
+            {
+                "dependencies": {
+                    "@pnpm/exe": { "from": "@pnpm/exe", "version": "11.4.0" }
+                }
+            }
+        ]"#;
+        assert!(!pnpm_global_registry_is_broken_from_list_json(list_json));
+    }
 }


### PR DESCRIPTION


## What does this PR do
Addresses part of #632.

A pnpm binary installed via the official `curl | sh` installer registers `@pnpm/exe` in the global manifest as a `file:` link into a mktemp dir. Once that temp dir is cleaned up (e.g. on reboot), `pnpm update -g` can no longer resolve the dangling link and fails with `ERR_PNPM_LINKED_PKG_DIR_NOT_FOUND`, even though pnpm itself works fine.

Detect this case (the only global package is `@pnpm/exe`) and run `pnpm self-update` instead. Corepack-managed installs do not register `@pnpm/exe` globally, so they keep using `pnpm update -g`.

### Output from local test:

**Before:**

```sh
2026-05-28T13:48:58-0400  dev-laptop-t14g5  ~  1
$ topgrade

── 13:51:24 - Sudo ─────────────────────────────────────────────────────────────
[sudo] password for jesse:
Sorry, try again.
[sudo] password for jesse:

# ...

── 13:55:33 - Vim ──────────────────────────────────────────────────────────────
Plugins upgraded

── 13:55:33 - Performant Node Package Manager ──────────────────────────────────
/home/jesse/.local/share/pnpm/global/v11/c6f5-19e6fba36be:
[ERR_PNPM_LINKED_PKG_DIR_NOT_FOUND] Could not install from "/tmp/tmp.xmRqYYgq7B" as it does not exist.

This error happened while installing a direct dependency of /home/jesse/.local/share/pnpm/global/v11/c6f5-19e6fba36be
pnpm failed:
   0: Command failed: `/home/jesse/.local/share/pnpm/bin/pnpm update -g`
   1: `/home/jesse/.local/share/pnpm/bin/pnpm` failed: exit status: 1

Location:
   src/steps/node.rs:96
Retry? (y)es/(N)o/(s)hell/(q)uit

── 13:55:51 - GitHub CLI Extensions ────────────────────────────────────────────
[copilot]: already up to date
✓ Successfully checked extension upgrades

# ...

── 13:55:55 - Summary ──────────────────────────────────────────────────────────
System update: OK
Brew: OK
Brew Cask: OK
config-update: OK
snap: OK
Firmware: OK
Flatpak: OK
asdf: OK
oh-my-zsh: OK
Gnome Shell Extensions: OK
atuin: OK
rustup: OK
.NET: OK
Visual Studio Code extensions: OK
pip3: OK
vim: OK
pnpm: FAILED
GitHub CLI Extensions: OK
Claude Code: OK
Powershell Modules Update: OK
```

**After:**

```sh
2026-05-28T14:29:34-0400  dev-laptop-t14g5  ~/git/3rd-party/topgrade (feat/pnpm-standalone-self-update ±)  0
$ ./target/debug/topgrade --only pnpm -y

── 14:30:58 - Sudo ─────────────────────────────────────────────────────────────
[sudo] password for jesse:

── 14:31:01 - Performant Node Package Manager ──────────────────────────────────
Checking for updates...
The currently active pnpm v11.4.0 is already "latest" and doesn't need an update

── 14:31:02 - Summary ──────────────────────────────────────────────────────────
pnpm: OK
```

## Standards checklist

- [X] The PR title is descriptive
- [X] I have read `CONTRIBUTING.md`
- [X] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [ ] If this PR introduces new user-facing messages they are translated
  - _Only adds some debug messages, not user-facing._

### AI involvement
I used Claude Opus 4.8 to identify the original issue and write the first draft of the Rust changes. I reviewed them, made minor changes, and tested locally. I wrote this PR.