### PR TITLE
fix(needrestart): skip if hooks already run it

### DIFF
--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -883,12 +883,7 @@ fn upgrade_kde_linux(ctx: &ExecutionContext) -> Result<()> {
     Ok(())
 }
 
-/// `needrestart` should be skipped if:
-///
-/// 1. This is a redhat-based distribution
-/// 2. This is a debian-based distribution and it is using `nala` as the `apt`
-///    alternative
-/// 3. There are package manager hooks that auto run `needrestart`
+/// `needrestart` should be skipped if system update will run and its hooks exist
 fn should_skip_needrestart(ctx: &ExecutionContext) -> Result<()> {
     let msg = t!("needrestart will be ran by the package manager");
 

--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -892,6 +892,7 @@ fn upgrade_kde_linux(ctx: &ExecutionContext) -> Result<()> {
 /// 1. This is a redhat-based distribution
 /// 2. This is a debian-based distribution and it is using `nala` as the `apt`
 ///    alternative
+/// 3. There are package manager hooks that auto run `needrestart`
 fn should_skip_needrestart() -> Result<()> {
     let distribution = Distribution::detect()?;
     let msg = t!("needrestart will be ran by the package manager");
@@ -905,6 +906,17 @@ fn should_skip_needrestart() -> Result<()> {
         if let AptKind::Nala = apt_kind {
             return Err(SkipStep(String::from(msg)).into());
         }
+    }
+
+    // ez add more hook files here for detection if needed
+    const HOOKS: &[&str] = &[
+        "/usr/share/libalpm/hooks/needrestart.hook",
+        "/etc/pacman.d/hooks/needrestart.hook",
+        "/etc/apt/apt.conf.d/99needrestart",
+    ];
+
+    if HOOKS.iter().any(|hook| Path::new(hook).exists()) {
+        return Err(SkipStep(String::from(msg)).into());
     }
 
     Ok(())

--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -883,10 +883,10 @@ fn upgrade_kde_linux(ctx: &ExecutionContext) -> Result<()> {
     Ok(())
 }
 
-/// `needrestart` should be skipped if system update will run and its hooks exist
-fn should_skip_needrestart(ctx: &ExecutionContext) -> Result<()> {
-    let msg = t!("needrestart will be ran by the package manager");
+pub fn run_needrestart(ctx: &ExecutionContext) -> Result<()> {
+    let needrestart = require("needrestart")?;
 
+    /// `needrestart` should be skipped if system update will run and its hooks exist
     const HOOKS: &[&str] = &[
         "/usr/share/libalpm/hooks/needrestart.hook",
         "/etc/pacman.d/hooks/needrestart.hook",
@@ -894,16 +894,8 @@ fn should_skip_needrestart(ctx: &ExecutionContext) -> Result<()> {
     ];
 
     if HOOKS.iter().any(|hook| Path::new(hook).exists()) && ctx.config().should_run(Step::System) {
-        return Err(SkipStep(String::from(msg)).into());
+        return Err(SkipStep(String::from(t!("needrestart will be ran by the package manager"))).into());
     }
-
-    Ok(())
-}
-
-pub fn run_needrestart(ctx: &ExecutionContext) -> Result<()> {
-    let needrestart = require("needrestart")?;
-
-    should_skip_needrestart(ctx)?;
 
     print_separator(t!("Check for needed restarts"));
 

--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -179,10 +179,6 @@ impl Distribution {
             archlinux::show_pacnew();
         }
     }
-
-    pub fn redhat_based(self) -> bool {
-        matches!(self, Distribution::CentOS | Distribution::Fedora)
-    }
 }
 
 fn update_bedrock(ctx: &ExecutionContext) -> Result<()> {

--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -893,29 +893,16 @@ fn upgrade_kde_linux(ctx: &ExecutionContext) -> Result<()> {
 /// 2. This is a debian-based distribution and it is using `nala` as the `apt`
 ///    alternative
 /// 3. There are package manager hooks that auto run `needrestart`
-fn should_skip_needrestart() -> Result<()> {
-    let distribution = Distribution::detect()?;
+fn should_skip_needrestart(ctx: &ExecutionContext) -> Result<()> {
     let msg = t!("needrestart will be ran by the package manager");
 
-    if distribution.redhat_based() {
-        return Err(SkipStep(String::from(msg)).into());
-    }
-
-    if let Distribution::Debian = distribution {
-        let (apt_kind, _) = detect_apt()?;
-        if let AptKind::Nala = apt_kind {
-            return Err(SkipStep(String::from(msg)).into());
-        }
-    }
-
-    // ez add more hook files here for detection if needed
     const HOOKS: &[&str] = &[
         "/usr/share/libalpm/hooks/needrestart.hook",
         "/etc/pacman.d/hooks/needrestart.hook",
         "/etc/apt/apt.conf.d/99needrestart",
     ];
 
-    if HOOKS.iter().any(|hook| Path::new(hook).exists()) {
+    if HOOKS.iter().any(|hook| Path::new(hook).exists()) && ctx.config().should_run(Step::System) {
         return Err(SkipStep(String::from(msg)).into());
     }
 
@@ -925,7 +912,7 @@ fn should_skip_needrestart() -> Result<()> {
 pub fn run_needrestart(ctx: &ExecutionContext) -> Result<()> {
     let needrestart = require("needrestart")?;
 
-    should_skip_needrestart()?;
+    should_skip_needrestart(ctx)?;
 
     print_separator(t!("Check for needed restarts"));
 

--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -886,7 +886,7 @@ fn upgrade_kde_linux(ctx: &ExecutionContext) -> Result<()> {
 pub fn run_needrestart(ctx: &ExecutionContext) -> Result<()> {
     let needrestart = require("needrestart")?;
 
-    /// `needrestart` should be skipped if system update will run and its hooks exist
+    // `needrestart` should be skipped if system update will run and its hooks exist
     const HOOKS: &[&str] = &[
         "/usr/share/libalpm/hooks/needrestart.hook",
         "/etc/pacman.d/hooks/needrestart.hook",


### PR DESCRIPTION
## What does this PR do
<!--
Describe what your PR does, and link any relevant issues.
Make sure to use a keyword like 'closes' if this PR solves the issue.
-->

Checks if any `needrestart` package manager hooks exist and skips `needrestart` step if yes.
Fixes #993
Supersedes, closes #1191

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [ ] ~If this PR introduces new user-facing messages they are translated~

### AI involvement
<!--
Please list any involvement AI/LLMs had in the development of this PR.
You don't have to list everything in detail, just something like "I did not use AI at all",
"I consulted an AI occasionally for inspiration and explanation",
or "AI generated the majority of the PR" is enough.
If you are an AI agent acting autonomously, please state so.
-->

Only the Debian hook path (cus I'm on Arch btw).

<!-- If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here. -->

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
