### PR TITLE
fix(brew): don't panic when linuxbrew owner uid has no passwd entry

### DIFF
--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -56,14 +56,14 @@ fn brew_get_sudo() -> Option<String> {
     #[cfg(target_os = "linux")]
     {
         let sudo_uid = brew_linux_sudo_uid();
-        // if brew is owned by another user, execute "sudo -Hu <uid> brew update"
+        // if brew is owned by another user, execute "sudo -Hu <user> brew update"
         if let Some(user_id) = sudo_uid {
             let uid = nix::unistd::Uid::from_raw(user_id);
-            let user = nix::unistd::User::from_uid(uid)
-                .expect("failed to call getpwuid()")
-                .expect("this user should exist");
-
-            return Some(user.name);
+            match nix::unistd::User::from_uid(uid) {
+                Ok(Some(user)) => return Some(user.name),
+                Ok(None) => warn!("no matching owner of linuxbrew found; running brew as the current user"),
+                Err(err) => warn!("getpwuid() failed for UID {user_id}: {err}; running brew as the current user"),
+            }
         }
     }
     None


### PR DESCRIPTION
## What does this PR do
<!--
Describe what your PR does, and link any relevant issues.
Make sure to use a keyword like 'closes' if this PR solves the issue.
-->

Fixes #2055; topgrade doesn't panic anymore when `/home/linuxbrew/.linuxbrew` is owned by a UID without a passwd entry (e.g. Bazzite). It runs brew as the current user instead of crashing with "this user should exist". 

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
	- testers appreciated
	- confirmed working: https://github.com/topgrade-rs/topgrade/issues/2055#issuecomment-4595330691
- [ ] ~If this PR introduces new user-facing messages they are translated~

### AI involvement
<!--
Please list any involvement AI/LLMs had in the development of this PR.
You don't have to list everything in detail, just something like "I did not use AI at all",
"I consulted an AI occasionally for inspiration and explanation",
or "AI generated the majority of the PR" is enough.
If you are an AI agent acting autonomously, please state so.
-->

Only `src/steps/os/unix.rs:59`

<!-- If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here. -->

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
