### PR TITLE
NOSQUASH: fix(steps): prevent shell command injection

### DIFF
--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -237,7 +237,7 @@ pub fn run_bashit(ctx: &ExecutionContext) -> Result<()> {
     print_separator("Bash-it");
 
     ctx.execute("bash")
-        .args(["-lic", &format!("bash-it update {}", ctx.config().bashit_branch())])
+        .args(["-lic", r#"bash-it update "$1""#, "bash", ctx.config().bashit_branch()])
         .status_checked()
 }
 

--- a/src/steps/os/windows.rs
+++ b/src/steps/os/windows.rs
@@ -145,41 +145,23 @@ fn upgrade_wsl_distribution(wsl: &Path, dist: &str, ctx: &ExecutionContext) -> R
 
     let mut command = ctx.execute(wsl);
 
-    // The `arg` method automatically quotes its arguments.
-    // This means we can't append additional arguments to `topgrade` in WSL
-    // by calling `arg` successively.
-    //
-    // For example:
-    //
-    // ```rust
-    // command
-    //  .args(["-d", dist, "bash", "-lc"])
-    //  .arg(format!("TOPGRADE_PREFIX={dist} exec {topgrade}"));
-    // ```
-    //
-    // creates a command string like:
-    // > `C:\WINDOWS\system32\wsl.EXE -d Ubuntu bash -lc 'TOPGRADE_PREFIX=Ubuntu exec /bin/topgrade'`
-    //
-    // Adding the following:
-    //
-    // ```rust
-    // command.arg("-v");
-    // ```
-    //
-    // appends the next argument like so:
-    // > `C:\WINDOWS\system32\wsl.EXE -d Ubuntu bash -lc 'TOPGRADE_PREFIX=Ubuntu exec /bin/topgrade' -v`
-    // which means `-v` isn't passed to `topgrade`.
-    let mut args = String::new();
-    if ctx.config().verbose() {
-        args.push_str("-v");
-    }
-
+    // Pass the distro name, discovered topgrade path, and forwarded flags as
+    // positional parameters so the inner `bash -lc` receives them as single argv
+    // elements instead of parsing their contents. `"${@:3}"` forwards the flags
+    // to `topgrade` (not `bash`) and expands to nothing when there are none.
     command
-        .args(["-d", dist, "bash", "-lc"])
-        .arg(format!("TOPGRADE_PREFIX={dist} exec {topgrade} {args}"));
-
-    if ctx.config().yes(Step::Wsl) {
-        command.arg("-y");
+        .args([
+            "-d",
+            dist,
+            "bash",
+            "-lc",
+            r#"TOPGRADE_PREFIX="$1" exec "$2" "${@:3}""#,
+            "bash",
+        ])
+        .arg(dist)
+        .arg(&topgrade);
+    if ctx.config().verbose() {
+        command.arg("-v");
     }
 
     command.status_checked()

--- a/src/steps/os/windows.rs
+++ b/src/steps/os/windows.rs
@@ -163,6 +163,9 @@ fn upgrade_wsl_distribution(wsl: &Path, dist: &str, ctx: &ExecutionContext) -> R
     if ctx.config().verbose() {
         command.arg("-v");
     }
+    if ctx.config().yes(Step::Wsl) {
+        command.arg("-y");
+    }
 
     command.status_checked()
 }

--- a/src/steps/remote/vagrant.rs
+++ b/src/steps/remote/vagrant.rs
@@ -196,7 +196,10 @@ pub fn topgrade_vagrant_box(ctx: &ExecutionContext, vagrant_box: &VagrantBox) ->
     } else {
         print_separator(separator);
     }
-    let mut command = format!("env TOPGRADE_PREFIX={} topgrade", vagrant_box.smart_name());
+    let mut command = format!(
+        "env TOPGRADE_PREFIX={} topgrade",
+        shell_words::quote(vagrant_box.smart_name())
+    );
     if ctx.config().yes(Step::Vagrant) {
         command.push_str(" -y");
     }

--- a/src/steps/zsh.rs
+++ b/src/steps/zsh.rs
@@ -54,8 +54,8 @@ pub fn run_antidote(ctx: &ExecutionContext) -> Result<()> {
         AntidoteUpdate::Shell => ctx.execute(zsh).args(["-i", "-c", "antidote update"]).status_checked(),
         AntidoteUpdate::Source(antidote) => ctx
             .execute(zsh)
-            .arg("-c")
-            .arg(format!("source {} && antidote update", antidote.display()))
+            .args(["-c", r#"source "$1" && antidote update"#, "zsh"])
+            .arg(&antidote)
             .status_checked(),
     }
 }


### PR DESCRIPTION
## What does this PR do
<!--
Describe what your PR does, and link any relevant issues.
Make sure to use a keyword like 'closes' if this PR solves the issue.
-->

Closes #2117

3 steps build a shell command with `format!()` and run the result through a shell, dropping a value straight into the command string. When that value contains shell metacharacters, the shell executes them instead of treating the value as data. Several of those values aren't fully under the running user's control: a WSL distro name, a Vagrant box or directory name, the antidote path that comes from `$ZDOTDIR`/`$HOME`, or the `bashit_branch` config field.

The fix hands each value to the shell as a positional parameter (`"$1"`), so the shell takes it as one argument and never looks inside it:

- bash-it: `bashit_branch` into `bash -lic 'bash-it update "$1"'` (`src/steps/os/unix.rs`)
- WSL: the distro name and discovered topgrade path into `bash -lc` (`src/steps/os/windows.rs`)
- antidote: the `.antidote/antidote.zsh` path into `zsh -c 'source "$1" && antidote update'` (`src/steps/zsh.rs`)

Vagrant is the one exception. `vagrant ssh -c` only takes a single command string and gives you no way to pass positional arguments, so its box name is `shell_words::quote`d instead.

The second commit in this PR fixes #558 (related issue): WSL's `--yes` was tacked onto the outer `bash` call, so it was swallowed as an unread shell positional and never reached topgrade.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [ ] ~If this PR introduces new user-facing messages they are translated~

### AI involvement
<!--
Please list any involvement AI/LLMs had in the development of this PR.
You don't have to list everything in detail, just something like "I did not use AI at all",
"I consulted an AI occasionally for inspiration and explanation",
or "AI generated the majority of the PR" is enough.
If you are an AI agent acting autonomously, please state so.
-->

[hyaline](https://github.com/uwuclxdy/hyaline) and Claude Code for autonomous vulnerability discovery and writing the fix. <!-- free advertisement ezz + here u go with another slop pr have fun :3 -->

<!-- If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here. -->

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
