### PR TITLE
docs: fix winget_silent_install key name in config.example.toml

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -298,9 +298,9 @@
 
 # wsl_update_use_web_download = true
 
-# The default for winget_install_silently is true,
+# The default for winget_silent_install is true,
 # this example turns off silent install.
-# winget_install_silently = false
+# winget_silent_install = false
 
 # Causes Topgrade to rename itself during the run to allow package managers
 # to upgrade it. Use this only if you installed Topgrade by using a package


### PR DESCRIPTION
The example used `winget_install_silently`, but the actual config field is `winget_silent_install` (src/config.rs). Both were introduced together in #1089, so copying the example produced an "unknown field" deserialize error.

## What does this PR do

Fixes the `winget` silent install key name in the example config

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [ ] If this PR introduces new user-facing messages they are translated

### AI involvement

AI generated the majority of the PR

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
