### PR TITLE
fix(wsl): skip Windows-path binaries in tool detection

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -250,6 +250,9 @@
 # Extra Home Manager arguments
 # home_manager_arguments = ["--flake", "file"]
 
+# Resolve tools from the Windows PATH (drive mounts like `/mnt/c`) while inside WSL.
+# Off by default so only the distro's own tools update (default: false).
+# wsl_use_windows_path = false
 
 [mandb]
 # Enable the mandb step (to update manual entries).

--- a/src/config.rs
+++ b/src/config.rs
@@ -381,6 +381,9 @@ pub struct Linux {
 
     #[merge(strategy = crate::utils::merge_strategies::vec_prepend_opt)]
     home_manager_arguments: Option<Vec<String>>,
+
+    #[merge(strategy = merge::option::overwrite_none)]
+    wsl_use_windows_path: Option<bool>,
 }
 
 #[derive(Deserialize, Default, Debug, Merge)]
@@ -1518,6 +1521,15 @@ impl Config {
             .windows
             .as_ref()
             .and_then(|w| w.wsl_update_use_web_download)
+            .unwrap_or(false)
+    }
+
+    /// Should tool detection keep using Windows PATH binaries (under `/mnt`) inside WSL
+    pub fn wsl_use_windows_path(&self) -> bool {
+        self.config_file
+            .linux
+            .as_ref()
+            .and_then(|l| l.wsl_use_windows_path)
             .unwrap_or(false)
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ use self::steps::{remote::*, *};
 use self::sudo::{Sudo, SudoCreateError, SudoKind};
 #[allow(clippy::wildcard_imports)]
 use self::terminal::*;
-use self::utils::{install_color_eyre, install_tracing, is_elevated, update_tracing};
+use self::utils::{install_color_eyre, install_tracing, is_elevated, set_wsl_use_windows_path, update_tracing};
 
 mod breaking_changes;
 mod command;
@@ -116,6 +116,7 @@ fn run() -> Result<()> {
     set_title(config.set_title());
     display_time(config.display_time());
     set_desktop_notifications(config.notify_each_step());
+    set_wsl_use_windows_path(config.wsl_use_windows_path());
 
     debug!("Version: {}", crate_version!());
     debug!("OS: {}", env!("TARGET"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,7 +116,7 @@ fn run() -> Result<()> {
     set_title(config.set_title());
     display_time(config.display_time());
     set_desktop_notifications(config.notify_each_step());
-    set_wsl_use_windows_path(config.wsl_use_windows_path());
+    set_wsl_use_windows_path(config.wsl_use_windows_path())?;
 
     debug!("Version: {}", crate_version!());
     debug!("OS: {}", env!("TARGET"));

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
-use color_eyre::eyre::Result;
+use color_eyre::eyre::{Result, eyre};
 use rust_i18n::t;
 
 use tracing::{debug, error, warn};
@@ -80,20 +80,17 @@ where
 /// default: off outside WSL, on inside.
 static WSL_USE_WINDOWS_PATH: OnceLock<bool> = OnceLock::new();
 
-pub fn set_wsl_use_windows_path(use_windows_path: bool) {
-    let _ = WSL_USE_WINDOWS_PATH.set(use_windows_path);
-}
-
-fn in_wsl() -> bool {
-    static IN_WSL: OnceLock<bool> = OnceLock::new();
-    *IN_WSL.get_or_init(|| crate::steps::generic::is_wsl().unwrap_or(false))
+pub fn set_wsl_use_windows_path(use_windows_path: bool) -> Result<()> {
+    WSL_USE_WINDOWS_PATH
+        .set(use_windows_path)
+        .map_err(|_| eyre!("WSL Windows-path setting was already initialized"))
 }
 
 /// Inside WSL a plain PATH lookup can resolve a Windows executable on `/mnt/*` that
 /// fails to run in the guest (topgrade-rs/topgrade#1243). When on, detection skips those.
 /// Off via `wsl_use_windows_path = true`.
 fn wsl_windows_path_filter_enabled() -> bool {
-    in_wsl() && !WSL_USE_WINDOWS_PATH.get().copied().unwrap_or(false)
+    crate::steps::generic::is_wsl().unwrap_or(false) && !WSL_USE_WINDOWS_PATH.get().copied().unwrap_or(false)
 }
 
 /// Mount points backed by Windows drives (drvfs on WSL1, 9p/virtiofs on WSL2).
@@ -142,16 +139,26 @@ fn which_native_in_wsl<T: AsRef<OsStr> + Debug>(binary_name: T) -> Option<PathBu
     };
 
     let prefixes = windows_mount_prefixes();
-    match candidates.find(|path| !is_windows_mount_path(path, prefixes)) {
+    let mut saw_candidate = false;
+    let native = candidates.find(|path| {
+        saw_candidate = true;
+        !is_windows_mount_path(path, prefixes)
+    });
+    match native {
         Some(path) => {
             debug!("Detected {:?} as {:?}", &path, &binary_name);
             Some(path)
         }
-        None => {
+        // Every PATH match was a Windows binary on a drive mount.
+        None if saw_candidate => {
             debug!(
                 "Cannot find native {:?} in PATH (only Windows binaries via WSL interop)",
                 &binary_name
             );
+            None
+        }
+        None => {
+            debug!("Cannot find {:?}", &binary_name);
             None
         }
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,11 +1,12 @@
 use std::ffi::OsStr;
 use std::fmt::Debug;
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 
 use color_eyre::eyre::Result;
 use rust_i18n::t;
 
-use tracing::{debug, error};
+use tracing::{debug, error, warn};
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::reload::{Handle, Layer};
 use tracing_subscriber::util::SubscriberInitExt;
@@ -75,7 +76,92 @@ where
     }
 }
 
+/// `[linux] wsl_use_windows_path`, set once at startup. While unset the filter keeps its
+/// default: off outside WSL, on inside.
+static WSL_USE_WINDOWS_PATH: OnceLock<bool> = OnceLock::new();
+
+pub fn set_wsl_use_windows_path(use_windows_path: bool) {
+    let _ = WSL_USE_WINDOWS_PATH.set(use_windows_path);
+}
+
+fn in_wsl() -> bool {
+    static IN_WSL: OnceLock<bool> = OnceLock::new();
+    *IN_WSL.get_or_init(|| crate::steps::generic::is_wsl().unwrap_or(false))
+}
+
+/// Inside WSL a plain PATH lookup can resolve a Windows executable on `/mnt/*` that
+/// fails to run in the guest (topgrade-rs/topgrade#1243). When on, detection skips those.
+/// Off via `wsl_use_windows_path = true`.
+fn wsl_windows_path_filter_enabled() -> bool {
+    in_wsl() && !WSL_USE_WINDOWS_PATH.get().copied().unwrap_or(false)
+}
+
+/// Mount points backed by Windows drives (drvfs on WSL1, 9p/virtiofs on WSL2).
+fn windows_mount_prefixes() -> &'static [PathBuf] {
+    static PREFIXES: OnceLock<Vec<PathBuf>> = OnceLock::new();
+    PREFIXES.get_or_init(|| {
+        // On a read failure the list stays empty, so the filter is inert (plain lookup).
+        let mounts = std::fs::read_to_string("/proc/mounts").unwrap_or_else(|e| {
+            warn!("Could not read /proc/mounts: {e}; WSL Windows-path filter stays inert");
+            String::new()
+        });
+        mounts
+            .lines()
+            .filter_map(|line| {
+                let mut cols = line.split_whitespace();
+                let _source = cols.next()?;
+                let mount_point = cols.next()?;
+                let fstype = cols.next()?;
+                let options = cols.next().unwrap_or("");
+                // A Windows drive is WSL1 drvfs, or a WSL2 9p/virtiofs mount tagged
+                // `aname=drvfs`. Keying on that tag rather than the fstype avoids WSL's own
+                // 9p/virtiofs mounts (/usr/lib/wsl/drivers, /mnt/wslg) and still catches a
+                // drive mounted via virtiofs.
+                (fstype == "drvfs" || options.contains("aname=drvfs")).then(|| PathBuf::from(mount_point))
+            })
+            .collect()
+    })
+}
+
+fn is_windows_mount_path(path: &Path, prefixes: &[PathBuf]) -> bool {
+    prefixes.iter().any(|prefix| path.starts_with(prefix))
+}
+
+/// `which`, but skips executables on Windows drive mounts.
+fn which_native_in_wsl<T: AsRef<OsStr> + Debug>(binary_name: T) -> Option<PathBuf> {
+    let mut candidates = match which_crate::which_all(&binary_name) {
+        Ok(candidates) => candidates,
+        Err(which_crate::Error::CannotFindBinaryPath) => {
+            debug!("Cannot find {:?}", &binary_name);
+            return None;
+        }
+        Err(e) => {
+            error!("Detecting {:?} failed: {}", &binary_name, e);
+            return None;
+        }
+    };
+
+    let prefixes = windows_mount_prefixes();
+    match candidates.find(|path| !is_windows_mount_path(path, prefixes)) {
+        Some(path) => {
+            debug!("Detected {:?} as {:?}", &path, &binary_name);
+            Some(path)
+        }
+        None => {
+            debug!(
+                "Cannot find native {:?} in PATH (only Windows binaries via WSL interop)",
+                &binary_name
+            );
+            None
+        }
+    }
+}
+
 pub fn which<T: AsRef<OsStr> + Debug>(binary_name: T) -> Option<PathBuf> {
+    if wsl_windows_path_filter_enabled() {
+        return which_native_in_wsl(&binary_name);
+    }
+
     match which_crate::which(&binary_name) {
         Ok(path) => {
             debug!("Detected {:?} as {:?}", &path, &binary_name);
@@ -97,6 +183,19 @@ pub fn which<T: AsRef<OsStr> + Debug>(binary_name: T) -> Option<PathBuf> {
 }
 
 pub fn require<T: AsRef<OsStr> + Debug>(binary_name: T) -> Result<PathBuf> {
+    if wsl_windows_path_filter_enabled() {
+        return which_native_in_wsl(&binary_name).ok_or_else(|| {
+            SkipStep(format!(
+                "{}",
+                t!(
+                    "Cannot find {binary_name} in PATH",
+                    binary_name = format!("{:?}", &binary_name)
+                )
+            ))
+            .into()
+        });
+    }
+
     match which_crate::which(&binary_name) {
         Ok(path) => {
             debug!("Detected {:?} as {:?}", &path, &binary_name);


### PR DESCRIPTION
## What does this PR do
<!--
Describe what your PR does, and link any relevant issues.
Make sure to use a keyword like 'closes' if this PR solves the issue.
-->

It fixes the crashes when running Topgrade inside WSL; Windows drives are exposed on `PATH` through interop, so a normal `which` usually resolves a Windows executable (e.g. `/mnt/c/Program Files/nodejs/npm`) that fails to run in the Linux environment.

This PR makes `utils::which` / `utils::require` skip executables under Windows drive mounts while running inside WSL: they return the first native `PATH` match, or `None` / `SkipStep` when every match is a Windows binary. Drives are read from `/proc/mounts` and matched by fstype `drvfs` (WSL1) or the `aname=drvfs` mount option (WSL2 `9p`/`virtiofs`); WSL's own system mounts like `/usr/lib/wsl/drivers` and `/mnt/wslg` are left out. This was tested and proven on a fresh Windows 11 installation (see logs below).

This behaviour is opt-out if for whatever reason you want the old one back: `[linux] wsl_use_windows_path = true`.
The filter is inert unless `is_wsl()`, so every other platform keeps the existing `which`.

Closes #1243.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.

Tested on WSL2 and WSL1 with a fake `flutter` on `/mnt/c`; `--only flutter --dry-run -v`:

<details>
  <summary>WSL2 (Ubuntu , kernel microsoft-standard-WSL2)</summary>

`/proc/mounts` shows two `9p` mounts; only the `aname=drvfs` one is a drive:

```
drivers /usr/lib/wsl/drivers 9p ro,...,aname=drivers;... 0 0         <- not a drive, left out
C:\134  /mnt/c              9p rw,...,aname=drvfs;path=C:\;... 0 0     <- drive, matched
```

```
===== BEFORE (HEAD, no filter): detects the Windows flutter and tries to run it =====
DEBUG Detected "/mnt/c/topgrade_wsl_repro/bin/flutter" as "flutter"
Dry running: /mnt/c/topgrade_wsl_repro/bin/flutter upgrade

===== AFTER (default filter on): skips the Windows flutter =====
DEBUG Cannot find native "flutter" in PATH (only Windows binaries via WSL interop)
Flutter: SKIPPED: Cannot find "flutter" in PATH

===== AFTER + escape hatch [linux] wsl_use_windows_path = true: Windows flutter again =====
DEBUG Detected "/mnt/c/topgrade_wsl_repro/bin/flutter" as "flutter"
Dry running: /mnt/c/topgrade_wsl_repro/bin/flutter upgrade
```

</details>

<details>
  <summary>WSL1 (Ubuntu-2404-WSL1, kernel 4.4.0-...-Microsoft)</summary>

```
C:\134 /mnt/c drvfs rw,noatime,uid=0,gid=0,case=off 0 0
```

`/mnt/c` fstype is literally `drvfs` (the other match arm).

```
===== BEFORE (HEAD, no filter): detects the drvfs flutter =====
DEBUG Detected "/mnt/c/topgrade_wsl_repro/bin/flutter" as "flutter"
Dry running: /mnt/c/topgrade_wsl_repro/bin/flutter upgrade

===== AFTER (default filter on): skips the drvfs flutter =====
DEBUG Cannot find native "flutter" in PATH (only Windows binaries via WSL interop)
Flutter: SKIPPED: Cannot find "flutter" in PATH

===== AFTER + escape hatch [linux] wsl_use_windows_path = true: drvfs flutter again =====
DEBUG Detected "/mnt/c/topgrade_wsl_repro/bin/flutter" as "flutter"
Dry running: /mnt/c/topgrade_wsl_repro/bin/flutter upgrade
```

</details>

All three pass on the `drvfs` arm too.

- [ ] ~If this PR introduces new user-facing messages they are translated~

### AI involvement
<!--
Please list any involvement AI/LLMs had in the development of this PR.
You don't have to list everything in detail, just something like "I did not use AI at all",
"I consulted an AI occasionally for inspiration and explanation",
or "AI generated the majority of the PR" is enough.
If you are an AI agent acting autonomously, please state so.
-->

Claude generated most of the fix and ran the WSL2/WSL1 verification. I reviewed, iterated and tested it myself as well.

<!-- If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here. -->

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
