### PR TITLE
fix(config): stop creating `topgrade.d/`

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ If the file with higher priority is present, no matter if it is valid or not, th
 ignored.
 
 On the first run (provided that no configuration file exists), `topgrade` will create a configuration file at
-`CONFIG_DIR/topgrade.toml` for you.
+`CONFIG_DIR/topgrade.toml` for you. Any files in `CONFIG_DIR/topgrade.d/` are also loaded and merged before the main
+configuration file.
 
 ### Custom Commands
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -772,9 +772,8 @@ impl ConfigFile {
             return Ok(res);
         }
 
-        let entries = fs::read_dir(&dir_to_search).inspect_err(|_| {
-            error!("Unable to read {}", dir_to_search.display());
-        })?;
+        let entries =
+            fs::read_dir(&dir_to_search).wrap_err_with(|| format!("Unable to read {}", dir_to_search.display()))?;
 
         for entry in entries {
             let entry_path = entry?.path();

--- a/src/config.rs
+++ b/src/config.rs
@@ -743,7 +743,7 @@ impl ConfigFile {
             }
         }
 
-        res.1 = Self::ensure_topgrade_d(&config_directory)?;
+        res.1 = Self::find_topgrade_d_configs(&config_directory)?;
 
         // If no config file exists, create a default one in the config directory
         if !res.0.exists() && res.1.is_empty() {
@@ -763,16 +763,20 @@ impl ConfigFile {
     }
 
     /// Searches topgrade.d for additional config files
-    fn ensure_topgrade_d(config_directory: &Path) -> Result<Vec<PathBuf>> {
+    fn find_topgrade_d_configs(config_directory: &Path) -> Result<Vec<PathBuf>> {
         let mut res = Vec::new();
         let dir_to_search = config_directory.join("topgrade.d");
 
         if !dir_to_search.exists() {
-            debug!("No additional configuration directory exists, creating one");
-            fs::create_dir_all(&dir_to_search)?;
+            debug!("No additional configuration directory exists, skipping");
+            return Ok(res);
         }
 
-        for entry in fs::read_dir(&dir_to_search)? {
+        let entries = fs::read_dir(&dir_to_search).inspect_err(|_| {
+            error!("Unable to read {}", dir_to_search.display());
+        })?;
+
+        for entry in entries {
             let entry_path = entry?.path();
 
             if entry_path.is_file() {
@@ -2321,6 +2325,29 @@ mod test {
         let str = include_str!("../config.example.toml");
 
         assert!(toml::from_str::<ConfigFile>(str).is_ok());
+    }
+
+    /// `topgrade.d` must not be auto-created, only read when present.
+    /// See: https://github.com/topgrade-rs/topgrade/issues/624
+    #[test]
+    fn test_topgrade_d_not_auto_created() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // Absent topgrade.d: contributes nothing and is not created.
+        let extra = ConfigFile::find_topgrade_d_configs(dir.path()).unwrap();
+        assert!(extra.is_empty(), "absent topgrade.d should yield no configs");
+        assert!(
+            !dir.path().join("topgrade.d").exists(),
+            "topgrade.d must not be auto-created"
+        );
+
+        // Present topgrade.d: files are picked up in sorted order.
+        let d = dir.path().join("topgrade.d");
+        std::fs::create_dir_all(&d).unwrap();
+        std::fs::write(d.join("b.toml"), "[misc]\n").unwrap();
+        std::fs::write(d.join("a.toml"), "[misc]\n").unwrap();
+        let extra = ConfigFile::find_topgrade_d_configs(dir.path()).unwrap();
+        assert_eq!(extra, vec![d.join("a.toml"), d.join("b.toml")]);
     }
 
     fn config() -> Config {


### PR DESCRIPTION
## What does this PR do
<!--
Describe what your PR does, and link any relevant issues.
Make sure to use a keyword like 'closes' if this PR solves the issue.
-->

Topgrade now doesn't automatically create `topgrade.d/` folder anymore. It only checks if it exists and merges those configs like before. Also added a line to the readme about this that was missing before.

ref #624

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [ ] ~If this PR introduces new user-facing messages they are translated~

### AI involvement
<!--
Please list any involvement AI/LLMs had in the development of this PR.
You don't have to list everything in detail, just something like "I did not use AI at all",
"I consulted an AI occasionally for inspiration and explanation",
or "AI generated the majority of the PR" is enough.
If you are an AI agent acting autonomously, please state so.
-->

Only for review and unit test generation.

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
