### PR TITLE
fix(skills): find lock file via XDG_STATE_HOME

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -2225,7 +2225,8 @@ pub fn run_skills(ctx: &ExecutionContext) -> Result<()> {
     {
         Some(state) => Path::new(state).join("skills"),
         None => HOME_DIR.join(".agents"),
-    }.join(".skill-lock.json");
+    }
+    .join(".skill-lock.json");
 
     if !skill_lock.exists() {
         return Err(SkipStep(format!("No skill lock file found at {}", skill_lock.display())).into());

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -2223,9 +2223,9 @@ pub fn run_skills(ctx: &ExecutionContext) -> Result<()> {
         .as_deref()
         .filter(|state| !state.is_empty())
     {
-        Some(state) => Path::new(state).join("skills").join(".skill-lock.json"),
-        None => HOME_DIR.join(".agents").join(".skill-lock.json"),
-    };
+        Some(state) => Path::new(state).join("skills"),
+        None => HOME_DIR.join(".agents"),
+    }.join(".skill-lock.json");
 
     if !skill_lock.exists() {
         return Err(SkipStep(format!("No skill lock file found at {}", skill_lock.display())).into());

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -2217,9 +2217,16 @@ pub fn run_colima(ctx: &ExecutionContext) -> Result<()> {
 pub fn run_skills(ctx: &ExecutionContext) -> Result<()> {
     let npx = require("npx")?;
 
-    let skill_lock = HOME_DIR.join(".agents").join(".skill-lock.json");
+    let skill_lock = match env::var_os("XDG_STATE_HOME")
+        .as_deref()
+        .filter(|state| !state.is_empty())
+    {
+        Some(state) => Path::new(state).join("skills").join(".skill-lock.json"),
+        None => HOME_DIR.join(".agents").join(".skill-lock.json"),
+    };
+
     if !skill_lock.exists() {
-        return Err(SkipStep("No ~/.agents/.skill-lock.json found".to_string()).into());
+        return Err(SkipStep(format!("No skill lock file found at {}", skill_lock.display())).into());
     }
 
     print_separator("Skills");

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -2217,6 +2217,8 @@ pub fn run_colima(ctx: &ExecutionContext) -> Result<()> {
 pub fn run_skills(ctx: &ExecutionContext) -> Result<()> {
     let npx = require("npx")?;
 
+    // Can't use XDG_DIRS since its `state_dir()` falls back to `~/.local/state` instead
+    // of `~/.agents` and it'd also break on non-unix systems
     let skill_lock = match env::var_os("XDG_STATE_HOME")
         .as_deref()
         .filter(|state| !state.is_empty())


### PR DESCRIPTION
## What does this PR do
<!--
Describe what your PR does, and link any relevant issues.
Make sure to use a keyword like 'closes' if this PR solves the issue.
-->

Closes #2110.

The step now finds the lock the same way `npx skills` does, with `~/.agents/.skill-lock.json` as the fallback.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [ ] ~If this PR introduces new user-facing messages they are translated~

### AI involvement
<!--
Please list any involvement AI/LLMs had in the development of this PR.
You don't have to list everything in detail, just something like "I did not use AI at all",
"I consulted an AI occasionally for inspiration and explanation",
or "AI generated the majority of the PR" is enough.
If you are an AI agent acting autonomously, please state so.
-->

For issue reproduction, testing that this PR fixes it and review.

<!-- If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here. -->

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
