### PR TITLE
fix(nix): skip profile check for Determinate Nix upgrade

### DIFF
--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -646,11 +646,11 @@ pub fn run_nix_self_upgrade(ctx: &ExecutionContext) -> Result<()> {
         return Err(SkipStep(t!("`nix upgrade-nix` can only be used on macOS or non-NixOS Linux").to_string()).into());
     }
 
-    print_separator(t!("Nix (self-upgrade)"));
-
     let nix_version = NixVersion::new(ctx, &nix)?;
 
     if nix_version.is_determinate_nix() {
+        print_separator(t!("Nix (self-upgrade)"));
+
         let nixd = require("determinate-nixd");
         let nixd = match nixd {
             Err(_) => {
@@ -672,6 +672,8 @@ pub fn run_nix_self_upgrade(ctx: &ExecutionContext) -> Result<()> {
             SkipStep(t!("`nix upgrade-nix` cannot be run when Nix is installed in a profile").to_string()).into(),
         );
     }
+
+    print_separator(t!("Nix (self-upgrade)"));
 
     let multi_user = fs::metadata(&nix)?.uid() == 0;
     debug!("Multi user nix: {}", multi_user);

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -646,12 +646,6 @@ pub fn run_nix_self_upgrade(ctx: &ExecutionContext) -> Result<()> {
         return Err(SkipStep(t!("`nix upgrade-nix` can only be used on macOS or non-NixOS Linux").to_string()).into());
     }
 
-    if nix_profile_dir(&nix)?.is_none() {
-        return Err(
-            SkipStep(t!("`nix upgrade-nix` cannot be run when Nix is installed in a profile").to_string()).into(),
-        );
-    }
-
     print_separator(t!("Nix (self-upgrade)"));
 
     let nix_version = NixVersion::new(ctx, &nix)?;
@@ -671,6 +665,12 @@ pub fn run_nix_self_upgrade(ctx: &ExecutionContext) -> Result<()> {
             .execute_opts(ctx, nixd, SudoExecuteOpts::new().login_shell())?
             .arg("upgrade")
             .status_checked();
+    }
+
+    if nix_profile_dir(&nix)?.is_none() {
+        return Err(
+            SkipStep(t!("`nix upgrade-nix` cannot be run when Nix is installed in a profile").to_string()).into(),
+        );
     }
 
     let multi_user = fs::metadata(&nix)?.uid() == 0;


### PR DESCRIPTION
## What does this PR do
This PR changes the Nix self-upgrade step to allow upgrading Determinate Nix despite being installed in a profile (which is how it's **normally** installed). The error message that topgrade prints even says it's about not being able to run the `nix upgrade-nix` command, which is not something that's run when using Determinate Nix anyway. The code comments confirm this check is specifically meant for avoiding the `nix upgrade-nix` bug:
https://github.com/topgrade-rs/topgrade/blob/78dc1b2ad27697a8f9c3653ce05664617b5e5941/src/steps/os/unix.rs#L691-L697

Tested on a fresh Ubuntu 26.04 Server VMs that were first set up with the following commands:
```
$ sudo apt update && sudo apt install build-essential
$ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
$ curl -fsSL https://install.determinate.systems/nix/tag/v3.20.0 | sh -s -- install
$ bash
$ cargo install --locked --git https://github.com/Jackenmen/topgrade --branch allow_determinate_nix_upgrade_when_installed_in_profile_merged
$ sudo -i
# nix profile add nixpkgs#micro
```
As you might note, it was tested with a differently named branch - that branch is a merge of this PR on top of #2072 - without that, the step is skipped due to another bug that #2072 fixes earlier in code.

Before:
```console
$ topgrade --verbose --only nix
DEBUG Current system locale is C
DEBUG Configuration directory /home/vm/.config/ does not exist
DEBUG Version: 17.5.1
DEBUG OS: x86_64-unknown-linux-gnu
DEBUG Args { inner: ["topgrade", "--verbose", "--only", "nix"] }
DEBUG Binary path: Ok("/home/vm/.cargo/bin/topgrade")
DEBUG self-update Feature Enabled: false
DEBUG Configuration: Config { opt: CommandLineArgs { edit_config: false, show_config_reference: false, run_in_tmux: false, no_tmux: false, cleanup: false, dry_run: false, run_type: Wet, no_retry: false, no_ask_retry: false, auto_retry: None, disable: [], only: [Nix], custom_commands: [], env: [], verbose: true, keep_at_end: false, skip_notify: false, notify_end: Always, yes: None, disable_predefined_git_repos: false, config: None, remote_host_limit: None, show_skipped: false, allow_root: false, sudo_loop: false, sudo_loop_interval: None, log_filter: "warn", gen_completion: None, gen_manpage: false, no_self_update: false }, config_file: ConfigFile { include: None, misc: None, pre_commands: None, post_commands: None, commands: None, conda: None, python: None, composer: None, brew: None, linux: None, mandb: None, git: None, go: None, containers: None, windows: None, npm: None, chezmoi: None, mise: None, yarn: None, deno: None, vim: None, firmware: None, vagrant: None, flatpak: None, pixi: None, distrobox: None, lensfun: None, julia: None, zigup: None, vscode: None, doom: None, cargo: None, rustup: None, pkgfile: None, viteplus: None }, allowed_steps: [Nix] }
DEBUG Running with euid: 1000
DEBUG Cannot find "doas"
DEBUG Detected "/usr/bin/sudo" as "sudo"
DEBUG Sudo: Ok(Sudo { path: Some("/usr/bin/sudo"), kind: Sudo })
DEBUG Step "nix"
DEBUG Detected "/nix/var/nix/profiles/default/bin/nix" as "nix"
DEBUG nix profile: "/home/vm/.nix-profile"
DEBUG Executing command `/nix/var/nix/profiles/default/bin/nix --version`
DEBUG `nix --version` output output=nix (Determinate Nix 3.20.0) 2.34.6

DEBUG Raw Nix version: 2.34.6
DEBUG Corrected raw Nix version: 2.34.6
DEBUG Nix version: Version { major: 2, minor: 34, patch: 6 }
DEBUG is_lix=false
DEBUG Detected "/nix/var/nix/profiles/default/bin/nix-channel" as "nix-channel"

── 22:32:16 - Nix Channels ─────────────────────────────────────────────────────
DEBUG Executing command `/nix/var/nix/profiles/default/bin/nix-channel --update`
warning: nix-channel is deprecated in favor of flakes in Determinate Nix. See https://zero-to-nix.com for a guide to Nix flakes. For details and to offer feedback on the deprecation process, see: https://github.com/DeterminateSystems/nix-src/issues/34.
unpacking 0 channels...
DEBUG Detected "/nix/var/nix/profiles/default/bin/nix-env" as "nix-env"

── 22:32:16 - Nix ──────────────────────────────────────────────────────────────
DEBUG Executing command `/nix/var/nix/profiles/default/bin/nix-env --upgrade`
DEBUG Step "nix upgrade-nix"
DEBUG Detected "/nix/var/nix/profiles/default/bin/nix" as "nix"
DEBUG Found Nix in "/nix/var/nix/profiles/default"
DEBUG Found Nix profile "/nix/store/ybja3aajapx71356kavyrm296n5mgpl7-profile"

── 22:32:16 - Summary ──────────────────────────────────────────────────────────
nix: OK
nix upgrade-nix: SKIPPED: `nix upgrade-nix` cannot be run when Nix is installed in a profile
DEBUG Desktop notification: Topgrade finished successfully
```

After:
```console
$ topgrade --verbose --only nix
DEBUG Current system locale is C
DEBUG Configuration directory /home/vm/.config/ does not exist
DEBUG Version: 17.5.1
DEBUG OS: x86_64-unknown-linux-gnu
DEBUG Args { inner: ["topgrade", "--verbose", "--only", "nix"] }
DEBUG Binary path: Ok("/home/vm/.cargo/bin/topgrade")
DEBUG self-update Feature Enabled: false
DEBUG Configuration: Config { opt: CommandLineArgs { edit_config: false, show_config_reference: false, run_in_tmux: false, no_tmux: false, cleanup: false, dry_run: false, run_type: Wet, no_retry: false, no_ask_retry: false, auto_retry: None, disable: [], only: [Nix], custom_commands: [], env: [], verbose: true, keep_at_end: false, skip_notify: false, notify_end: Always, yes: None, disable_predefined_git_repos: false, config: None, remote_host_limit: None, show_skipped: false, allow_root: false, sudo_loop: false, sudo_loop_interval: None, log_filter: "warn", gen_completion: None, gen_manpage: false, no_self_update: false }, config_file: ConfigFile { include: None, misc: None, pre_commands: None, post_commands: None, commands: None, conda: None, python: None, composer: None, brew: None, linux: None, mandb: None, git: None, go: None, containers: None, windows: None, npm: None, chezmoi: None, mise: None, yarn: None, deno: None, vim: None, firmware: None, vagrant: None, flatpak: None, pixi: None, distrobox: None, lensfun: None, julia: None, zigup: None, vscode: None, doom: None, cargo: None, rustup: None, pkgfile: None, viteplus: None }, allowed_steps: [Nix] }
DEBUG Running with euid: 1000
DEBUG Cannot find "doas"
DEBUG Detected "/usr/bin/sudo" as "sudo"
DEBUG Sudo: Ok(Sudo { path: Some("/usr/bin/sudo"), kind: Sudo })
DEBUG Step "nix"
DEBUG Detected "/nix/var/nix/profiles/default/bin/nix" as "nix"
DEBUG nix profile: "/home/vm/.nix-profile"
DEBUG Executing command `/nix/var/nix/profiles/default/bin/nix --version`
DEBUG `nix --version` output output=nix (Determinate Nix 3.20.0) 2.34.6

DEBUG Raw Nix version: 2.34.6
DEBUG Corrected raw Nix version: 2.34.6
DEBUG Nix version: Version { major: 2, minor: 34, patch: 6 }
DEBUG is_lix=false
DEBUG Detected "/nix/var/nix/profiles/default/bin/nix-channel" as "nix-channel"

── 22:24:38 - Nix Channels ─────────────────────────────────────────────────────
DEBUG Executing command `/nix/var/nix/profiles/default/bin/nix-channel --update`
warning: nix-channel is deprecated in favor of flakes in Determinate Nix. See https://zero-to-nix.com for a guide to Nix flakes. For details and to offer feedback on the deprecation process, see: https://github.com/DeterminateSystems/nix-src/issues/34.
unpacking 0 channels...
DEBUG Detected "/nix/var/nix/profiles/default/bin/nix-env" as "nix-env"

── 22:24:39 - Nix ──────────────────────────────────────────────────────────────
DEBUG Executing command `/nix/var/nix/profiles/default/bin/nix-env --upgrade`
DEBUG Step "nix upgrade-nix"
DEBUG Detected "/nix/var/nix/profiles/default/bin/nix" as "nix"

── 22:24:39 - Nix (self-upgrade) ───────────────────────────────────────────────
DEBUG Executing command `/nix/var/nix/profiles/default/bin/nix --version`
DEBUG `nix --version` output output=nix (Determinate Nix 3.20.0) 2.34.6

DEBUG is_determinate_nix=true
DEBUG Detected "/usr/local/bin/determinate-nixd" as "determinate-nixd"
DEBUG Executing command `/usr/bin/sudo -i /usr/local/bin/determinate-nixd upgrade`
Upgrading Determinate Nixd...
Upgrading Determinate Nix...
Upgrading Nix to "/nix/store/k5skl4hvbbmyvq12cjih8hpzpgr2p51a-determinate-nix-3.21.0"
Restarting Determinate Nixd...

── 22:26:26 - Summary ──────────────────────────────────────────────────────────
nix: OK
nix upgrade-nix: OK
DEBUG Desktop notification: Topgrade finished successfully
```

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [x] If this PR introduces new user-facing messages they are translated

### AI involvement
I did not use AI at all

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
