### PR TITLE
fix(nix): don't skip self-upgrade on non-NixOS Linux

### DIFF
--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -631,16 +631,14 @@ pub fn run_nix_self_upgrade(ctx: &ExecutionContext) -> Result<()> {
     let nix = require("nix")?;
 
     // Should we attempt to upgrade Nix with `nix upgrade-nix`?
-    #[allow(unused_mut)]
-    let mut should_self_upgrade = cfg!(target_os = "macos");
-
-    #[cfg(target_os = "linux")]
-    {
-        // We can't use `nix upgrade-nix` on NixOS.
-        if let Ok(Distribution::NixOS) = Distribution::detect() {
-            should_self_upgrade = false;
+    let should_self_upgrade = cfg_select! {
+        target_os = "linux" => match ctx.distribution() {
+            // We can't use `nix upgrade-nix` on NixOS.
+            Ok(Distribution::NixOS) => false,
+            _ => true,
         }
-    }
+        _ => cfg!(target_os = "macos")
+    };
 
     if !should_self_upgrade {
         return Err(SkipStep(t!("`nix upgrade-nix` can only be used on macOS or non-NixOS Linux").to_string()).into());

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -631,14 +631,14 @@ pub fn run_nix_self_upgrade(ctx: &ExecutionContext) -> Result<()> {
     let nix = require("nix")?;
 
     // Should we attempt to upgrade Nix with `nix upgrade-nix`?
-    let should_self_upgrade = cfg_select! {
-        target_os = "linux" => match ctx.distribution() {
-            // We can't use `nix upgrade-nix` on NixOS.
-            Ok(Distribution::NixOS) => false,
-            _ => true,
-        }
-        _ => cfg!(target_os = "macos")
+    #[cfg(target_os = "linux")]
+    let should_self_upgrade = match ctx.distribution() {
+        // We can't use `nix upgrade-nix` on NixOS.
+        Ok(Distribution::NixOS) => false,
+        _ => true,
     };
+    #[cfg(not(target_os = "linux"))]
+    let should_self_upgrade = cfg!(target_os = "macos");
 
     if !should_self_upgrade {
         return Err(SkipStep(t!("`nix upgrade-nix` can only be used on macOS or non-NixOS Linux").to_string()).into());


### PR DESCRIPTION
## What does this PR do

This PR fixes the erroneous calculation of whether Nix should self-upgrade on non-NixOS Linux. The problem was that on non-macOS, the variable was set to false by default, and the Linux-only section only "mutated" it when the used distro was NixOS, setting it to false, which it already was anyway.

I've opted to refactor this slightly to avoid the variable being mutable at all. I originally did it with `cfg_select!`, which I think was cleaner, but it's too new a feature to be available in the minimum version that this project sets, so two `#[cfg(...)]`s it is...
If you'd prefer for me to just add an else to the existing `if let` instead, I can do that too.

Tested on Ubuntu 22.04 (and on a clean 26.04 VM with Determinate Nix on it as well).

Before:
```
$ topgrade --verbose --dry-run --only nix
[...]

── 02:00:59 - Nix ──────────────────────────────────────────────────────────────
Dry running: /nix/var/nix/profiles/system/bin/nix-env --upgrade
DEBUG Step "nix upgrade-nix"
DEBUG Detected "/nix/var/nix/profiles/system/bin/nix" as "nix"

── 02:00:59 - Summary ──────────────────────────────────────────────────────────
nix: OK
nix upgrade-nix: SKIPPED: `nix upgrade-nix` can only be used on macOS or non-NixOS Linux
DEBUG Desktop notification: Topgrade finished successfully
```
After:
```
$ topgrade --verbose --dry-run --only nix
[...]

── 01:44:36 - Nix ──────────────────────────────────────────────────────────────
Dry running: /nix/var/nix/profiles/system/bin/nix-env --upgrade
DEBUG Step "nix upgrade-nix"
DEBUG Detected "/nix/var/nix/profiles/system/bin/nix" as "nix"
DEBUG Found Nix in "/nix/var/nix/profiles/system"
DEBUG Found Nix profile "/nix/store/6066f47sslw0sqn5amy1rlivk2vgkiq4-system-profile-environment"

── 01:44:36 - Summary ──────────────────────────────────────────────────────────
nix: OK
nix upgrade-nix: SKIPPED: `nix upgrade-nix` cannot be run when Nix is installed in a profile
DEBUG Desktop notification: Topgrade finished successfully
```

You'll note that the self-upgrade still would not run with my system's Nix install, but it *did* manage to go past the "can only be used on macOS or non-NixOS Linux" message, so the PR is addressing what it says in the title. Whether it's correct that topgrade can't self-upgrade Nix in such a case is not yet clear to me *but* it's imo out of scope for this PR anyway.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [x] If this PR introduces new user-facing messages they are translated

### AI involvement
I did not use AI at all

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
