### PR TITLE
feat(step): add sera (KDE Plasma addon updater)

### DIFF
--- a/src/step.rs
+++ b/src/step.rs
@@ -156,6 +156,7 @@ pub enum Step {
     Scoop,
     Sdkman,
     SelfUpdate,
+    Sera,
     Sheldon,
     Shell,
     Skills,
@@ -604,6 +605,11 @@ impl Step {
                     }
                 }
             }
+            Sera =>
+            {
+                #[cfg(all(unix, not(any(target_os = "macos", target_os = "android"))))]
+                runner.execute(*self, "sera", || unix::run_sera(ctx))?
+            }
             Sheldon => runner.execute(*self, "sheldon", || generic::run_sheldon(ctx))?,
             Shell => {
                 #[cfg(unix)]
@@ -806,6 +812,7 @@ pub(crate) fn default_steps() -> Vec<Step> {
         Waydroid,
         AutoCpufreq,
         CinnamonSpices,
+        Sera,
         Mandb,
         Pkgfile,
         Yadm,

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -1138,6 +1138,7 @@ pub fn run_atuin(ctx: &ExecutionContext) -> Result<()> {
     ctx.execute(atuin).status_checked()
 }
 
+#[cfg(not(any(target_os = "android", target_os = "macos")))]
 pub fn run_sera(ctx: &ExecutionContext) -> Result<()> {
     let sera = require("sera")?;
 

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -1138,6 +1138,14 @@ pub fn run_atuin(ctx: &ExecutionContext) -> Result<()> {
     ctx.execute(atuin).status_checked()
 }
 
+pub fn run_sera(ctx: &ExecutionContext) -> Result<()> {
+    let sera = require("sera")?;
+
+    print_separator("sera");
+
+    ctx.execute(sera).arg("upgrade").status_checked()
+}
+
 pub fn reboot(ctx: &ExecutionContext) -> Result<()> {
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     if let Ok(()) = system_shutdown::reboot() {


### PR DESCRIPTION
## What does this PR do
Adds support for `sera`, a CLI updater for KDE Plasma addons (widgets, plugins, plasmoids).

Ref: https://gitlab.com/cscs/sera

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.

Dry run:
```
── 11:11:55 - sera ─────────────────────────────────────────────────────────────
Dry running: /home/jordan/.local/bin/sera upgrade

── 11:11:55 - Summary ──────────────────────────────────────────────────────────
sera: OK
```

Full run:
```
── 11:11:59 - sera ─────────────────────────────────────────────────────────────

✔ Fetching data from the API
✔ Checking widgets for updates
✔ Nothing to do


── 11:12:03 - Summary ──────────────────────────────────────────────────────────
sera: OK
```

- [ ] If this PR introduces new user-facing messages they are translated

### AI involvement
none

## For new steps

<!-- This section can be deleted if you are not adding a new step. -->

- [x] *Optional:* Topgrade skips this step where needed
- [x] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by
  the underlying command

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
