### PR TITLE
fix(shell): quote sourced command paths

### DIFF
--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -32,7 +32,7 @@ use crate::execution_context::ExecutionContext;
 use crate::executor::Executor;
 use crate::step::Step;
 use crate::terminal::print_separator;
-use crate::utils::{PathExt, require};
+use crate::utils::{PathExt, require, shell_source_command};
 
 fn get_sudo_uid<P: AsRef<Path>>(path: P) -> Option<u32> {
     if let Ok(metadata) = fs::metadata(&path) {
@@ -1059,8 +1059,7 @@ pub fn run_sdkman(ctx: &ExecutionContext) -> Result<()> {
         .map_or_else(|_| HOME_DIR.join(".sdkman"), PathBuf::from)
         .join("bin")
         .join("sdkman-init.sh")
-        .require()
-        .map(|p| format!("{}", &p.display()))?;
+        .require()?;
 
     print_separator("SDKMAN!");
 
@@ -1077,25 +1076,25 @@ pub fn run_sdkman(ctx: &ExecutionContext) -> Result<()> {
         .unwrap_or("false");
 
     if selfupdate_enabled == "true" {
-        let cmd_selfupdate = format!("source {} && sdk selfupdate", &sdkman_init_path);
+        let cmd_selfupdate = shell_source_command(&sdkman_init_path, "sdk selfupdate");
         ctx.execute(&bash)
             .args(["-c", cmd_selfupdate.as_str()])
             .status_checked()?;
     }
 
-    let cmd_update = format!("source {} && sdk update", &sdkman_init_path);
+    let cmd_update = shell_source_command(&sdkman_init_path, "sdk update");
     ctx.execute(&bash).args(["-c", cmd_update.as_str()]).status_checked()?;
 
-    let cmd_upgrade = format!("source {} && sdk upgrade", &sdkman_init_path);
+    let cmd_upgrade = shell_source_command(&sdkman_init_path, "sdk upgrade");
     ctx.execute(&bash).args(["-c", cmd_upgrade.as_str()]).status_checked()?;
 
     if ctx.config().cleanup() {
-        let cmd_flush_archives = format!("source {} && sdk flush archives", &sdkman_init_path);
+        let cmd_flush_archives = shell_source_command(&sdkman_init_path, "sdk flush archives");
         ctx.execute(&bash)
             .args(["-c", cmd_flush_archives.as_str()])
             .status_checked()?;
 
-        let cmd_flush_temp = format!("source {} && sdk flush temp", &sdkman_init_path);
+        let cmd_flush_temp = shell_source_command(&sdkman_init_path, "sdk flush temp");
         ctx.execute(&bash)
             .args(["-c", cmd_flush_temp.as_str()])
             .status_checked()?;

--- a/src/steps/zsh.rs
+++ b/src/steps/zsh.rs
@@ -11,7 +11,7 @@ use crate::command::CommandExt;
 use crate::execution_context::ExecutionContext;
 use crate::git::RepoStep;
 use crate::terminal::print_separator;
-use crate::utils::{PathExt, require};
+use crate::utils::{PathExt, require, shell_source_command};
 use etcetera::base_strategy::BaseStrategy;
 
 pub fn run_zr(ctx: &ExecutionContext) -> Result<()> {
@@ -21,7 +21,7 @@ pub fn run_zr(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("zr");
 
-    let cmd = format!("source {} && zr --update", zshrc().display());
+    let cmd = shell_source_command(&zshrc(), "zr --update");
     ctx.execute(zsh).args(["-l", "-c", cmd.as_str()]).status_checked()
 }
 
@@ -55,7 +55,7 @@ pub fn run_antidote(ctx: &ExecutionContext) -> Result<()> {
         AntidoteUpdate::Source(antidote) => ctx
             .execute(zsh)
             .arg("-c")
-            .arg(format!("source {} && antidote update", antidote.display()))
+            .arg(shell_source_command(&antidote, "antidote update"))
             .status_checked(),
     }
 }
@@ -86,7 +86,7 @@ pub fn run_antigen(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("antigen");
 
-    let cmd = format!("source {} && (antigen selfupdate ; antigen update)", zshrc.display());
+    let cmd = shell_source_command(&zshrc, "(antigen selfupdate ; antigen update)");
     ctx.execute(zsh).args(["-l", "-c", cmd.as_str()]).status_checked()
 }
 
@@ -99,7 +99,7 @@ pub fn run_zgenom(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("zgenom");
 
-    let cmd = format!("source {} && zgenom selfupdate && zgenom update", zshrc.display());
+    let cmd = shell_source_command(&zshrc, "zgenom selfupdate && zgenom update");
     ctx.execute(zsh).args(["-l", "-c", cmd.as_str()]).status_checked()
 }
 
@@ -126,7 +126,7 @@ pub fn run_zinit(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("zinit");
 
-    let cmd = format!("source {} && zinit self-update && zinit update --all", zshrc.display());
+    let cmd = shell_source_command(&zshrc, "zinit self-update && zinit update --all");
     ctx.execute(zsh).args(["-i", "-c", cmd.as_str()]).status_checked()
 }
 
@@ -138,7 +138,7 @@ pub fn run_zi(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("zi");
 
-    let cmd = format!("source {} && zi self-update && zi update --all", zshrc.display());
+    let cmd = shell_source_command(&zshrc, "zi self-update && zi update --all");
     ctx.execute(zsh).args(["-i", "-c", &cmd]).status_checked()
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -280,6 +280,15 @@ pub fn string_prepend_str(string: &mut String, s: &str) {
     *string = new_string;
 }
 
+/// Builds a shell command that sources `path` before running `command`.
+///
+/// Only `path` is quoted. `command` must be a trusted shell fragment.
+#[cfg(unix)]
+pub fn shell_source_command(path: &Path, command: &str) -> String {
+    let path = path.to_string_lossy();
+    format!("source {} && {command}", shell_words::quote(path.as_ref()))
+}
+
 #[cfg(unix)]
 pub fn hostname() -> Result<String> {
     match nix::unistd::gethostname() {
@@ -310,6 +319,33 @@ pub fn is_elevated() -> bool {
         debug!("Detected elevated process");
     }
     elevated
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use std::path::Path;
+
+    use super::shell_source_command;
+
+    #[test]
+    fn shell_source_command_preserves_paths_with_spaces() {
+        let command = shell_source_command(Path::new("/tmp/topgrade test/.zshrc"), "zr --update");
+
+        assert_eq!(
+            shell_words::split(&command).unwrap(),
+            ["source", "/tmp/topgrade test/.zshrc", "&&", "zr", "--update"]
+        );
+    }
+
+    #[test]
+    fn shell_source_command_preserves_paths_with_single_quotes() {
+        let command = shell_source_command(Path::new("/tmp/topgrade's test/.zshrc"), "zr --update");
+
+        assert_eq!(
+            shell_words::split(&command).unwrap(),
+            ["source", "/tmp/topgrade's test/.zshrc", "&&", "zr", "--update"]
+        );
+    }
 }
 
 pub mod merge_strategies {


### PR DESCRIPTION
## What does this PR do

Addresses https://github.com/topgrade-rs/topgrade/pull/2136#issuecomment-4893272990.

Adds `shell_source_command` util that constructs shell commands with quoted source paths and implements it in command constructors in `src/steps/os/unix.rs` and `src/steps/zsh.rs`. Also adds a unit test for `shell_source_command`.

I kept this as a small util rather than introducing a more abstracted command builder because we only need to safely interpolate the sourced file path given that the commands are static. I also used a helper instead of in-lining the quote call at each site because the same `source <path> && ...` pattern appears in multiple steps, so centralizing it keeps the call sites readable, avoids repeating the quoting logic, and gives the path handling one focused test.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.

Ran the following:

```
cargo fmt --check
cargo check
cargo clippy
cargo test
```

The test suite includes the added unit coverage for source paths with spaces and single quotes.

I also ran an end-to-end smoke test through Topgrade:

- Built local ./target/debug/topgrade
- Created a fake zr binary in a temp PATH
- Created temp ZDOTDIR paths containing a space and a single quote
- Each .zshrc exported a marker
- Ran `./target/debug/topgrade --only shell --run-type wet`

Output:

```
--- 21:22:51 - zr ---
--- 21:22:51 - Summary ---
zr: OK
--- 21:22:51 - zr ---
--- 21:22:51 - Summary ---
zr: OK
topgrade smoke markers:
space-ok
quote-ok
```

I also verified the same smoke test fails on origin/main without this fix:

```
--- baseline case: space dir ---
--- 21:24:53 - zr ---
zsh:source:1: no such file or directory: /tmp/topgrade
--- 21:24:53 - Summary ---
zr: FAILED

--- baseline case: quote's dir ---
--- 21:24:53 - zr ---
zsh:1: unmatched '
--- 21:24:53 - Summary ---
zr: FAILED
```

- [ ] If this PR introduces new user-facing messages they are translated (N/A: no new or changed user-facing messages)

### AI involvement

I prompted Codex to find all instances of unquoted source paths, replace them with the new util, and construct and run the smoke test detailed above. I reviewed the implementation and am submitting the PR myself.

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
