### PR TITLE
fix(pip3): skip self-update on Termux

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -832,6 +832,12 @@ pub fn run_pip3_update(ctx: &ExecutionContext) -> Result<()> {
         .output_checked_utf8()
         .map_err(|_| SkipStep("pip does not exist".to_string()))?;
 
+    if cfg!(target_os = "android") {
+        return Err(
+            SkipStep("Skip pip3 update because upgrading pip via pip is forbidden on termux".to_string()).into(),
+        );
+    }
+
     let check_extern_managed_script = "import sysconfig; from os import path; print('Y') if path.isfile(path.join(sysconfig.get_path('stdlib'), 'EXTERNALLY-MANAGED')) else print('N')";
     let output = ctx
         .execute(&python3)

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -834,7 +834,7 @@ pub fn run_pip3_update(ctx: &ExecutionContext) -> Result<()> {
 
     if cfg!(target_os = "android") {
         return Err(
-            SkipStep("Skip pip3 update because upgrading pip via pip is forbidden on termux".to_string()).into(),
+            SkipStep("pip is managed by termux".to_string()).into(),
         );
     }
 

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -833,9 +833,7 @@ pub fn run_pip3_update(ctx: &ExecutionContext) -> Result<()> {
         .map_err(|_| SkipStep("pip does not exist".to_string()))?;
 
     if cfg!(target_os = "android") {
-        return Err(
-            SkipStep("pip is managed by termux".to_string()).into(),
-        );
+        return Err(SkipStep("pip is managed by termux".to_string()).into());
     }
 
     let check_extern_managed_script = "import sysconfig; from os import path; print('Y') if path.isfile(path.join(sysconfig.get_path('stdlib'), 'EXTERNALLY-MANAGED')) else print('N')";


### PR DESCRIPTION
## What does this PR do
<!--
Describe what your PR does, and link any relevant issues.
Make sure to use a keyword like 'closes' if this PR solves the issue.
-->

This PR skips pip3 upgrade command if os is android.
closes #2059 

I almost forgot. Here is the verbose output of my test:
<details>
<pre>
❯ ./target/debug/topgrade -v
DEBUG Current system locale is en-US
DEBUG Configuration at /data/data/com.termux/files/home/.config/topgrade.toml
DEBUG Loaded configuration: ConfigFile { include: Some(Include { paths: None }), misc: Some(Misc { allow_root: None, pre_sudo: None, sudo_loop: None, sudo_loop_interval: None, sudo_command: None, disable: None, first: None, last: None, ignore_failures: None, remote_topgrades: None, remote_topgrade_path: None, ssh_arguments: None, tmux_arguments: None, set_title: None, display_time: None, assume_yes: None, ask_retry: None, auto_retry: None, no_retry: None, show_skipped: None, run_in_tmux: None, tmux_session_mode: None, cleanup: None, notify_each_step: None, skip_notify: None, notify_end: None, bashit_branch: None, only: None, no_self_update: None, log_filters: None, show_distribution_summary: None, nix_handler: None }), pre_commands: Some({}), post_commands: Some({}), commands: Some({}), conda: Some(Conda { env_names: None, env_paths: None }), python: Some(Python { enable_pip_review: None, enable_pip_review_local: None, enable_pipupgrade: None, pipupgrade_arguments: None, poetry_force_self_update: None }), composer: Some(Composer { self_update: None }), brew: Some(Brew { greedy_cask: None, greedy_latest: None, greedy_auto_updates: None, autoremove: None, fetch_head: None }), linux: Some(Linux { yay_arguments: None, aura_aur_arguments: None, aura_pacman_arguments: None, arch_package_manager: None, show_arch_news: None, garuda_update_arguments: None, trizen_arguments: None, pikaur_arguments: None, pamac_arguments: None, shelly_arguments: None, dnf_arguments: None, nix_arguments: None, nix_env_arguments: None, apt_arguments: None, enable_tlmgr: None, redhat_distro_sync: None, suse_dup: None, rpm_ostree: None, bootc: None, emerge_sync_flags: None, emerge_update_flags: None, home_manager_arguments: None }), mandb: Some(Mandb { enable: None }), git: Some(Git { max_concurrency: None, arguments: None, repos: None, pull_predefined: None, fetch_only: None }), go: None, containers: Some(Containers { ignored_containers: None, runtime: None, system_prune: None, use_sudo: None }), windows: Some(Windows { accept_all_updates: None, updates_auto_reboot: None, self_rename: None, open_remotes_in_new_terminal: None, wsl_update_pre_release: None, wsl_update_use_web_download: None, winget_silent_install: None, winget_use_sudo: None }), npm: Some(NPM { use_sudo: None }), chezmoi: Some(Chezmoi { exclude_encrypted: None }), mise: Some(Mise { bump: None, interactive: None, jobs: None, verbose: None, quiet: None, silent: None }), yarn: Some(Yarn { use_sudo: None }), deno: Some(Deno { version: None }), vim: Some(Vim { force_plug_update: None, vim_pack_prune: None }), firmware: Some(Firmware { upgrade: None }), vagrant: Some(Vagrant { directories: None, power_on: None, always_suspend: None }), flatpak: Some(Flatpak { use_sudo: None }), pixi: Some(Pixi { include_release_notes: None }), distrobox: Some(Distrobox { use_root: None, containers: None }), lensfun: Some(Lensfun { use_sudo: None }), julia: Some(JuliaConfig { startup_file: None }), zigup: Some(Zigup { target_versions: None, install_dir: None, path_link: None, cleanup: None }), vscode: Some(VscodeConfig { profile: None }), doom: Some(DoomConfig { aot: None }), cargo: None, rustup: Some(Rustup { channels: None }), pkgfile: Some(Pkgfile { enable: None }), viteplus: None }
DEBUG Version: 17.5.1
DEBUG OS: aarch64-linux-android
DEBUG Args { inner: ["./target/debug/topgrade", "-v"] }
DEBUG Binary path: Ok("/data/data/com.termux/files/home/topgrade/target/debug/topgrade")
DEBUG self-update Feature Enabled: false
DEBUG Configuration: Config { opt: CommandLineArgs { edit_config: false, show_config_reference: false, run_in_tmux: false, no_tmux: false, cleanup: false, dry_run: false, run_type: Wet, no_retry: false, no_ask_retry: false, auto_retry: None, disable: [], only: [], custom_commands: [], env: [], verbose: true, keep_at_end: false, skip_notify: false, notify_end: Always, yes: None, disable_predefined_git_repos: false, config: None, remote_host_limit: None, show_skipped: false, allow_root: false, sudo_loop: false, sudo_loop_interval: None, log_filter: "warn", gen_completion: None, gen_manpage: false, no_self_update: false }, config_file: ConfigFile { include: Some(Include { paths: None }), misc: Some(Misc { allow_root: None, pre_sudo: None, sudo_loop: None, sudo_loop_interval: None, sudo_command: None, disable: None, first: None, last: None, ignore_failures: None, remote_topgrades: None, remote_topgrade_path: None, ssh_arguments: None, tmux_arguments: None, set_title: None, display_time: None, assume_yes: None, ask_retry: None, auto_retry: None, no_retry: None, show_skipped: None, run_in_tmux: None, tmux_session_mode: None, cleanup: None, notify_each_step: None, skip_notify: None, notify_end: None, bashit_branch: None, only: None, no_self_update: None, log_filters: None, show_distribution_summary: None, nix_handler: None }), pre_commands: Some({}), post_commands: Some({}), commands: Some({}), conda: Some(Conda { env_names: None, env_paths: None }), python: Some(Python { enable_pip_review: None, enable_pip_review_local: None, enable_pipupgrade: None, pipupgrade_arguments: None, poetry_force_self_update: None }), composer: Some(Composer { self_update: None }), brew: Some(Brew { greedy_cask: None, greedy_latest: None, greedy_auto_updates: None, autoremove: None, fetch_head: None }), linux: Some(Linux { yay_arguments: None, aura_aur_arguments: None, aura_pacman_arguments: None, arch_package_manager: None, show_arch_news: None, garuda_update_arguments: None, trizen_arguments: None, pikaur_arguments: None, pamac_arguments: None, shelly_arguments: None, dnf_arguments: None, nix_arguments: None, nix_env_arguments: None, apt_arguments: None, enable_tlmgr: None, redhat_distro_sync: None, suse_dup: None, rpm_ostree: None, bootc: None, emerge_sync_flags: None, emerge_update_flags: None, home_manager_arguments: None }), mandb: Some(Mandb { enable: None }), git: Some(Git { max_concurrency: None, arguments: None, repos: None, pull_predefined: None, fetch_only: None }), go: None, containers: Some(Containers { ignored_containers: None, runtime: None, system_prune: None, use_sudo: None }), windows: Some(Windows { accept_all_updates: None, updates_auto_reboot: None, self_rename: None, open_remotes_in_new_terminal: None, wsl_update_pre_release: None, wsl_update_use_web_download: None, winget_silent_install: None, winget_use_sudo: None }), npm: Some(NPM { use_sudo: None }), chezmoi: Some(Chezmoi { exclude_encrypted: None }), mise: Some(Mise { bump: None, interactive: None, jobs: None, verbose: None, quiet: None, silent: None }), yarn: Some(Yarn { use_sudo: None }), deno: Some(Deno { version: None }), vim: Some(Vim { force_plug_update: None, vim_pack_prune: None }), firmware: Some(Firmware { upgrade: None }), vagrant: Some(Vagrant { directories: None, power_on: None, always_suspend: None }), flatpak: Some(Flatpak { use_sudo: None }), pixi: Some(Pixi { include_release_notes: None }), distrobox: Some(Distrobox { use_root: None, containers: None }), lensfun: Some(Lensfun { use_sudo: None }), julia: Some(JuliaConfig { startup_file: None }), zigup: Some(Zigup { target_versions: None, install_dir: None, path_link: None, cleanup: None }), vscode: Some(VscodeConfig { profile: None }), doom: Some(DoomConfig { aot: None }), cargo: None, rustup: Some(Rustup { channels: None }), pkgfile: Some(Pkgfile { enable: None }), viteplus: None }, allowed_steps: [AM, AndroidStudio, Antigravity, AppMan, Aqua, Asdf, Atom, Atuin, Audit, AutoCpufreq, Bin, Bob, BrewCask, BrewFormula, Bun, BunPackages, Cargo, Certbot, Chezmoi, Chocolatey, Choosenim, CinnamonSpices, ClamAvDb, ClaudeCode, Colima, Composer, Conda, ConfigUpdate, Containers, Cursor, CustomCommands, DebGet, Deno, Distrobox, DkpPacman, Dotnet, Elan, Emacs, Falconf, Firmware, Flatpak, Flutter, Fossil, Gcloud, Gearlever, Gem, Getnf, Ghcup, GitRepos, GithubCliExtensions, GnomeShellExtensions, Go, Guix, Haxelib, Helix, HelixDb, Helm, HomeManager, Hyprpm, InstallRelease, JetbrainsAqua, JetbrainsClion, JetbrainsDatagrip, JetbrainsDataspell, JetbrainsGateway, JetbrainsGoland, JetbrainsIdea, JetbrainsMps, JetbrainsPhpstorm, JetbrainsPycharm, JetbrainsRider, JetbrainsRubymine, JetbrainsRustrover, JetbrainsToolbox, JetbrainsWebstorm, Jetpack, Julia, Juliaup, Kakoune, Krew, Lensfun, Lure, Macports, Mamba, Mandb, Mas, Maza, Micro, MicrosoftOffice, MicrosoftStore, Miktex, Mise, Myrepos, Nix, Node, Ollama, Opam, Pacdef, Pacstall, Pearl, Pi, Pip3, PipReview, PipReviewLocal, Pipupgrade, Pipx, Pipxu, Pixi, Pkg, Pkgfile, Pkgin, PlatformioCore, Pnpm, Poetry, Powershell, Protonplus, Protonup, Pyenv, Raco, Rcm, Remotes, Restarts, Rtcl, RubyGems, Rustup, Rye, Scoop, Sdkman, SelfUpdate, Sheldon, Shell, Skills, Snap, Sparkle, Spicetify, Stack, Stew, System, Tldr, Tlmgr, Tmux, Toolbx, Tpack, Typst, Uv, Vagrant, Vcpkg, Vim, VitePlus, VoltaPackages, Vscode, VscodeInsiders, Vscodium, VscodiumInsiders, Waydroid, Windsurf, Winget, Wsl, WslUpdate, Xcodes, Yadm, Yarn, Yazi, Zigup, Zvm] }
DEBUG Running with euid: 10302
DEBUG Cannot find "doas"
DEBUG Detected "/data/data/com.termux/files/usr/bin/sudo" as "sudo"
DEBUG Sudo: Ok(Sudo { path: Some("/data/data/com.termux/files/usr/bin/sudo"), kind: Sudo })
DEBUG Step "Termux Packages"
DEBUG Detected "/data/data/com.termux/files/usr/bin/nala" as "nala"

── 07:34:51 - Termux Packages ────────────────────────────────
DEBUG Executing command `/data/data/com.termux/files/usr/bin/nala upgrade`
No Change: https://mirrors.ravidwivedi.in/termux/termux-main
stable InRelease
No Change: https://mirrors.ravidwivedi.in/termux/termux-root
root InRelease
No Change: https://mirrors.ravidwivedi.in/termux/termux-x11
x11 InRelease
Fetched 0 Bytes in 2s (0 bytes/s)
All packages are up to date.
DEBUG Step "yadm"
DEBUG Step "nix"
DEBUG Step "nix upgrade-nix"
DEBUG Step "guix"
DEBUG Step "home-manager"
DEBUG Step "asdf"
DEBUG Step "mise"
DEBUG Step "pkgin"
DEBUG Step "bun-packages"
DEBUG Step "zr"
DEBUG Detected "/data/data/com.termux/files/usr/bin/zsh" as "zsh"
DEBUG Step "antibody"
DEBUG Detected "/data/data/com.termux/files/usr/bin/zsh" as "zsh"
DEBUG Step "antidote"
DEBUG Detected "/data/data/com.termux/files/usr/bin/zsh" as "zsh"
DEBUG Step "antigen"
DEBUG Detected "/data/data/com.termux/files/usr/bin/zsh" as "zsh"
DEBUG Path "/data/data/com.termux/files/home/.zshrc" exists
DEBUG Step "zgenom"
DEBUG Detected "/data/data/com.termux/files/usr/bin/zsh" as "zsh"
DEBUG Path "/data/data/com.termux/files/home/.zshrc" exists
DEBUG Step "zplug"
DEBUG Detected "/data/data/com.termux/files/usr/bin/zsh" as "zsh"
DEBUG Path "/data/data/com.termux/files/home/.zshrc" exists
DEBUG Step "zinit"
DEBUG Detected "/data/data/com.termux/files/usr/bin/zsh" as "zsh"
DEBUG Path "/data/data/com.termux/files/home/.zshrc" exists
DEBUG Step "zi"
DEBUG Detected "/data/data/com.termux/files/usr/bin/zsh" as "zsh"
DEBUG Path "/data/data/com.termux/files/home/.zshrc" exists
DEBUG Step "zim"
DEBUG Detected "/data/data/com.termux/files/usr/bin/zsh" as "zsh"
DEBUG Executing command `zsh -c '[[ -n ${ZIM_HOME} ]] && print -n ${ZIM_HOME}'`
DEBUG Command failed: Err(
   0: \x1b[91mCommand failed: `zsh -c '[[ -n ${ZIM_HOME} ]] && print -n ${ZIM_HOME}'`\x1b[0m
   1: \x1b[91m`zsh` failed: exit status: 1 with \x1b[0m

Location:
   \x1b[35msrc/steps/zsh.rs\x1b[0m:\x1b[35m131\x1b[0m)
DEBUG Step "oh-my-zsh"
DEBUG Detected "/data/data/com.termux/files/usr/bin/zsh" as "zsh"
DEBUG Path "/data/data/com.termux/files/home/.oh-my-zsh" exists

── 07:34:55 - oh-my-zsh ──────────────────────────────────────
DEBUG Executing command `zsh -c 'test $ZSH_CUSTOM && echo -n $ZSH_CUSTOM'`
DEBUG Command failed: Err(
   0: \x1b[91mCommand failed: `zsh -c 'test $ZSH_CUSTOM && echo -n $ZSH_CUSTOM'`\x1b[0m
   1: \x1b[91m`zsh` failed: exit status: 1 with \x1b[0m

Location:
   \x1b[35msrc/steps/zsh.rs\x1b[0m:\x1b[35m185\x1b[0m)
DEBUG Running zsh returned Command failed: `zsh -c 'test $ZSH_CUSTOM && echo -n $ZSH_CUSTOM'`. Using default path: /data/data/com.termux/files/home/.oh-my-zsh/custom
DEBUG oh-my-zsh custom dir: /data/data/com.termux/files/home/.oh-my-zsh/custom
DEBUG Detected "/data/data/com.termux/files/usr/bin/git" as "git"
DEBUG Checking if /data/data/com.termux/files/home/.oh-my-zsh/custom is a git repository
DEBUG Executing command `/data/data/com.termux/files/usr/bin/git rev-parse --show-toplevel`
DEBUG /data/data/com.termux/files/home/.oh-my-zsh/custom/example.zsh is a file. Checking /data/data/com.termux/files/home/.oh-my-zsh/custom
DEBUG Checking if /data/data/com.termux/files/home/.oh-my-zsh/custom is a git repository
DEBUG Executing command `/data/data/com.termux/files/usr/bin/git rev-parse --show-toplevel`
DEBUG Checking if /data/data/com.termux/files/home/.oh-my-zsh/custom/plugins is a git repository
DEBUG Executing command `/data/data/com.termux/files/usr/bin/git rev-parse --show-toplevel`
DEBUG Checking if /data/data/com.termux/files/home/.oh-my-zsh/custom/plugins/example is a git repository
DEBUG Executing command `/data/data/com.termux/files/usr/bin/git rev-parse --show-toplevel`
DEBUG Checking if /data/data/com.termux/files/home/.oh-my-zsh/custom/plugins/zsh-autosuggestions is a git repository
DEBUG Executing command `/data/data/com.termux/files/usr/bin/git rev-parse --show-toplevel`
DEBUG Checking if /data/data/com.termux/files/home/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting is a git repository
DEBUG Executing command `/data/data/com.termux/files/usr/bin/git rev-parse --show-toplevel`
DEBUG Checking if /data/data/com.termux/files/home/.oh-my-zsh/custom/plugins/zsh-you-should-use is a git repository
DEBUG Executing command `/data/data/com.termux/files/usr/bin/git rev-parse --show-toplevel`
DEBUG Checking if /data/data/com.termux/files/home/.oh-my-zsh/custom/plugins/zsh-bat is a git repository
DEBUG Executing command `/data/data/com.termux/files/usr/bin/git rev-parse --show-toplevel`
DEBUG Checking if /data/data/com.termux/files/home/.oh-my-zsh/custom/plugins/autoupdate is a git repository
DEBUG Executing command `/data/data/com.termux/files/usr/bin/git rev-parse --show-toplevel`
DEBUG Checking if /data/data/com.termux/files/home/.oh-my-zsh/custom/plugins/zsh-lsd is a git repository
DEBUG Executing command `/data/data/com.termux/files/usr/bin/git rev-parse --show-toplevel`
DEBUG Checking if /data/data/com.termux/files/home/.oh-my-zsh/custom/themes is a git repository
DEBUG Executing command `/data/data/com.termux/files/usr/bin/git rev-parse --show-toplevel`
DEBUG /data/data/com.termux/files/home/.oh-my-zsh/custom/themes/example.zsh-theme is a file. Checking /data/data/com.termux/files/home/.oh-my-zsh/custom/themes
DEBUG Checking if /data/data/com.termux/files/home/.oh-my-zsh/custom/themes is a git repository
DEBUG Executing command `/data/data/com.termux/files/usr/bin/git rev-parse --show-toplevel`
DEBUG Checking if /data/data/com.termux/files/home/.oh-my-zsh/custom/themes/powerlevel10k is a git repository
DEBUG Executing command `/data/data/com.termux/files/usr/bin/git rev-parse --show-toplevel`
DEBUG Executing command `zsh /data/data/com.termux/files/home/.oh-my-zsh/tools/upgrade.sh`
Updating Oh My Zsh
         __                                     __
  ____  / /_     ____ ___  __  __   ____  _____/ /_
 / __ \/ __ \   / __ `__ \/ / / /  /_  / / ___/ __ \
/ /_/ / / / /  / / / / / / /_/ /    / /_(__  ) / / /
\____/_/ /_/  /_/ /_/ /_/\__, /    /___/____/_/ /_/
                        /____/

Oh My Zsh is already at the latest version.

To keep up with the latest news and updates, follow us on X: https://x.com/ohmyzsh
Want to get involved in the community? Join our Discord: https://discord.gg/ohmyzsh
Get your Oh My Zsh swag at: https://commitgoods.com/collections/oh-my-zsh
DEBUG Step "oh-my-bash"
DEBUG Detected "/data/data/com.termux/files/usr/bin/bash" as "bash"
DEBUG Step "fisher"
DEBUG Step "bash-it"
DEBUG Step "oh-my-fish"
DEBUG Step "fish-plug"
DEBUG Step "fundle"
DEBUG Step "tmux"
DEBUG Step "tpack"
DEBUG Step "pearl"
DEBUG Step "pyenv"
DEBUG Step "SDKMAN!"
DEBUG Detected "/data/data/com.termux/files/usr/bin/bash" as "bash"
DEBUG Step "rcm"
DEBUG Step "maza"
DEBUG Step "hyprpm"
DEBUG Step "atuin"
DEBUG Step "apm"
DEBUG Step "fossil"
DEBUG Step "elan"
DEBUG Step "rye"
DEBUG Step "rustup"
DEBUG Step "juliaup"
DEBUG Step ".NET"
DEBUG Step "choosenim"
DEBUG Step "cargo"
DEBUG Path "/data/data/com.termux/files/home/.cargo" exists
DEBUG Detected "/data/data/com.termux/files/usr/bin/cargo" as "cargo"
DEBUG Step "Antigravity extensions"
DEBUG Step "Cursor extensions"
DEBUG Step "Flutter"
DEBUG Step "go-global-update"
DEBUG Step "gup"
DEBUG Step "Emacs"
DEBUG Path "/data/data/com.termux/files/home/.config/emacs" doesn't exist
DEBUG Path "/data/data/com.termux/files/home/.emacs.d" doesn't exist
DEBUG Step "opam"
DEBUG Step "vcpkg"
DEBUG Step "pi"
DEBUG Step "pipx"
DEBUG Step "pipxu"
DEBUG Step "Visual Studio Code extensions"
DEBUG Step "Visual Studio Code Insiders extensions"
DEBUG Step "VSCodium extensions"
DEBUG Step "VSCodium Insiders extensions"
DEBUG Step "Windsurf extensions"
DEBUG Step "conda"
DEBUG Step "mamba"
DEBUG Step "pixi"
DEBUG Step "miktex"
DEBUG Step "pip3"
DEBUG Detected "/data/data/com.termux/files/usr/bin/python" as "python"
DEBUG Executing command `/data/data/com.termux/files/usr/bin/python -V`
DEBUG Detected "/data/data/com.termux/files/usr/bin/python3" as "python3"
DEBUG Executing command `/data/data/com.termux/files/usr/bin/python3 -V`
DEBUG Executing command `/data/data/com.termux/files/usr/bin/python -m pip`
DEBUG Step "pip-review"
DEBUG Step "pip-review (local)"
DEBUG Step "pipupgrade"
DEBUG Step "getnf"
DEBUG Step "ghcup"
DEBUG Step "stack"
DEBUG Step "TLDR"
DEBUG Step "tlmgr"
DEBUG Step "myrepos"
DEBUG Step "chezmoi"
DEBUG Step "jetpack"
DEBUG Step "vim"
DEBUG Detected "/data/data/com.termux/files/usr/bin/vim" as "vim"
DEBUG Executing command `/data/data/com.termux/files/usr/bin/vim --version`
DEBUG Path "/data/data/com.termux/files/home/.vimrc" exists

── 07:34:57 - Vim ────────────────────────────────────────────
DEBUG Wrote vim script to "/data/data/com.termux/files/usr/tmp/.tmp66AGce"
not found in 'runtimepath': "ftdetect/*.vim"
not found in 'packpath': "pack/*/start/*"
not found in 'packpath': "pack/*/start/netrw"
not found in 'packpath': "pack/*/start/*"
not found in 'runtimepath': "plugin/**/*.vim"
Reading viminfo file "/data/data/com.termux/files/home/.viminfo" info oldfiles
Writing viminfo file "/data/data/com.termux/files/home/.viminfo"Plugins upgraded
DEBUG Step "Neovim"
DEBUG Step "The Ultimate vimrc"
DEBUG Step "voom"
DEBUG Step "Kakoune"
DEBUG Step "helix"
DEBUG Step "HelixDB"
DEBUG Step "npm"
DEBUG Detected "/data/data/com.termux/files/usr/bin/npm" as "npm"

── 07:34:57 - Node Package Manager ───────────────────────────
DEBUG Executing command `/data/data/com.termux/files/usr/bin/npm --version`
DEBUG Executing command `/data/data/com.termux/files/usr/bin/npm update '--location=global'`

changed 10 packages in 3s

15 packages are looking for funding
  run `npm fund` for details
DEBUG Step "yarn"
DEBUG Step "pnpm"
DEBUG Step "volta packages"
DEBUG Step "viteplus"
DEBUG Step "Containers"
DEBUG Step "deno"
DEBUG Detected "/data/data/com.termux/files/usr/bin/deno" as "deno"
DEBUG Step "composer"
DEBUG Step "krew"
DEBUG Step "helm"
DEBUG Step "gem"
DEBUG Step "rubygems"
DEBUG Step "julia"
DEBUG Step "haxelib"
DEBUG Step "sheldon"
DEBUG Step "stew"
DEBUG Step "rtcl"
DEBUG Step "bin"
DEBUG Step "gcloud"
DEBUG Step "micro"
DEBUG Step "raco"
DEBUG Step "spicetify"
DEBUG Step "GitHub CLI Extensions"
DEBUG Step "Bob"
DEBUG Step "Certbot"
DEBUG Step "Git Repositories"
DEBUG Detected "/data/data/com.termux/files/usr/bin/git" as "git"
DEBUG Path "/data/data/com.termux/files/home/.config/emacs" doesn't exist
DEBUG Path "/data/data/com.termux/files/home/.emacs.d" doesn't exist
DEBUG /data/data/com.termux/files/home/.doom.d does not exist
DEBUG Checking if /data/data/com.termux/files/home/.vim is a git repository
DEBUG Executing command `/data/data/com.termux/files/usr/bin/git rev-parse --show-toplevel`
DEBUG Command failed: Err(
   0: \x1b[91mCommand failed: `/data/data/com.termux/files/usr/bin/git rev-parse --show-toplevel`

      Stderr:
      fatal: not a git repository (or any parent up to mount point /)
      Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).\x1b[0m
   1: \x1b[91m`/data/data/com.termux/files/usr/bin/git` failed: exit status: 128 with fatal: not a git repository (or any parent up to mount point /)
      Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
      \x1b[0m

Location:
   \x1b[35msrc/steps/git.rs\x1b[0m:\x1b[35m208\x1b[0m)
DEBUG /data/data/com.termux/files/home/.config/nvim does not exist
DEBUG /data/data/com.termux/files/home/.ideavimrc does not exist
DEBUG /data/data/com.termux/files/home/.intellimacs does not exist
DEBUG /data/data/com.termux/files/home/.dotfiles does not exist
DEBUG Cannot find "pwsh"
DEBUG Cannot find "powershell"
DEBUG /data/data/com.termux/files/home/.zshrc is a file. Checking /data/data/com.termux/files/home
DEBUG Checking if /data/data/com.termux/files/home is a git repository
DEBUG Executing command `/data/data/com.termux/files/usr/bin/git rev-parse --show-toplevel`
DEBUG Command failed: Err(
   0: \x1b[91mCommand failed: `/data/data/com.termux/files/usr/bin/git rev-parse --show-toplevel`

      Stderr:
      fatal: not a git repository (or any parent up to mount point /)
      Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).\x1b[0m
   1: \x1b[91m`/data/data/com.termux/files/usr/bin/git` failed: exit status: 128 with fatal: not a git repository (or any parent up to mount point /)
      Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
      \x1b[0m

Location:
   \x1b[35msrc/steps/git.rs\x1b[0m:\x1b[35m208\x1b[0m)
DEBUG /data/data/com.termux/files/home/.tmux does not exist
DEBUG /data/data/com.termux/files/home/.config/fish does not exist
DEBUG /data/data/com.termux/files/home/.config/openbox does not exist
DEBUG /data/data/com.termux/files/home/.config/bspwm does not exist
DEBUG /data/data/com.termux/files/home/.config/i3 does not exist
DEBUG /data/data/com.termux/files/home/.config/sway does not exist
DEBUG Step "ClamAV Databases"
DEBUG Step "Claude Code"
DEBUG Step "Colima"
DEBUG Step "Skills"
DEBUG Detected "/data/data/com.termux/files/usr/bin/npx" as "npx"
DEBUG Step "PlatformIO Core"
DEBUG Step "Lensfun's database update"
DEBUG Step "Poetry"
DEBUG Step "uv"
DEBUG Detected "/data/data/com.termux/files/usr/bin/uv" as "uv"

── 07:35:01 - uv ─────────────────────────────────────────────
DEBUG Executing command `/data/data/com.termux/files/usr/bin/uv --version`
DEBUG Executing command `/data/data/com.termux/files/usr/bin/uv tool upgrade --all`
Nothing to upgrade
DEBUG Executing command `/data/data/com.termux/files/usr/bin/uv python upgrade`
There are no installed versions to upgrade
DEBUG Step "ZVM"
DEBUG Step "aqua"
DEBUG Step "bun"
DEBUG Step "Ollama"
DEBUG Step "zigup"
DEBUG Step "JetBrains Toolbox"
DEBUG Step "Android Studio Plugins"
DEBUG Step "JetBrains Aqua Plugins"
DEBUG Step "JetBrains CL"
DEBUG Step "JetBrains DataGrip"
DEBUG Step "JetBrains DataSpell Plugins"
DEBUG Step "JetBrains Gateway Plugins"
DEBUG Step "JetBrains GoLand Plugins"
DEBUG Step "JetBrains IntelliJ IDEA Plugins"
DEBUG Step "JetBrains MPS Plugins"
DEBUG Step "JetBrains PhpStorm Plugins"
DEBUG Step "JetBrains PyCharm Plugins"
DEBUG Step "JetBrains Rider Plugins"
DEBUG Step "JetBrains RubyMine Plugins"
DEBUG Step "JetBrains RustRover Plugins"
DEBUG Step "JetBrains WebStorm Plugins"
DEBUG Step "Yazi packages"
DEBUG Step "falconf sync"
DEBUG Step "Powershell Modules Update"
DEBUG Step "Vagrant boxes"
DEBUG Step "Typst"
DEBUG Step "Install Release"

── 07:35:01 - Summary ────────────────────────────────────────
Termux Packages: OK
yadm: SKIPPED: Cannot find "yadm" in PATH
nix: SKIPPED: Cannot find "nix" in PATH
nix upgrade-nix: SKIPPED: Cannot find "nix" in PATH
guix: SKIPPED: Cannot find "guix" in PATH
home-manager: SKIPPED: Cannot find any of "home-manager", "nh" in PATH
asdf: SKIPPED: Cannot find "asdf" in PATH
mise: SKIPPED: Cannot find "mise" in PATH
pkgin: SKIPPED: Cannot find "pkgin" in PATH
bun-packages: SKIPPED: Cannot find "bun" in PATH
zr: SKIPPED: Cannot find "zr" in PATH
antibody: SKIPPED: Cannot find "antibody" in PATH
antidote: SKIPPED: Path "/data/data/com.termux/files/home/.antidote" doesn't exist
antigen: SKIPPED: Path "/data/data/com.termux/files/home/antigen.zsh" doesn't exist
zgenom: SKIPPED: Path "/data/data/com.termux/files/home/.zgenom" doesn't exist
zplug: SKIPPED: Path "/data/data/com.termux/files/home/.zplug" doesn't exist
zinit: SKIPPED: Path "/data/data/com.termux/files/home/.local/share/zinit" doesn't exist
zi: SKIPPED: Path "/data/data/com.termux/files/home/.zi" doesn't exist
zim: SKIPPED: Path "/data/data/com.termux/files/home/.zim" doesn't exist
oh-my-zsh: OK
oh-my-bash: SKIPPED: Path "/data/data/com.termux/files/home/.oh-my-bash" doesn't exist
fisher: SKIPPED: Cannot find "fish" in PATH
bash-it: SKIPPED: Path "/data/data/com.termux/files/home/.bash_it" doesn't exist
oh-my-fish: SKIPPED: Cannot find "fish" in PATH
fish-plug: SKIPPED: Cannot find "fish" in PATH
fundle: SKIPPED: Cannot find "fish" in PATH
tmux: SKIPPED: Path "/data/data/com.termux/files/home/.tmux/plugins/tpm/bin/update_plugins" doesn't exist
tpack: SKIPPED: Cannot find "tpack" in PATH
pearl: SKIPPED: Cannot find "pearl" in PATH
pyenv: SKIPPED: Cannot find "pyenv" in PATH
SDKMAN!: SKIPPED: Path "/data/data/com.termux/files/home/.sdkman/bin/sdkman-init.sh" doesn't exist
rcm: SKIPPED: Cannot find "rcup" in PATH
maza: SKIPPED: Cannot find "maza" in PATH
hyprpm: SKIPPED: Cannot find "hyprpm" in PATH
atuin: SKIPPED: Cannot find "atuin-update" in PATH
apm: SKIPPED: Cannot find "apm" in PATH
fossil: SKIPPED: Cannot find "fossil" in PATH
elan: SKIPPED: Cannot find "elan" in PATH
rye: SKIPPED: Cannot find "rye" in PATH
rustup: SKIPPED: Cannot find "rustup" in PATH
juliaup: SKIPPED: Cannot find "juliaup" in PATH
.NET: SKIPPED: Cannot find "dotnet" in PATH
choosenim: SKIPPED: Cannot find "choosenim" in PATH
cargo: SKIPPED: Path "/data/data/com.termux/files/home/.cargo/.crates.toml" doesn't exist
Antigravity extensions: SKIPPED: Cannot find "antigravity" in PATH
Cursor extensions: SKIPPED: Cannot find "cursor" in PATH
Flutter: SKIPPED: Cannot find "flutter" in PATH
go-global-update: SKIPPED: Cannot find "go" in PATH
gup: SKIPPED: Cannot find "go" in PATH
Emacs: SKIPPED: Cannot find "emacs" in PATH
opam: SKIPPED: Cannot find "opam" in PATH
vcpkg: SKIPPED: Cannot find "vcpkg" in PATH
pi: SKIPPED: Cannot find "pi" in PATH
pipx: SKIPPED: Cannot find "pipx" in PATH
pipxu: SKIPPED: Cannot find "pipxu" in PATH
Visual Studio Code extensions: SKIPPED: Cannot find "code" in PATH
Visual Studio Code Insiders extensions: SKIPPED: Cannot find "code-insiders" in PATH
VSCodium extensions: SKIPPED: Cannot find "codium" in PATH
VSCodium Insiders extensions: SKIPPED: Cannot find "codium-insiders" in PATH
Windsurf extensions: SKIPPED: Cannot find "windsurf" in PATH
conda: SKIPPED: Cannot find "conda" in PATH
mamba: SKIPPED: Cannot find "mamba" in PATH
pixi: SKIPPED: Cannot find "pixi" in PATH
miktex: SKIPPED: Cannot find "miktex" in PATH
pip3: SKIPPED: Skip pip3 update because upgrading pip via pip is forbidden on termux
pip-review: SKIPPED: Cannot find "pip-review" in PATH
pip-review (local): SKIPPED: Cannot find "pip-review" in PATH
pipupgrade: SKIPPED: Cannot find "pipupgrade" in PATH
getnf: SKIPPED: Cannot find "getnf" in PATH
ghcup: SKIPPED: Cannot find "ghcup" in PATH
stack: SKIPPED: Cannot find "stack" in PATH
TLDR: SKIPPED: Cannot find "tldr" in PATH
tlmgr: SKIPPED: tlmgr must be explicitly enabled in the configuration to run in Android/Linux
myrepos: SKIPPED: Cannot find "mr" in PATH
chezmoi: SKIPPED: Cannot find "chezmoi" in PATH
jetpack: SKIPPED: Cannot find "jetpack" in PATH
vim: OK
Neovim: SKIPPED: Cannot find "nvim" in PATH
The Ultimate vimrc: SKIPPED: Path "/data/data/com.termux/files/home/.vim_runtime" doesn't exist
voom: SKIPPED: Cannot find "voom" in PATH
Kakoune: SKIPPED: Cannot find "kak" in PATH
helix: SKIPPED: Neither `hx` nor `helix` command points to Helix Editor
HelixDB: SKIPPED: Cannot find "helix" in PATH
npm: OK
yarn: SKIPPED: Cannot find "yarn" in PATH
pnpm: SKIPPED: Cannot find "pnpm" in PATH
volta packages: SKIPPED: Cannot find "volta" in PATH
viteplus: SKIPPED: Cannot find "vp" in PATH
Containers: SKIPPED: Cannot find "docker" in PATH
deno: SKIPPED: Deno installed outside of .deno directory
composer: SKIPPED: Cannot find "composer" in PATH
krew: SKIPPED: Cannot find "kubectl-krew" in PATH
helm: SKIPPED: Cannot find "helm" in PATH
gem: SKIPPED: Cannot find "gem" in PATH
rubygems: SKIPPED: Path "/data/data/com.termux/files/home/.gem" doesn't exist
julia: SKIPPED: Cannot find "julia" in PATH
haxelib: SKIPPED: Cannot find "haxelib" in PATH
sheldon: SKIPPED: Cannot find "sheldon" in PATH
stew: SKIPPED: Cannot find "stew" in PATH
rtcl: SKIPPED: Cannot find "rupdate" in PATH
bin: SKIPPED: Cannot find "bin" in PATH
gcloud: SKIPPED: Cannot find "gcloud" in PATH
micro: SKIPPED: Cannot find "micro" in PATH
raco: SKIPPED: Cannot find "raco" in PATH
spicetify: SKIPPED: Cannot find "spicetify-cli" in PATH
GitHub CLI Extensions: SKIPPED: Cannot find "gh" in PATH
Bob: SKIPPED: Cannot find "bob" in PATH
Certbot: SKIPPED: Cannot find "certbot" in PATH
Git Repositories: SKIPPED: No repositories to pull
ClamAV Databases: SKIPPED: Cannot find "freshclam" in PATH
Claude Code: SKIPPED: Cannot find "claude" in PATH
Colima: SKIPPED: Cannot find "colima" in PATH
Skills: SKIPPED: No ~/.agents/.skill-lock.json found
PlatformIO Core: SKIPPED: Cannot find "/data/data/com.termux/files/home/.platformio/penv/bin/pio" in PATH
Lensfun's database update: SKIPPED: Cannot find "lensfun-update-data" in PATH
Poetry: SKIPPED: Cannot find "poetry" in PATH
uv: OK
ZVM: SKIPPED: Cannot find "zvm" in PATH
aqua: SKIPPED: Cannot find "aqua" in PATH
bun: SKIPPED: Cannot find "bun" in PATH
Ollama: SKIPPED: Cannot find "ollama" in PATH
zigup: SKIPPED: Cannot find "zigup" in PATH
JetBrains Toolbox: SKIPPED: Unsupported operating system android
Android Studio Plugins: SKIPPED: Cannot find any of "studio", "android-studio", "android-studio-beta", "android-studio-canary" in PATH
JetBrains Aqua Plugins: SKIPPED: Cannot find "aqua" in PATH
JetBrains CL: SKIPPED: Cannot find any of "clion", "clion-eap" in PATH
JetBrains DataGrip: SKIPPED: Cannot find any of "datagrip", "datagrip-eap" in PATH
JetBrains DataSpell Plugins: SKIPPED: Cannot find any of "dataspell", "dataspell-eap" in PATH
JetBrains Gateway Plugins: SKIPPED: Cannot find any of "gateway", "jetbrains-gateway", "jetbrains-gateway-eap" in PATH
JetBrains GoLand Plugins: SKIPPED: Cannot find any of "goland", "goland-eap" in PATH
JetBrains IntelliJ IDEA Plugins: SKIPPED: Cannot find any of "idea", "intellij-idea-ultimate-edition", "intellij-idea-ultimate", "intellij-idea-community-edition", "intellij-idea-community" in PATH
JetBrains MPS Plugins: SKIPPED: Cannot find any of "mps", "jetbrains-mps" in PATH
JetBrains PhpStorm Plugins: SKIPPED: Cannot find "phpstorm" in PATH
JetBrains PyCharm Plugins: SKIPPED: Cannot find any of "pycharm", "pycharm-professional", "pycharm-eap" in PATH
JetBrains Rider Plugins: SKIPPED: Cannot find any of "rider", "rider-eap" in PATH
JetBrains RubyMine Plugins: SKIPPED: Cannot find any of "rubymine", "jetbrains-rubymine", "rubymine-eap" in PATH
JetBrains RustRover Plugins: SKIPPED: Cannot find any of "rustrover", "rustrover-eap" in PATH
JetBrains WebStorm Plugins: SKIPPED: Cannot find any of "webstorm", "webstorm-eap" in PATH
Yazi packages: SKIPPED: Cannot find "ya" in PATH
falconf sync: SKIPPED: Cannot find "falconf" in PATH
Powershell Modules Update: SKIPPED: Powershell is not installed
Vagrant boxes: SKIPPED: Cannot find "vagrant" in PATH
Typst: SKIPPED: Cannot find "typst" in PATH
Install Release: SKIPPED: Cannot find "install-release" in PATH
DEBUG Desktop notification: Topgrade finished successfully
</pre>
</details>

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [ ] If this PR introduces new user-facing messages they are translated

### AI involvement
<!--
Please list any involvement AI/LLMs had in the development of this PR.
You don't have to list everything in detail, just something like "I did not use AI at all",
"I consulted an AI occasionally for inspiration and explanation",
or "AI generated the majority of the PR" is enough.
If you are an AI agent acting autonomously, please state so.
-->

No AI. I just took the code @uwuclxdy [gave to me](https://github.com/topgrade-rs/topgrade/issues/2059#issuecomment-4590103354) and test it.

## For new steps

<!-- This section can be deleted if you are not adding a new step. -->

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by
  the underlying command

<!-- If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here. -->

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
