### PR TITLE
feat(shelly): Update CLI syntax, show news and skip flatpak

### DIFF
--- a/src/steps/os/archlinux.rs
+++ b/src/steps/os/archlinux.rs
@@ -328,7 +328,6 @@ impl Shelly {
 
 impl ArchPackageManager for Shelly {
     fn upgrade(&self, ctx: &ExecutionContext) -> Result<()> {
-
         if ctx.config().show_arch_news() {
             let mut cmd = ctx.execute(&self.executable);
             cmd.arg("news");
@@ -349,8 +348,11 @@ impl ArchPackageManager for Shelly {
 
         let mut cmd = ctx.execute(&self.executable);
         cmd.arg("upgrade-all")
-            .arg("--no-flatpak")
             .args(ctx.config().shelly_arguments().split_whitespace());
+
+        if ctx.config().should_run(Step::Flatpak) {
+            cmd.arg("--no-flatpak");
+        }
 
         if ctx.config().yes(Step::System) {
             cmd.arg("--no-confirm");

--- a/src/steps/os/archlinux.rs
+++ b/src/steps/os/archlinux.rs
@@ -328,18 +328,18 @@ impl Shelly {
 
 impl ArchPackageManager for Shelly {
     fn upgrade(&self, ctx: &ExecutionContext) -> Result<()> {
-        let mut cmd = ctx.execute(&self.executable);
 
-        cmd.arg("news").args(ctx.config().shelly_arguments().split_whitespace());
-
-        if ctx.config().yes(Step::System) {
-            cmd.arg("--no-confirm");
+        if ctx.config().show_arch_news() {
+            let mut cmd = ctx.execute(&self.executable);
+            cmd.arg("news");
+            if ctx.config().yes(Step::System) {
+                cmd.arg("--no-confirm");
+            }
+            cmd.status_checked()?;
         }
 
-        cmd.status_checked()?;
-
         let mut cmd = ctx.execute(&self.executable);
-        cmd.arg("sync").args(ctx.config().shelly_arguments().split_whitespace());
+        cmd.arg("sync");
 
         if ctx.config().yes(Step::System) {
             cmd.arg("--no-confirm");

--- a/src/steps/os/archlinux.rs
+++ b/src/steps/os/archlinux.rs
@@ -328,19 +328,35 @@ impl Shelly {
 
 impl ArchPackageManager for Shelly {
     fn upgrade(&self, ctx: &ExecutionContext) -> Result<()> {
-        let mut command = ctx.execute(&self.executable);
+        let mut cmd = ctx.execute(&self.executable);
 
-        command
-            .arg("upgrade")
-            .arg("--all")
-            .arg("--sync")
+        cmd.arg("news").args(ctx.config().shelly_arguments().split_whitespace());
+
+        if ctx.config().yes(Step::System) {
+            cmd.arg("--no-confirm");
+        }
+
+        cmd.status_checked()?;
+
+        let mut cmd = ctx.execute(&self.executable);
+        cmd.arg("sync").args(ctx.config().shelly_arguments().split_whitespace());
+
+        if ctx.config().yes(Step::System) {
+            cmd.arg("--no-confirm");
+        }
+
+        cmd.status_checked()?;
+
+        let mut cmd = ctx.execute(&self.executable);
+        cmd.arg("upgrade-all")
+            .arg("--no-flatpak")
             .args(ctx.config().shelly_arguments().split_whitespace());
 
         if ctx.config().yes(Step::System) {
-            command.arg("--no-confirm");
+            cmd.arg("--no-confirm");
         }
 
-        command.status_checked()?;
+        cmd.status_checked()?;
 
         Ok(())
     }


### PR DESCRIPTION

## What does this PR do
<!--
Describe what your PR does, and link any relevant issues.
Make sure to use a keyword like 'closes' if this PR solves the issue.
-->

This PR fixes the outdated shelly CLI syntax which currently prevents this option from working properly.
To prevent redundant execution I added the flag `--no-flatpak` by default as topgrade already contains designated logic to upgrade flatpaks.
I also added `shelly news` at the beginning. It displays the arch news and remembers which ones have already been read. I think this makes sense on arch systems so the setup can be cancelled in time if manual intervention is required.

All those commands support the `--no-confirm` option.

For further reading about the new syntax: https://www.seafoam-labs.org/shelly-alpm/docs/cli-reference/

Closes #2122 

## Standards checklist

- [X] The PR title is descriptive
- [X] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [X] If this PR introduces new user-facing messages they are translated <- not needed as shelly is already translated

### AI involvement
<!--
Please list any involvement AI/LLMs had in the development of this PR.
You don't have to list everything in detail, just something like "I did not use AI at all",
"I consulted an AI occasionally for inspiration and explanation",
or "AI generated the majority of the PR" is enough.
If you are an AI agent acting autonomously, please state so.
-->

Used AI to explain some of the syntax (as I have zero rust experience; In fact this is my first PR on github ever). The code itself has no AI involvement.

## For new steps

<!-- This section can be deleted if you are not adding a new step. -->

- [ ] *Optional:* Topgrade skips this step where needed
- [X] *Optional:* The `--dry-run` option works with this step
- [X] *Optional:* The `--yes` option works with this step if it is supported by
  the underlying command

```
topgrade --dry-run

── 10:37:41 - System update ────────────────────────────────────────────────────
Dry running: /usr/bin/shelly news
Dry running: /usr/bin/shelly sync
Dry running: /usr/bin/shelly upgrade-all --no-flatpak
```

<!-- If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here. -->

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
