### PR TITLE
NOSQUASH: feat(mise): support Windows

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -333,9 +333,8 @@
 # (default: false)
 # bump = false
 
-# Number of jobs to run in parallel
-# (default: 4)
-# jobs = 4
+# Number of jobs to run in parallel (mise's default)
+# jobs = 8
 
 # Run interactively
 # (default: false)

--- a/src/config.rs
+++ b/src/config.rs
@@ -2218,8 +2218,8 @@ impl Config {
             .unwrap_or(false)
     }
 
-    pub fn mise_jobs(&self) -> u32 {
-        self.config_file.mise.as_ref().and_then(|mise| mise.jobs).unwrap_or(4)
+    pub fn mise_jobs(&self) -> Option<u32> {
+        self.config_file.mise.as_ref().and_then(|mise| mise.jobs)
     }
 
     pub fn mise_interactive(&self) -> bool {

--- a/src/step.rs
+++ b/src/step.rs
@@ -474,11 +474,7 @@ impl Step {
                 runner.execute(*self, "Microsoft Store", || windows::microsoft_store(ctx))?
             }
             Miktex => runner.execute(*self, "miktex", || generic::run_miktex_packages_update(ctx))?,
-            Mise =>
-            {
-                #[cfg(unix)]
-                runner.execute(*self, "mise", || unix::run_mise(ctx))?
-            }
+            Mise => runner.execute(*self, "mise", || generic::run_mise(ctx))?,
             Myrepos => runner.execute(*self, "myrepos", || generic::run_myrepos_update(ctx))?,
             Nix => {
                 #[cfg(unix)]

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -2355,3 +2355,64 @@ pub fn run_ollama_pull(ctx: &ExecutionContext) -> Result<()> {
 
     pull_result
 }
+
+pub fn run_mise(ctx: &ExecutionContext) -> Result<()> {
+    let mise = require("mise")?;
+
+    print_separator("mise");
+
+    ctx.execute(&mise).args(["plugins", "update"]).status_checked()?;
+
+    let output = ctx
+        .execute(&mise)
+        .args(["self-update"])
+        .output_checked_with(|_| Ok(()))?;
+    let status_code = output
+        .status
+        .code()
+        .ok_or_eyre("Couldn't get status code (terminated by signal)")?;
+    let stderr = std::str::from_utf8(&output.stderr).wrap_err("Expected output to be valid UTF-8")?;
+    if stderr.contains("cannot update") && status_code == 1 {
+        debug!("Mise self-update not available")
+    } else {
+        std::io::stdout().lock().write_all(&output.stdout)?;
+        std::io::stderr().lock().write_all(&output.stderr)?;
+        if status_code != 0 {
+            return Err(StepFailed.into());
+        }
+    }
+
+    let mut cmd = ctx.execute(&mise);
+
+    cmd.arg("upgrade");
+
+    if ctx.config().mise_interactive() {
+        cmd.arg("--interactive");
+    }
+
+    if ctx.config().mise_bump() {
+        cmd.arg("--bump");
+    }
+
+    if ctx.config().mise_silent() {
+        cmd.arg("--silent");
+    }
+
+    if ctx.config().mise_quiet() {
+        cmd.arg("--quiet");
+    }
+
+    if ctx.config().mise_verbose() {
+        cmd.arg("--verbose");
+    }
+
+    if ctx.config().yes(Step::Mise) {
+        cmd.arg("--yes");
+    }
+
+    if ctx.config().mise_jobs() != 4 {
+        cmd.args(["--jobs", &ctx.config().mise_jobs().to_string()]);
+    }
+
+    cmd.status_checked()
+}

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -2410,8 +2410,8 @@ pub fn run_mise(ctx: &ExecutionContext) -> Result<()> {
         cmd.arg("--yes");
     }
 
-    if ctx.config().mise_jobs() != 4 {
-        cmd.args(["--jobs", &ctx.config().mise_jobs().to_string()]);
+    if let Some(jobs) = ctx.config().mise_jobs() {
+        cmd.args(["--jobs", &jobs.to_string()]);
     }
 
     cmd.status_checked()

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -1,6 +1,8 @@
 use color_eyre::eyre::Context;
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+use color_eyre::eyre::OptionExt;
 use color_eyre::eyre::Result;
-use color_eyre::eyre::{OptionExt, bail, eyre};
+use color_eyre::eyre::{bail, eyre};
 use etcetera::BaseStrategy;
 use ini::Ini;
 use regex::Regex;
@@ -8,13 +10,12 @@ use rust_i18n::t;
 use semver::Version;
 use std::env::home_dir;
 use std::ffi::OsStr;
-use std::io::Write;
+use std::fs;
 use std::os::unix::fs::MetadataExt;
 use std::path::Component;
 use std::path::PathBuf;
 use std::sync::LazyLock;
 use std::{env::var, path::Path};
-use std::{fs, io};
 use tracing::{debug, warn};
 
 use crate::XDG_DIRS;
@@ -867,68 +868,6 @@ pub fn run_asdf(ctx: &ExecutionContext) -> Result<()> {
     }
 
     ctx.execute(&asdf).args(["plugin", "update", "--all"]).status_checked()
-}
-
-pub fn run_mise(ctx: &ExecutionContext) -> Result<()> {
-    let mise = require("mise")?;
-
-    print_separator("mise");
-
-    ctx.execute(&mise).args(["plugins", "update"]).status_checked()?;
-
-    let output = ctx
-        .execute(&mise)
-        .args(["self-update"])
-        .output_checked_with(|_| Ok(()))?;
-    let status_code = output
-        .status
-        .code()
-        .ok_or_eyre("Couldn't get status code (terminated by signal)")?;
-    let stderr = std::str::from_utf8(&output.stderr).wrap_err("Expected output to be valid UTF-8")?;
-    if stderr.contains("cannot update") && status_code == 1 {
-        debug!("Mise self-update not available")
-    } else {
-        // Write the output
-        io::stdout().write_all(&output.stdout)?;
-        io::stderr().write_all(&output.stderr)?;
-        if status_code != 0 {
-            return Err(StepFailed.into());
-        }
-    }
-
-    let mut cmd = ctx.execute(&mise);
-
-    cmd.arg("upgrade");
-
-    if ctx.config().mise_interactive() {
-        cmd.arg("--interactive");
-    }
-
-    if ctx.config().mise_bump() {
-        cmd.arg("--bump");
-    }
-
-    if ctx.config().mise_silent() {
-        cmd.arg("--silent");
-    }
-
-    if ctx.config().mise_quiet() {
-        cmd.arg("--quiet");
-    }
-
-    if ctx.config().mise_verbose() {
-        cmd.arg("--verbose");
-    }
-
-    if ctx.config().yes(Step::Mise) {
-        cmd.arg("--yes");
-    }
-
-    if ctx.config().mise_jobs() != 4 {
-        cmd.args(["--jobs", &ctx.config().mise_jobs().to_string()]);
-    }
-
-    cmd.status_checked()
 }
 
 pub fn run_home_manager(ctx: &ExecutionContext) -> Result<()> {


### PR DESCRIPTION
The mise step was gated to Unix. Move it into the shared module and run it everywhere, since mise works on Windows too.

## What does this PR do

This implements #2111.

`mise` is a key piece of my dotfiles setup these days.  I've added `topgrade` recently, but have missed the support on Windows.  The 'fix' is fairly straightforward - and just shifts the module from unix to shared, so its supported on Windows.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.

```
―― mise ――
mise is already up to date
mise All tools are up to date
―― Summary ――
mise: OK
```

- [ ] If this PR introduces new user-facing messages they are translated

### AI involvement
Heavy.  AI did the code move and drove local testing.  I have also evaluated it myself.
The AI-driven testing produced local builds in Linux & Windows, ensured `mise` was called appropriately with a dry-run and real execution just to be sure.

## For new steps

<!-- This section can be deleted if you are not adding a new step. -->

- [x] *Optional:* Topgrade skips this step where needed
- [x] *Optional:* The `--dry-run` option works with this step
- [x] *Optional:* The `--yes` option works with this step if it is supported by
  the underlying command


<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->

