### PR TITLE
fix(antidote): update from interactive zsh when available

### DIFF
--- a/src/steps/zsh.rs
+++ b/src/steps/zsh.rs
@@ -1,5 +1,5 @@
 use std::env;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use color_eyre::eyre::Result;
 use tracing::debug;
@@ -33,17 +33,39 @@ pub fn zshrc() -> PathBuf {
     zdotdir().join(".zshrc")
 }
 
+enum AntidoteUpdate {
+    Shell,
+    Source(PathBuf),
+}
+
 pub fn run_antidote(ctx: &ExecutionContext) -> Result<()> {
     let zsh = require("zsh")?;
-    let mut antidote = zdotdir().join(".antidote").require()?;
-    antidote.push("antidote.zsh");
+    let update = if antidote_available_in_shell(ctx, &zsh) {
+        AntidoteUpdate::Shell
+    } else {
+        let mut antidote = zdotdir().join(".antidote").require()?;
+        antidote.push("antidote.zsh");
+        AntidoteUpdate::Source(antidote)
+    };
 
     print_separator("antidote");
 
+    match update {
+        AntidoteUpdate::Shell => ctx.execute(zsh).args(["-i", "-c", "antidote update"]).status_checked(),
+        AntidoteUpdate::Source(antidote) => ctx
+            .execute(zsh)
+            .arg("-c")
+            .arg(format!("source {} && antidote update", antidote.display()))
+            .status_checked(),
+    }
+}
+
+fn antidote_available_in_shell(ctx: &ExecutionContext, zsh: &Path) -> bool {
     ctx.execute(zsh)
-        .arg("-c")
-        .arg(format!("source {} && antidote update", antidote.display()))
-        .status_checked()
+        .always()
+        .args(["-i", "-c", "antidote home"])
+        .output_checked()
+        .is_ok()
 }
 
 pub fn run_antibody(ctx: &ExecutionContext) -> Result<()> {


### PR DESCRIPTION
## What does this PR do

Fixes #987.

This updates the Antidote step to use interactive zsh when Antidote is already available there, while preserving the existing `$ZDOTDIR/.antidote` sourcing behavior as a fallback.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.

Tested with Antidote installed via Homebrew and loaded from interactive zsh.

Dry run:

```
―― 14:42:57 - antidote ――
Dry running: /bin/zsh -i -c 'antidote update'
―― 14:42:57 - Summary ――
antidote: OK
```

Full wet test:

```
―― 15:15:15 - antidote ――
Updating bundles...
Bundle updates complete.

Self updating is disabled in this build.
Use your OS package manager to update antidote itself.
...
antidote: OK
```
And Rust checks with test ouput:

```
cargo fmt --check
cargo check
cargo clippy
cargo test
  
test result: ok. 24 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

- [ ] If this PR introduces new user-facing messages they are translated (N/A: no user-facing messages added or changed)

### AI involvement

I used Codex to help investigate the root cause, prepare the patch branch, and run validation. I reviewed the implementation, asked for revisions, and am writing/submitting this PR myself.

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->