### PR TITLE
fix(powershell): skip step if there is a wrapper script

### DIFF
--- a/locales/app.yml
+++ b/locales/app.yml
@@ -152,6 +152,22 @@ _version: 2
   zh_CN: "未安装 Powershell"
   zh_TW: "未安裝 Powershell"
   de: "Powershell ist nicht installiert"
+"Cannot detect PowerShell in a dumb terminal":
+  en: "Cannot detect PowerShell in a dumb terminal"
+  lt: "Nepavyko aptikti PowerShell ribotame terminale"
+  es: "No se puede detectar PowerShell en un terminal limitado"
+  fr: "Impossible de détecter PowerShell dans un terminal limité"
+  zh_CN: "无法在简易终端中检测 PowerShell"
+  zh_TW: "無法在簡易終端機中偵測 PowerShell"
+  de: "PowerShell kann in einem eingeschränkten Terminal nicht erkannt werden"
+"{binary} at {path} is a wrapper script":
+  en: "%{binary} at %{path} is a wrapper script"
+  lt: "%{binary} kelyje %{path} yra apvalkalo scenarijus"
+  es: "%{binary} en %{path} es un script contenedor"
+  fr: "%{binary} à %{path} est un script d'encapsulation"
+  zh_CN: "%{path} 处的 %{binary} 是一个包装脚本"
+  zh_TW: "%{path} 處的 %{binary} 是一個包裝指令稿"
+  de: "%{binary} unter %{path} ist ein Wrapper-Skript"
 "PowerShellGet Update-Module is unavailable or could not be loaded. Skipping PowerShell module updates.":
   en: "PowerShellGet Update-Module is unavailable or could not be loaded. Skipping PowerShell module updates."
   lt: "PowerShellGet Update-Module nepasiekiama arba jos nepavyko įkelti. Praleidžiamas PowerShell modulių atnaujinimas."

--- a/src/execution_context.rs
+++ b/src/execution_context.rs
@@ -6,18 +6,16 @@ use std::sync::{Mutex, OnceLock};
 
 use clap::ValueEnum;
 use color_eyre::eyre::Result;
-use rust_i18n::t;
 use serde::Deserialize;
 use strum::EnumString;
 
 use crate::config::Config;
-use crate::error::MissingSudo;
+use crate::error::{MissingSudo, SkipStep};
 use crate::executor::{DryCommand, Executor};
 use crate::powershell::Powershell;
 #[cfg(target_os = "linux")]
 use crate::steps::linux::Distribution;
 use crate::sudo::Sudo;
-use crate::utils::require_option;
 
 /// An enum telling whether Topgrade should perform dry runs or actually perform the steps.
 #[derive(Clone, Copy, Debug, Deserialize, Default, EnumString, ValueEnum)]
@@ -66,7 +64,7 @@ pub struct ExecutionContext<'a> {
     under_ssh: bool,
     #[cfg(target_os = "linux")]
     distribution: &'a Result<Distribution>,
