### PR TITLE
fix(claude-code): don't fail with EOF on long output

### DIFF
--- a/src/executor.rs
+++ b/src/executor.rs
@@ -107,6 +107,14 @@ impl Executor {
         self
     }
 
+    /// See `std::process::Command::stdout`
+    pub fn stdout<T: Into<Stdio>>(&mut self, cfg: T) -> &mut Executor {
+        if let Executor::Wet(c) | Executor::Damp(c) = self {
+            c.stdout(cfg);
+        }
+        self
+    }
+
     #[allow(dead_code)]
     /// See `std::process::Command::remove_env`
     pub fn env_remove<K>(&mut self, key: K) -> &mut Executor

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -7,10 +7,8 @@ use rust_i18n::t;
 use semver::Version;
 use serde::Deserialize;
 use std::ffi::OsString;
-use std::io::BufReader;
 use std::iter::once;
 use std::path::PathBuf;
-use std::process::Stdio;
 use std::sync::LazyLock;
 use std::{env, path::Path};
 use std::{fs, io::Write};
@@ -2130,28 +2128,24 @@ pub fn run_claude_code(ctx: &ExecutionContext) -> Result<()> {
         .args(["plugin", "marketplace", "update"])
         .status_checked()?;
 
-    let ExecutorChild::Wet(mut child) = ctx
-        .execute(&claude)
+    // https://github.com/topgrade-rs/topgrade/pull/2062#issuecomment-4703754240
+    let temp_dir = tempdir().context("Failed to create temp dir for `claude plugin list`")?;
+    let json_path = temp_dir.path().join("plugins.json");
+    let json_file = fs::File::create(&json_path).context("Failed to create temp file for `claude plugin list`")?;
+
+    ctx.execute(&claude)
         .always()
         .args(["plugin", "list", "--json"])
-        .stdout(Stdio::piped())
-        .spawn()?
-    else {
-        unreachable!(".always() handles this")
-    };
+        .stdout(json_file)
+        .status_checked()?;
 
-    let stdout = child.stdout.take().expect("stdout was piped");
-    let plugins: Vec<ClaudePlugin> = serde_json::from_reader(BufReader::new(stdout)).wrap_err_with(|| {
+    let json = fs::read_to_string(&json_path).context("Failed to read `claude plugin list --json` output")?;
+    let plugins: Vec<ClaudePlugin> = serde_json::from_str(&json).wrap_err_with(|| {
         output_changed_message!(
             "claude plugin list --json",
             "json output is invalid or does not match expected structure"
         )
     })?;
-
-    let status = child.wait().context("Failed to wait for `claude plugin list --json`")?;
-    if !status.success() {
-        bail!("`claude plugin list --json` exited with {status}");
-    }
 
     let mut success = true;
     for plugin in &plugins {

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -7,8 +7,10 @@ use rust_i18n::t;
 use semver::Version;
 use serde::Deserialize;
 use std::ffi::OsString;
+use std::io::BufReader;
 use std::iter::once;
 use std::path::PathBuf;
+use std::process::Stdio;
 use std::sync::LazyLock;
 use std::{env, path::Path};
 use std::{fs, io::Write};
@@ -2128,16 +2130,28 @@ pub fn run_claude_code(ctx: &ExecutionContext) -> Result<()> {
         .args(["plugin", "marketplace", "update"])
         .status_checked()?;
 
-    let output = ctx
+    let ExecutorChild::Wet(mut child) = ctx
         .execute(&claude)
+        .always()
         .args(["plugin", "list", "--json"])
-        .output_checked_utf8()?;
-    let plugins: Vec<ClaudePlugin> = serde_json::from_str(&output.stdout).wrap_err_with(|| {
+        .stdout(Stdio::piped())
+        .spawn()?
+    else {
+        todo!()
+    };
+
+    let stdout = child.stdout.take().expect("stdout was piped");
+    let plugins: Vec<ClaudePlugin> = serde_json::from_reader(BufReader::new(stdout)).wrap_err_with(|| {
         output_changed_message!(
             "claude plugin list --json",
             "json output is invalid or does not match expected structure"
         )
     })?;
+
+    let status = child.wait().context("Failed to wait for `claude plugin list --json`")?;
+    if !status.success() {
+        bail!("`claude plugin list --json` exited with {status}");
+    }
 
     let mut success = true;
     for plugin in &plugins {

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -2137,7 +2137,7 @@ pub fn run_claude_code(ctx: &ExecutionContext) -> Result<()> {
         .stdout(Stdio::piped())
         .spawn()?
     else {
-        todo!()
+        unreachable!(".always() handles this")
     };
 
     let stdout = child.stdout.take().expect("stdout was piped");


### PR DESCRIPTION
## What does this PR do
<!--
Describe what your PR does, and link any relevant issues.
Make sure to use a keyword like 'closes' if this PR solves the issue.
-->

Maybe fixes a macos specific issue https://github.com/topgrade-rs/topgrade/issues/2045 by streaming stdout into `serde_json::from_reader` over a piped `BufReader`.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [ ] ~If this PR introduces new user-facing messages they are translated~

### AI involvement
<!--
Please list any involvement AI/LLMs had in the development of this PR.
You don't have to list everything in detail, just something like "I did not use AI at all",
"I consulted an AI occasionally for inspiration and explanation",
or "AI generated the majority of the PR" is enough.
If you are an AI agent acting autonomously, please state so.
-->

this pr was entirely ai generated <!-- :broken_heart:  -->

<!-- If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here. -->

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->

