### PR TITLE
NOSQUASH: fix(nix): use sudo when current profile is not owned by us

### DIFF
--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -6,7 +6,6 @@ use ini::Ini;
 use regex::Regex;
 use rust_i18n::t;
 use semver::Version;
-use std::env::home_dir;
 use std::ffi::OsStr;
 use std::io::Write;
 use std::os::unix::fs::MetadataExt;
@@ -21,7 +20,7 @@ use crate::XDG_DIRS;
 use crate::command::CommandExt;
 use crate::config::NixHandler;
 use crate::sudo::SudoExecuteOpts;
-use crate::utils::require_one;
+use crate::utils::{is_elevated, require_one};
 use crate::{HOME_DIR, output_changed_message};
 
 #[cfg(target_os = "linux")]
@@ -565,18 +564,85 @@ impl NixVersion {
     }
 }
 
-pub fn run_nix(ctx: &ExecutionContext) -> Result<()> {
-    let nix = require("nix")?;
-    // TODO: Is None possible here? Should we use HOME_DIR instead?
-    let profile_path = match home_dir() {
-        Some(home) => XDG_DIRS
+fn nix_state_dir() -> PathBuf {
+    PathBuf::from(std::env::var_os("NIX_STATE_DIR").unwrap_or("/nix/var/nix".into()))
+}
+
+/// Get the path to the user profile link.
+/// User profile link is a symbolic link to the user's current profile:
+/// - `~/.nix-profile`
+/// - `$XDG_STATE_HOME/nix/profile` if `use-xdg-base-directories` is set to `true`.
+///
+/// Ref: https://nix.dev/manual/nix/2.34/command-ref/new-cli/nix3-profile#user-profile-link
+fn nix_get_user_profile_link(ctx: &ExecutionContext, nix: &Path) -> Result<PathBuf> {
+    let config_output = ctx
+        .execute(nix)
+        .always()
+        .args(nix_args())
+        .arg("config")
+        .arg("show")
+        .arg("use-xdg-base-directories")
+        .output_checked_utf8()?;
+
+    debug!(
+        output=%config_output,
+        "`nix config show use-xdg-base-directories` output"
+    );
+
+    let config_value_string = config_output.stdout.lines().next();
+
+    let use_xdg_base_directories = match config_value_string {
+        Some("true") => true,
+        Some("false") => false,
+        None => {
+            return Err(eyre!(output_changed_message!(
+                "nix config show use-xdg-base-directories",
+                "empty output"
+            )));
+        }
+        _ => {
+            return Err(eyre!(output_changed_message!(
+                "nix config show use-xdg-base-directories",
+                "invalid bool value"
+            )));
+        }
+    };
+
+    if use_xdg_base_directories {
+        XDG_DIRS
             .state_dir()
             .map(|d| d.join("nix/profile"))
-            .filter(|p| p.exists())
-            .unwrap_or(Path::new(&home).join(".nix-profile")),
-        None => Path::new("/nix/var/nix/profiles/per-user/default").into(),
-    };
-    debug!("nix profile: {:?}", profile_path);
+            .ok_or_else(|| eyre!("Unable to get the user's state directory"))
+    } else {
+        Ok(HOME_DIR.join(".nix-profile"))
+    }
+}
+
+/// Get the path to the user's current profile.
+/// This will try to resolve the user profile link or use the default values,
+/// if it couldn't be resolved,
+///
+/// Note that the return value of this is expected to be another symlink
+/// as that's what a profile is - a symlink to a specific generation of a user environment.
+///
+/// Ref: https://nix.dev/manual/nix/2.34/package-management/profiles
+fn nix_get_current_profile_path(ctx: &ExecutionContext, nix: &Path) -> Result<PathBuf> {
+    let user_profile_link = nix_get_user_profile_link(ctx, nix)?;
+
+    match user_profile_link.read_link() {
+        Ok(profile_link) => Ok(profile_link),
+        Err(_) if is_elevated() => Ok(nix_state_dir().join("profiles/per-user/root/profile")),
+        Err(_) => XDG_DIRS
+            .state_dir()
+            .map(|d| d.join("nix/profiles/profile"))
+            .ok_or_else(|| eyre!("Unable to get the user's state directory")),
+    }
+}
+
+pub fn run_nix(ctx: &ExecutionContext) -> Result<()> {
+    let nix = require("nix")?;
+    let profile_path = nix_get_current_profile_path(ctx, &nix)?;
+    debug!("nix current profile: {:?}", profile_path);
     let manifest_json_path = profile_path.join("manifest.json");
 
     #[cfg(target_os = "macos")]

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -33,39 +33,46 @@ use crate::step::Step;
 use crate::terminal::print_separator;
 use crate::utils::{PathExt, require};
 
-#[cfg(target_os = "linux")]
-fn brew_linux_sudo_uid() -> Option<u32> {
-    let linuxbrew_directory = "/home/linuxbrew/.linuxbrew";
-    if let Ok(metadata) = fs::metadata(linuxbrew_directory) {
+fn get_sudo_uid<P: AsRef<Path>>(path: P) -> Option<u32> {
+    if let Ok(metadata) = fs::metadata(&path) {
         let owner_id = metadata.uid();
         let current_id = nix::unistd::Uid::effective();
         // print debug these two values
-        debug!("linuxbrew_directory owner_id: {owner_id}, current_id: {current_id}");
+        debug!(
+            "path: {path:?}, owner_id: {owner_id}, current_id: {current_id}",
+            path = path.as_ref()
+        );
         return if owner_id == current_id.as_raw() {
-            None // no need for sudo if linuxbrew is owned by the current user
+            None // no need for sudo if path is owned by the current user
         } else {
-            Some(owner_id) // otherwise use sudo to run brew as the owner
+            Some(owner_id) // otherwise use sudo to run as the owner
         };
     }
     None
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
-fn brew_get_sudo() -> Option<String> {
-    #[cfg(target_os = "linux")]
-    {
-        let sudo_uid = brew_linux_sudo_uid();
-        // if brew is owned by another user, execute "sudo -Hu <user> brew update"
-        if let Some(user_id) = sudo_uid {
-            let uid = nix::unistd::Uid::from_raw(user_id);
-            match nix::unistd::User::from_uid(uid) {
-                Ok(Some(user)) => return Some(user.name),
-                Ok(None) => warn!("no matching owner of linuxbrew found; running brew as the current user"),
-                Err(err) => warn!("getpwuid() failed for UID {user_id}: {err}; running brew as the current user"),
-            }
+fn get_sudo_user<P: AsRef<Path>>(path: P) -> Option<String> {
+    let sudo_uid = get_sudo_uid(path);
+    // if path is owned by another user, execute "sudo -Hu <user> <binary_name>"
+    if let Some(user_id) = sudo_uid {
+        let uid = nix::unistd::Uid::from_raw(user_id);
+        match nix::unistd::User::from_uid(uid) {
+            Ok(Some(user)) => return Some(user.name),
+            Ok(None) => warn!("could not find a user entry with UID {user_id}; running binary as the current user"),
+            Err(err) => warn!("getpwuid() failed for UID {user_id}: {err}; running binary as the current user"),
         }
     }
     None
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn brew_get_sudo_user() -> Option<String> {
+    if cfg!(target_os = "linux") {
+        let linuxbrew_directory = "/home/linuxbrew/.linuxbrew";
+        get_sudo_user(linuxbrew_directory)
+    } else {
+        None
+    }
 }
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
@@ -88,7 +95,7 @@ impl Brew {
         Ok(Self {
             variant,
             path: require(variant.binary_name())?,
-            sudo: brew_get_sudo(),
+            sudo: brew_get_sudo_user(),
         })
     }
 
@@ -628,6 +635,7 @@ fn nix_get_user_profile_link(ctx: &ExecutionContext, nix: &Path) -> Result<PathB
 /// Ref: https://nix.dev/manual/nix/2.34/package-management/profiles
 fn nix_get_current_profile_path(ctx: &ExecutionContext, nix: &Path) -> Result<PathBuf> {
     let user_profile_link = nix_get_user_profile_link(ctx, nix)?;
+    debug!("nix user profile link: {:?}", user_profile_link);
 
     match user_profile_link.read_link() {
         Ok(profile_link) => Ok(profile_link),
@@ -678,7 +686,14 @@ pub fn run_nix(ctx: &ExecutionContext) -> Result<()> {
             warn!("`nix-channel --update` failed: {e}");
         }
         print_separator("Nix Profiles");
-        ctx.execute(nix)
+        let mut command = match &get_sudo_user(profile_path) {
+            None => ctx.execute(nix),
+            Some(user) => {
+                let sudo = ctx.require_sudo()?;
+                sudo.execute_opts(ctx, &nix, SudoExecuteOpts::new().set_home().user(user).login_shell())?
+            }
+        };
+        command
             .args(nix_args())
             .arg("profile")
             .arg("upgrade")
@@ -691,7 +706,17 @@ pub fn run_nix(ctx: &ExecutionContext) -> Result<()> {
         let nix_env = require("nix-env")?;
         print_separator("Nix");
 
-        let mut command = ctx.execute(nix_env);
+        let mut command = match &get_sudo_user(profile_path) {
+            None => ctx.execute(nix_env),
+            Some(user) => {
+                let sudo = ctx.require_sudo()?;
+                sudo.execute_opts(
+                    ctx,
+                    &nix_env,
+                    SudoExecuteOpts::new().set_home().user(user).login_shell(),
+                )?
+            }
+        };
         command.arg("--upgrade");
         if let Some(args) = ctx.config().nix_env_arguments() {
             command.args(args.split_whitespace());


### PR DESCRIPTION
## What does this PR do
This PR updates the implementation to run `nix profile upgrade` and `nix-env --upgrade` with `sudo -Hiu <profile_owner>` when the current profile is not owned by the current user.
Additionally, this PR also [improved the correctness of calculating what the current profile is based on the value of `use-xdg-base-directories` from Nix's config](https://github.com/topgrade-rs/topgrade/pull/2076/commits/0e2ec1f6480d93beb2b7a44e6efa716ae35dbeea). The PR could have been slightly smaller if I didn't do that, but I was using the terminology from the Nix docs, and it felt wrong to keep the not entirely correct implementation.

This is a stepping stone towards #2075 - it introduces the needed pieces to upgrade profiles owned by a user other than the current one. It is, however, already useful - it should fix permission issues around trying to upgrade packages on a user whose default user profile is `/nix/var/nix/profiles/default` that were mentioned in https://github.com/topgrade-rs/topgrade/issues/620

**NOTE:** I'm not a Rust dev, so I'm sorry if there are some bad code patterns used in this PR. Just let me know, and I'll do my best to fix it!

Tested on a fresh Ubuntu 26.04 Server VM with a Determinate Nix install.

<details>
<summary>Test 1 - update packages in a profile owned by the current user</summary>

```
$ topgrade --verbose --only nix
DEBUG Current system locale is C
DEBUG Configuration directory /home/vm/.config/ does not exist
DEBUG Version: 17.5.1
DEBUG OS: x86_64-unknown-linux-gnu
DEBUG Args { inner: ["topgrade", "--verbose", "--only", "nix"] }
DEBUG Binary path: Ok("/home/vm/.cargo/bin/topgrade")
DEBUG self-update Feature Enabled: false
DEBUG Configuration: Config { opt: CommandLineArgs { edit_config: false, show_config_reference: false, run_in_tmux: false, no_tmux: false, cleanup: false, dry_run: false, run_type: Wet, no_retry: false, no_ask_retry: false, auto_retry: None, disable: [], only: [Nix], custom_commands: [], env: [], verbose: true, keep_at_end: false, skip_notify: false, notify_end: Always, yes: None, disable_predefined_git_repos: false, config: None, remote_host_limit: None, show_skipped: false, allow_root: false, sudo_loop: false, sudo_loop_interval: None, log_filter: "warn", gen_completion: None, gen_manpage: false, no_self_update: false }, config_file: ConfigFile { include: None, misc: None, pre_commands: None, post_commands: None, commands: None, conda: None, python: None, composer: None, brew: None, linux: None, mandb: None, git: None, go: None, containers: None, windows: None, npm: None, chezmoi: None, mise: None, yarn: None, deno: None, vim: None, firmware: None, vagrant: None, flatpak: None, pixi: None, distrobox: None, lensfun: None, julia: None, zigup: None, vscode: None, doom: None, cargo: None, rustup: None, pkgfile: None, viteplus: None }, allowed_steps: [Nix] }
DEBUG Running with euid: 1000
DEBUG Cannot find "doas"
DEBUG Detected "/usr/bin/sudo" as "sudo"
DEBUG Sudo: Ok(Sudo { path: Some("/usr/bin/sudo"), kind: Sudo })
DEBUG Step "nix"
DEBUG Detected "/nix/var/nix/profiles/default/bin/nix" as "nix"
DEBUG Executing command `/nix/var/nix/profiles/default/bin/nix --extra-experimental-features nix-command config show use-xdg-base-directories`
DEBUG `nix config show use-xdg-base-directories` output output=false

DEBUG nix user profile link: "/home/vm/.nix-profile"
DEBUG nix current profile: "/home/vm/.local/state/nix/profiles/profile"
DEBUG Executing command `/nix/var/nix/profiles/default/bin/nix --version`
DEBUG `nix --version` output output=nix (Determinate Nix 3.21.0) 2.34.6

DEBUG Raw Nix version: 2.34.6
DEBUG Corrected raw Nix version: 2.34.6
DEBUG Nix version: Version { major: 2, minor: 34, patch: 6 }
DEBUG is_lix=false
DEBUG Detected "/nix/var/nix/profiles/default/bin/nix-channel" as "nix-channel"

── 07:29:25 - Nix Channels ─────────────────────────────────────────────────────
DEBUG Executing command `/nix/var/nix/profiles/default/bin/nix-channel --update`
warning: nix-channel is deprecated in favor of flakes in Determinate Nix. See https://zero-to-nix.com for a guide to Nix flakes. For details and to offer feedback on the deprecation process, see: https://github.com/DeterminateSystems/nix-src/issues/34.
unpacking 0 channels...

── 07:29:25 - Nix Profiles ─────────────────────────────────────────────────────
DEBUG path: "/home/vm/.local/state/nix/profiles/profile", owner_id: 1000, current_id: 1000
DEBUG Executing command `/nix/var/nix/profiles/default/bin/nix --extra-experimental-features nix-command profile upgrade --all --impure --verbose`
unpacking 'https://flakehub.com/f/DeterminateSystems/nixpkgs-weekly/0.1' into the Git cache...
upgrading 'legacyPackages.x86_64-linux.cowsay' from flake 'https://api.flakehub.com/f/pinned/DeterminateSystems/nixpkgs-weekly/0.1.1008784%2Brev-4df1b885d76a54e1aa1a318f8d16fd6005b6401f/019e8725-c925-7ec1-8f35-3f9effcf169a/source.tar.gz?narHash=sha256-vhVhuXzFrIOfcssC/9hDHx7MHzDKjF3keHuREOQqQiQ%3D' to 'https://api.flakehub.com/f/pinned/DeterminateSystems/nixpkgs-weekly/0.1.1008784%2Brev-4df1b885d76a54e1aa1a318f8d16fd6005b6401f/019e8725-c925-7ec1-8f35-3f9effcf169a/source.tar.gz?narHash=sha256-vhVhuXzFrIOfcssC/9hDHx7MHzDKjF3keHuREOQqQiQ%3D'
upgrading 'legacyPackages.x86_64-linux.ponysay' from flake 'https://api.flakehub.com/f/pinned/DeterminateSystems/nixpkgs-weekly/0.1.1008784%2Brev-4df1b885d76a54e1aa1a318f8d16fd6005b6401f/019e8725-c925-7ec1-8f35-3f9effcf169a/source.tar.gz?narHash=sha256-vhVhuXzFrIOfcssC/9hDHx7MHzDKjF3keHuREOQqQiQ%3D' to 'https://api.flakehub.com/f/pinned/DeterminateSystems/nixpkgs-weekly/0.1.1008784%2Brev-4df1b885d76a54e1aa1a318f8d16fd6005b6401f/019e8725-c925-7ec1-8f35-3f9effcf169a/source.tar.gz?narHash=sha256-vhVhuXzFrIOfcssC/9hDHx7MHzDKjF3keHuREOQqQiQ%3D'
upgrading 'legacyPackages.x86_64-linux.ripgrep' from flake 'https://api.flakehub.com/f/pinned/DeterminateSystems/nixpkgs-weekly/0.1.1008784%2Brev-4df1b885d76a54e1aa1a318f8d16fd6005b6401f/019e8725-c925-7ec1-8f35-3f9effcf169a/source.tar.gz?narHash=sha256-vhVhuXzFrIOfcssC/9hDHx7MHzDKjF3keHuREOQqQiQ%3D' to 'https://api.flakehub.com/f/pinned/DeterminateSystems/nixpkgs-weekly/0.1.1008784%2Brev-4df1b885d76a54e1aa1a318f8d16fd6005b6401f/019e8725-c925-7ec1-8f35-3f9effcf169a/source.tar.gz?narHash=sha256-vhVhuXzFrIOfcssC/9hDHx7MHzDKjF3keHuREOQqQiQ%3D'
[0/3 built, 7.6 KiB DL] DEBUG Step "nix upgrade-nix"
DEBUG Detected "/nix/var/nix/profiles/default/bin/nix" as "nix"

── 07:29:28 - Nix (self-upgrade) ───────────────────────────────────────────────
DEBUG Executing command `/nix/var/nix/profiles/default/bin/nix --version`
DEBUG `nix --version` output output=nix (Determinate Nix 3.21.0) 2.34.6

DEBUG is_determinate_nix=true
DEBUG Detected "/usr/local/bin/determinate-nixd" as "determinate-nixd"
DEBUG Executing command `/usr/bin/sudo -i /usr/local/bin/determinate-nixd upgrade`
You are already running the latest version of Determinate Nix (3.21.0).

── 07:29:28 - Summary ──────────────────────────────────────────────────────────
nix: OK
nix upgrade-nix: OK
DEBUG Desktop notification: Topgrade finished successfully
```

</details>

<details>
<summary>Test 2 - update packages in the default profile (owned by root)</summary>

```
$ topgrade --verbose --only nix
DEBUG Current system locale is C
DEBUG Configuration directory /home/vm/.config/ does not exist
DEBUG Version: 17.5.1
DEBUG OS: x86_64-unknown-linux-gnu
DEBUG Args { inner: ["topgrade", "--verbose", "--only", "nix"] }
DEBUG Binary path: Ok("/home/vm/.cargo/bin/topgrade")
DEBUG self-update Feature Enabled: false
DEBUG Configuration: Config { opt: CommandLineArgs { edit_config: false, show_config_reference: false, run_in_tmux: false, no_tmux: false, cleanup: false, dry_run: false, run_type: Wet, no_retry: false, no_ask_retry: false, auto_retry: None, disable: [], only: [Nix], custom_commands: [], env: [], verbose: true, keep_at_end: false, skip_notify: false, notify_end: Always, yes: None, disable_predefined_git_repos: false, config: None, remote_host_limit: None, show_skipped: false, allow_root: false, sudo_loop: false, sudo_loop_interval: None, log_filter: "warn", gen_completion: None, gen_manpage: false, no_self_update: false }, config_file: ConfigFile { include: None, misc: None, pre_commands: None, post_commands: None, commands: None, conda: None, python: None, composer: None, brew: None, linux: None, mandb: None, git: None, go: None, containers: None, windows: None, npm: None, chezmoi: None, mise: None, yarn: None, deno: None, vim: None, firmware: None, vagrant: None, flatpak: None, pixi: None, distrobox: None, lensfun: None, julia: None, zigup: None, vscode: None, doom: None, cargo: None, rustup: None, pkgfile: None, viteplus: None }, allowed_steps: [Nix] }
DEBUG Running with euid: 1000
DEBUG Cannot find "doas"
DEBUG Detected "/usr/bin/sudo" as "sudo"
DEBUG Sudo: Ok(Sudo { path: Some("/usr/bin/sudo"), kind: Sudo })
DEBUG Step "nix"
DEBUG Detected "/home/vm/.nix-profile/bin/nix" as "nix"
DEBUG Executing command `/home/vm/.nix-profile/bin/nix --extra-experimental-features nix-command config show use-xdg-base-directories`
DEBUG `nix config show use-xdg-base-directories` output output=false

DEBUG nix user profile link: "/home/vm/.nix-profile"
DEBUG nix current profile: "/nix/var/nix/profiles/default"
DEBUG Executing command `/home/vm/.nix-profile/bin/nix --version`
DEBUG `nix --version` output output=nix (Determinate Nix 3.21.0) 2.34.6

DEBUG Raw Nix version: 2.34.6
DEBUG Corrected raw Nix version: 2.34.6
DEBUG Nix version: Version { major: 2, minor: 34, patch: 6 }
DEBUG is_lix=false
DEBUG Detected "/home/vm/.nix-profile/bin/nix-channel" as "nix-channel"

── 07:30:37 - Nix Channels ─────────────────────────────────────────────────────
DEBUG Executing command `/home/vm/.nix-profile/bin/nix-channel --update`
warning: nix-channel is deprecated in favor of flakes in Determinate Nix. See https://zero-to-nix.com for a guide to Nix flakes. For details and to offer feedback on the deprecation process, see: https://github.com/DeterminateSystems/nix-src/issues/34.
unpacking 0 channels...

── 07:30:37 - Nix Profiles ─────────────────────────────────────────────────────
DEBUG path: "/nix/var/nix/profiles/default", owner_id: 0, current_id: 1000
DEBUG Executing command `/usr/bin/sudo -i -H -u root /home/vm/.nix-profile/bin/nix --extra-experimental-features nix-command profile upgrade --all --impure --verbose`
warning: Found package 'determinate-nix', but it was not added from a flake, so it can't be checked for upgrades!
unpacking 'https://flakehub.com/f/DeterminateSystems/nixpkgs-weekly/0.1' into the Git cache...
upgrading 'legacyPackages.x86_64-linux.micro' from flake 'https://api.flakehub.com/f/pinned/DeterminateSystems/nixpkgs-weekly/0.1.1008784%2Brev-4df1b885d76a54e1aa1a318f8d16fd6005b6401f/019e8725-c925-7ec1-8f35-3f9effcf169a/source.tar.gz?narHash=sha256-vhVhuXzFrIOfcssC/9hDHx7MHzDKjF3keHuREOQqQiQ%3D' to 'https://api.flakehub.com/f/pinned/DeterminateSystems/nixpkgs-weekly/0.1.1008784%2Brev-4df1b885d76a54e1aa1a318f8d16fd6005b6401f/019e8725-c925-7ec1-8f35-3f9effcf169a/source.tar.gz?narHash=sha256-vhVhuXzFrIOfcssC/9hDHx7MHzDKjF3keHuREOQqQiQ%3D'
warning: Found package 'nss-cacert', but it was not added from a flake, so it can't be checked for upgrades!
[7.6 KiB DL]DEBUG Step "nix upgrade-nix"
DEBUG Detected "/home/vm/.nix-profile/bin/nix" as "nix"

── 07:30:38 - Nix (self-upgrade) ───────────────────────────────────────────────
DEBUG Executing command `/home/vm/.nix-profile/bin/nix --version`
DEBUG `nix --version` output output=nix (Determinate Nix 3.21.0) 2.34.6

DEBUG is_determinate_nix=true
DEBUG Detected "/usr/local/bin/determinate-nixd" as "determinate-nixd"
DEBUG Executing command `/usr/bin/sudo -i /usr/local/bin/determinate-nixd upgrade`
You are already running the latest version of Determinate Nix (3.21.0).

── 07:30:38 - Summary ──────────────────────────────────────────────────────────
nix: OK
nix upgrade-nix: OK
DEBUG Desktop notification: Topgrade finished successfully
```

</details>

And for comparison, this is a failure I'm getting with the default profile set as the current profile without this PR:

<details>
<summary>Failure when running without this PR</summary>

```
── 07:39:20 - Nix Channels ─────────────────────────────────────────────────────
DEBUG Executing command `/home/vm/.nix-profile/bin/nix-channel --update`
warning: nix-channel is deprecated in favor of flakes in Determinate Nix. See https://zero-to-nix.com for a guide to Nix flakes. For details and to offer feedback on the deprecation process, see: https://github.com/DeterminateSystems/nix-src/issues/34.
unpacking 0 channels...

── 07:39:20 - Nix Profiles ─────────────────────────────────────────────────────
DEBUG Executing command `/home/vm/.nix-profile/bin/nix --extra-experimental-features nix-command profile upgrade --all --impure --verbose`
warning: Found package 'determinate-nix', but it was not added from a flake, so it can't be checked for upgrades!
upgrading 'legacyPackages.x86_64-linux.micro' from flake 'https://api.flakehub.com/f/pinned/DeterminateSystems/nixpkgs-weekly/0.1.1008784%2Brev-4df1b885d76a54e1aa1a318f8d16fd6005b6401f/019e8725-c925-7ec1-8f35-3f9effcf169a/source.tar.gz?narHash=sha256-vhVhuXzFrIOfcssC/9hDHx7MHzDKjF3keHuREOQqQiQ%3D' to 'https://api.flakehub.com/f/pinned/DeterminateSystems/nixpkgs-weekly/0.1.1008784%2Brev-4df1b885d76a54e1aa1a318f8d16fd6005b6401f/019e8725-c925-7ec1-8f35-3f9effcf169a/source.tar.gz?narHash=sha256-vhVhuXzFrIOfcssC/9hDHx7MHzDKjF3keHuREOQqQiQ%3D'
warning: Found package 'nss-cacert', but it was not added from a flake, so it can't be checked for upgrades!
error: creating symlink "/nix/var/nix/profiles/default-1-link.tmp-35571-846930886" -> "/nix/store/ybja3aajapx71356kavyrm296n5mgpl7-profile": Permission denied
DEBUG Command failed: Err(
   0: \x1b[91mCommand failed: `/home/vm/.nix-profile/bin/nix --extra-experimental-features nix-command profile upgrade --all --impure --verbose`\x1b[0m
   1: \x1b[91m`/home/vm/.nix-profile/bin/nix` failed: exit status: 1\x1b[0m

Location:
   \x1b[35msrc/steps/os/unix.rs\x1b[0m:\x1b[35m614\x1b[0m)
DEBUG Step "nix" failed: 
   0: \x1b[91mCommand failed: `/home/vm/.nix-profile/bin/nix --extra-experimental-features nix-command profile upgrade --all --impure --verbose`\x1b[0m
   1: \x1b[91m`/home/vm/.nix-profile/bin/nix` failed: exit status: 1\x1b[0m

Location:
   \x1b[35msrc/steps/os/unix.rs\x1b[0m:\x1b[35m614\x1b[0m
nix failed: 
   0: Command failed: `/home/vm/.nix-profile/bin/nix --extra-experimental-features nix-command profile upgrade --all --impure --verbose`
   1: `/home/vm/.nix-profile/bin/nix` failed: exit status: 1

Location:
   src/steps/os/unix.rs:614
Retry? (y)es/(N)o/(s)hell/(q)uit
DEBUG Step "nix upgrade-nix"
DEBUG Detected "/home/vm/.nix-profile/bin/nix" as "nix"

── 07:40:47 - Nix (self-upgrade) ───────────────────────────────────────────────
DEBUG Executing command `/home/vm/.nix-profile/bin/nix --version`
DEBUG `nix --version` output output=nix (Determinate Nix 3.21.0) 2.34.6

DEBUG is_determinate_nix=true
DEBUG Detected "/usr/local/bin/determinate-nixd" as "determinate-nixd"
DEBUG Executing command `/usr/bin/sudo -i /usr/local/bin/determinate-nixd upgrade`
You are already running the latest version of Determinate Nix (3.21.0).

── 07:40:47 - Summary ──────────────────────────────────────────────────────────
nix: FAILED
nix upgrade-nix: OK
DEBUG Desktop notification: Topgrade finished with errors
```

</details>

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [x] If this PR introduces new user-facing messages they are translated

### AI involvement
I did not use AI at all

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
