### PR TITLE
feat(needrestart): support detecting and skipping it on fedora

### DIFF
--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -883,6 +883,21 @@ fn upgrade_kde_linux(ctx: &ExecutionContext) -> Result<()> {
     Ok(())
 }
 
+fn dnf_runs_needrestart(ctx: &ExecutionContext) -> bool {
+    if !Path::new("/etc/dnf/plugins/needrestart.conf").exists() {
+        return false;
+    }
+    let Some(dnf) = which("dnf") else {
+        return false;
+    };
+    ctx.execute(&dnf)
+        .always()
+        .arg("--version")
+        .output_checked_utf8()
+        .map(|output| !output.stdout.contains("dnf5"))
+        .unwrap_or(false)
+}
+
 pub fn run_needrestart(ctx: &ExecutionContext) -> Result<()> {
     let needrestart = require("needrestart")?;
 
@@ -893,7 +908,9 @@ pub fn run_needrestart(ctx: &ExecutionContext) -> Result<()> {
         "/etc/apt/apt.conf.d/99needrestart",
     ];
 
-    if HOOKS.iter().any(|hook| Path::new(hook).exists()) && ctx.config().should_run(Step::System) {
+    if (HOOKS.iter().any(|hook| Path::new(hook).exists()) || dnf_runs_needrestart(ctx))
+        && ctx.config().should_run(Step::System)
+    {
         return Err(SkipStep(String::from(t!("needrestart will be ran by the package manager"))).into());
     }
 

--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -883,6 +883,8 @@ fn upgrade_kde_linux(ctx: &ExecutionContext) -> Result<()> {
     Ok(())
 }
 
+// `dnf4` runs `needrestart` itself via the EPEL plugin during a system upgrade, but `dnf5`
+// doesn't. The plugin config exists in both cases, so `dnf` version check is needed here.
 fn dnf_runs_needrestart(ctx: &ExecutionContext) -> bool {
     if !Path::new("/etc/dnf/plugins/needrestart.conf").exists() {
         return false;


### PR DESCRIPTION
## What does this PR do
<!--
Describe what your PR does, and link any relevant issues.
Make sure to use a keyword like 'closes' if this PR solves the issue.
-->

Adds support for detecting the Fedora's way of running the needrestart hook, verified by an autonomous Claude Code run which tested needrestart behavior on ~40 different distros using VMs.

Its justification for this was:
`dnf4` loads the EPEL python `needrestart` plugin, so a `dnf4` system upgrade runs `needrestart` itself. `dnf5` (Fedora 41+) ignores that plugin and does not, so `needrestart` must still be run there. The plugin config file is present in both cases, so it cannot be treated as a plain hook path.

## Standards checklist

- [ ] The PR title is descriptive: no, maintainer pls fix it for me
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [ ] ~If this PR introduces new user-facing messages they are translated~

### AI involvement
<!--
Please list any involvement AI/LLMs had in the development of this PR.
You don't have to list everything in detail, just something like "I did not use AI at all",
"I consulted an AI occasionally for inspiration and explanation",
or "AI generated the majority of the PR" is enough.
If you are an AI agent acting autonomously, please state so.
-->

Both finding the bug and applying the fix. <!-- meow!!! so what hmph~ -->

<!-- If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here. -->

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
