### PR TITLE
fix(mise): refresh process env after upgrade

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -8,6 +8,7 @@ use regex::bytes::Regex;
 use rust_i18n::t;
 use semver::Version;
 use serde::Deserialize;
+use std::collections::BTreeMap;
 use std::ffi::OsString;
 #[cfg(unix)]
 use std::fs::remove_dir_all;
@@ -2424,5 +2425,39 @@ pub fn run_mise(ctx: &ExecutionContext) -> Result<()> {
         cmd.args(["--jobs", &jobs.to_string()]);
     }
 
-    cmd.status_checked()
+    cmd.status_checked()?;
+
+    refresh_mise_env(ctx, &mise)
+}
+
+/// Refresh the process environment after `mise upgrade` so later steps and binary
+/// lookups resolve the upgraded mise-managed tools. `mise env --json` reports the
+/// activated environment, which we apply to the `PATH`/vars that child commands inherit.
+/// See <https://github.com/topgrade-rs/topgrade/issues/2041>.
+fn refresh_mise_env(ctx: &ExecutionContext, mise: &Path) -> Result<()> {
+    if ctx.run_type().dry() {
+        return Ok(());
+    }
+
+    let output = ctx
+        .execute(mise)
+        .args(["env", "--json"])
+        .output_checked()
+        .wrap_err("failed to run `mise env --json`")?;
+    let raw = std::str::from_utf8(&output.stdout).wrap_err("`mise env --json` output was not UTF-8")?;
+    let vars = parse_mise_env_json(raw)?;
+
+    for (key, value) in vars {
+        // SAFETY: `set_var` is not thread-safe; this mirrors the existing `env::set_var`
+        // calls in `main.rs` and `steps/zsh.rs`. Steps run sequentially, so the only
+        // concurrent reader is the sudo keep-alive loop, the same pre-existing condition
+        // those call sites already accept.
+        unsafe { std::env::set_var(key, value) };
+    }
+    debug!("Refreshed process environment from mise");
+    Ok(())
+}
+
+fn parse_mise_env_json(raw: &str) -> Result<BTreeMap<String, String>> {
+    serde_json::from_str(raw).wrap_err("failed to parse mise environment JSON")
 }

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -2445,7 +2445,7 @@ fn refresh_mise_env(ctx: &ExecutionContext, mise: &Path) -> Result<()> {
         .output_checked()
         .wrap_err("failed to run `mise env --json`")?;
     let raw = std::str::from_utf8(&output.stdout).wrap_err("`mise env --json` output was not UTF-8")?;
-    let vars = parse_mise_env_json(raw)?;
+    let vars: BTreeMap<String, String> = serde_json::from_str(raw).wrap_err("failed to parse mise environment JSON")?;
 
     for (key, value) in vars {
         // SAFETY: `set_var` is not thread-safe; this mirrors the existing `env::set_var`
@@ -2456,8 +2456,4 @@ fn refresh_mise_env(ctx: &ExecutionContext, mise: &Path) -> Result<()> {
     }
     debug!("Refreshed process environment from mise");
     Ok(())
-}
-
-fn parse_mise_env_json(raw: &str) -> Result<BTreeMap<String, String>> {
-    serde_json::from_str(raw).wrap_err("failed to parse mise environment JSON")
 }


### PR DESCRIPTION
## What does this PR do
<!--
Describe what your PR does, and link any relevant issues.
Make sure to use a keyword like 'closes' if this PR solves the issue.
-->

Fixes #2041
Supersedes, closes #2082

This PR runs `mise env --json` right after `mise upgrade` and writes the result back with `std::env::set_var`. Child commands pick up the new `PATH` and env vars on their own, without a separate command-resolution path. It's the same `env::set_var` approach already used in `main.rs` and `steps/zsh.rs`.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
    - **Anyone that had the Mise issue is welcome to test if this fixes it.**
- [ ] ~If this PR introduces new user-facing messages they are translated~

### AI involvement
<!--
Please list any involvement AI/LLMs had in the development of this PR.
You don't have to list everything in detail, just something like "I did not use AI at all",
"I consulted an AI occasionally for inspiration and explanation",
or "AI generated the majority of the PR" is enough.
If you are an AI agent acting autonomously, please state so.
-->

An LLM generated the entirety of this PR. <!-- topgrade will soon be just ai generated code rip 😿 -->

<!-- If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here. -->

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