-    powershell: OnceLock<Option<Powershell>>,
+    powershell: OnceLock<Result<Powershell, SkipStep>>,
 }
 
 impl<'a> ExecutionContext<'a> {
@@ -131,14 +129,13 @@ impl<'a> ExecutionContext<'a> {
         self.distribution
     }
 
-    pub fn powershell(&self) -> &Option<Powershell> {
+    pub fn powershell(&self) -> &Result<Powershell, SkipStep> {
         self.powershell.get_or_init(|| Powershell::new(self))
     }
 
     pub fn require_powershell(&self) -> Result<&Powershell> {
-        require_option(
-            self.powershell().as_ref(),
-            t!("Powershell is not installed").to_string(),
-        )
+        self.powershell()
+            .as_ref()
+            .map_err(|skip| SkipStep(skip.0.clone()).into())
     }
 }

--- a/src/execution_context.rs
+++ b/src/execution_context.rs
@@ -136,6 +136,7 @@ impl<'a> ExecutionContext<'a> {
     pub fn require_powershell(&self) -> Result<&Powershell> {
         self.powershell()
             .as_ref()
+            // necessary because `skip` is a `&SkipStep` borrowed from `self` (`skip.into()` gives E0521)
             .map_err(|skip| SkipStep(skip.0.clone()).into())
     }
 }

--- a/src/steps/git.rs
+++ b/src/steps/git.rs
@@ -58,7 +58,7 @@ pub fn run_git_pull_or_fetch(ctx: &ExecutionContext) -> Result<()> {
                 repos.insert_if_repo(ctx, HOME_DIR.join(".dotfiles"));
             }
 
-            if let Some(powershell) = ctx.powershell()
+            if let Ok(powershell) = ctx.powershell()
                 && let Some(profile) = powershell.profile()
             {
                 repos.insert_if_repo(ctx, profile);

--- a/src/steps/powershell.rs
+++ b/src/steps/powershell.rs
@@ -7,6 +7,7 @@ use color_eyre::eyre::eyre;
 use tracing::debug;
 
 use crate::command::CommandExt;
+use crate::error::SkipStep;
 use crate::execution_context::ExecutionContext;
 use crate::executor::Executor;
 use crate::terminal;
@@ -19,30 +20,42 @@ pub struct Powershell {
 }
 
 impl Powershell {
-    pub fn new(ctx: &ExecutionContext) -> Option<Self> {
+    /// Detects a usable PowerShell. The `Err` carries the reason so the step can
+    /// surface it as its skip message instead of a generic "not installed"
+    pub fn new(ctx: &ExecutionContext) -> Result<Self, SkipStep> {
         if terminal::is_dumb() {
-            return None;
+            return Err(SkipStep("Cannot detect PowerShell in a dumb terminal".to_string()));
         }
 
-        let (path, is_pwsh) = which("pwsh")
-            .filter(|p| !p.has_shebang())
-            .map(|p| (Some(p), true))
-            .or_else(|| {
-                which("powershell")
-                    .filter(|p| !p.has_shebang())
-                    .map(|p| (Some(p), false))
-            })
-            .unwrap_or((None, false));
+        let (path, is_pwsh) = Self::detect_path()?;
 
-        path.map(|path| {
-            let mut ret = Self {
-                path,
-                profile: None,
-                is_pwsh,
+        let mut ret = Self {
+            path,
+            profile: None,
+            is_pwsh,
+        };
+        ret.set_profile(ctx);
+        Ok(ret)
+    }
+
+    fn detect_path() -> Result<(PathBuf, bool), SkipStep> {
+        let mut skip_reason = SkipStep("Powershell is not installed".to_string());
+
+        for (binary, is_pwsh) in [("pwsh", true), ("powershell", false)] {
+            let Some(path) = which(binary) else {
+                continue;
             };
-            ret.set_profile(ctx);
-            ret
-        })
+
+            if path.has_shebang() {
+                skip_reason = SkipStep(format!("{binary} at {} is a wrapper script", path.display()));
+                debug!("{skip_reason}");
+                continue;
+            }
+
+            return Ok((path, is_pwsh));
+        }
+
+        Err(skip_reason)
     }
 
     pub fn profile(&self) -> Option<&PathBuf> {

--- a/src/steps/powershell.rs
+++ b/src/steps/powershell.rs
@@ -25,8 +25,13 @@ impl Powershell {
         }
 
         let (path, is_pwsh) = which("pwsh")
+            .filter(|p| !p.has_shebang())
             .map(|p| (Some(p), true))
-            .or_else(|| which("powershell").map(|p| (Some(p), false)))
+            .or_else(|| {
+                which("powershell")
+                    .filter(|p| !p.has_shebang())
+                    .map(|p| (Some(p), false))
+            })
             .unwrap_or((None, false));
 
         path.map(|path| {

--- a/src/steps/powershell.rs
+++ b/src/steps/powershell.rs
@@ -25,7 +25,7 @@ impl Powershell {
     /// surface it as its skip message instead of a generic "not installed"
     pub fn new(ctx: &ExecutionContext) -> Result<Self, SkipStep> {
         if terminal::is_dumb() {
-            return Err(SkipStep("Cannot detect PowerShell in a dumb terminal".to_string()));
+            return Err(SkipStep(t!("Cannot detect PowerShell in a dumb terminal").to_string()));
         }
 
         let (path, is_pwsh) = Self::detect_path()?;
@@ -48,7 +48,14 @@ impl Powershell {
             };
 
             if path.has_shebang() {
-                skip_reason = SkipStep(format!("{binary} at {} is a wrapper script", path.display()));
+                skip_reason = SkipStep(
+                    t!(
+                        "{binary} at {path} is a wrapper script",
+                        binary = binary,
+                        path = path.display()
+                    )
+                    .to_string(),
+                );
                 debug!("{skip_reason}");
                 continue;
             }

--- a/src/steps/powershell.rs
+++ b/src/steps/powershell.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use color_eyre::eyre::Result;
 #[cfg(windows)]
 use color_eyre::eyre::eyre;
+use rust_i18n::t;
 use tracing::debug;
 
 use crate::command::CommandExt;
@@ -39,7 +40,7 @@ impl Powershell {
     }
 
     fn detect_path() -> Result<(PathBuf, bool), SkipStep> {
-        let mut skip_reason = SkipStep("Powershell is not installed".to_string());
+        let mut skip_reason = SkipStep(t!("Powershell is not installed").to_string());
 
         for (binary, is_pwsh) in [("pwsh", true), ("powershell", false)] {
             let Some(path) = which(binary) else {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -25,6 +25,9 @@ where
     fn if_exists(self) -> Option<Self>;
     fn is_descendant_of(&self, ancestor: &Path) -> bool;
 
+    /// Used to check for UNIX launcher shims that shadow a real executable
+    fn has_shebang(&self) -> bool;
+
     /// Returns the path if it exists or ErrorKind::SkipStep otherwise
     fn require(self) -> Result<Self>;
 }
@@ -45,6 +48,17 @@ where
 
     fn is_descendant_of(&self, ancestor: &Path) -> bool {
         self.as_ref().iter().zip(ancestor.iter()).all(|(a, b)| a == b)
+    }
+
+    fn has_shebang(&self) -> bool {
+        use std::io::Read;
+
+        // checks for `#!` by the reading the first 2 bytes of the file
+        let mut magic = [0u8; 2];
+        std::fs::File::open(self.as_ref())
+            .and_then(|mut file| file.read_exact(&mut magic))
+            .is_ok()
+            && &magic == b"#!"
     }
 
     fn require(self) -> Result<Self> {


### PR DESCRIPTION
## What does this PR do
<!--
Describe what your PR does, and link any relevant issues.
Make sure to use a keyword like 'closes' if this PR solves the issue.
-->

Adds a `.has_shebang()` helper which checks the first two bytes of a file and returns true/false. It is used to fix a winapps powershell wrapper script issue, but it may be used in the future for similar scenarios.

Closes https://github.com/topgrade-rs/topgrade/issues/2081

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
```
16:29 uwuclxdy:~/repos/rs/topgrade (main*) 2 11.81ms $ topgrade --only powershell

── 16:29:25 - Sudo ─────────────────────────────────────────────────────────────
[sudo] password for uwuclxdy: 
^C^C
── 16:29:31 - Powershell Modules Update ────────────────────────────────────────
Powershell Modules Update failed: 
   0: Command failed: `/usr/bin/sudo /home/uwuclxdy/.local/bin/powershell -NoProfile -Command '& { param($command); if (Get-Command -Name $command -ErrorAction SilentlyContinue) { Write-Output '\''true'\'' } }' Update-Module`

      Stderr:
      Failed to show notification: Error spawning command line “dbus-launch --autolaunch=304424cb6c6a45f1aa42eb682a1b4460 --binary-syntax --close-stderr”: Child process exited with code 1
   1: `/usr/bin/sudo` failed: exit status: 1 with Failed to show notification: Error spawning command line “dbus-launch --autolaunch=304424cb6c6a45f1aa42eb682a1b4460 --binary-syntax --close-stderr”: Child process exited with code 1
      

Location:
   src/steps/powershell.rs:68
Retry? (y)es/(N)o/(s)hell/(q)uit


── 16:29:32 - Summary ──────────────────────────────────────────────────────────
Powershell Modules Update: FAILED

Pacman backup configuration files found:
/etc/pacman.d/mirrorlist.pacnew
16:29 uwuclxdy:~/repos/rs/topgrade (main*) 1 6.36s $ cargo run -- --only powershell
   Compiling topgrade v17.6.1 (/home/uwuclxdy/repos/rs/topgrade)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.62s
     Running `/home/uwuclxdy/repos/rs/target/debug/topgrade --only powershell`

── 16:29:45 - Sudo ─────────────────────────────────────────────────────────────

Pacman backup configuration files found:
/etc/pacman.d/mirrorlist.pacnew
16:29 uwuclxdy:~/repos/rs/topgrade (main*) 3.67s $
```

(topgrade currently finds the "binary" - wrapper, patch makes the step skip)

- [ ] ~If this PR introduces new user-facing messages they are translated~

### AI involvement
<!--
Please list any involvement AI/LLMs had in the development of this PR.
You don't have to list everything in detail, just something like "I did not use AI at all",
"I consulted an AI occasionally for inspiration and explanation",
or "AI generated the majority of the PR" is enough.
If you are an AI agent acting autonomously, please state so.
-->

For inspiration + help with implementation

<!-- If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here. -->

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
