### PR TITLE
fix(mise): avoid project cwd for upgrades

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -2377,13 +2377,20 @@ pub fn run_ollama_pull(ctx: &ExecutionContext) -> Result<()> {
 
 pub fn run_mise(ctx: &ExecutionContext) -> Result<()> {
     let mise = require("mise")?;
+    // Run from a fresh directory so caller project-local mise.toml files do not
+    // affect the mise step.
+    let temp_dir = tempdir()?;
 
     print_separator("mise");
 
-    ctx.execute(&mise).args(["plugins", "update"]).status_checked()?;
+    ctx.execute(&mise)
+        .current_dir(temp_dir.path())
+        .args(["plugins", "update"])
+        .status_checked()?;
 
     let output = ctx
         .execute(&mise)
+        .current_dir(temp_dir.path())
         .args(["self-update"])
         .output_checked_with(|_| Ok(()))?;
     let status_code = output
@@ -2404,6 +2411,7 @@ pub fn run_mise(ctx: &ExecutionContext) -> Result<()> {
     let mut cmd = ctx.execute(&mise);
 
     cmd.arg("upgrade");
+    cmd.current_dir(temp_dir.path());
 
     if ctx.config().mise_interactive() {
         cmd.arg("--interactive");
@@ -2435,20 +2443,21 @@ pub fn run_mise(ctx: &ExecutionContext) -> Result<()> {
 
     cmd.status_checked()?;
 
-    refresh_mise_env(ctx, &mise)
+    refresh_mise_env(ctx, &mise, temp_dir.path())
 }
 
 /// Refresh the process environment after `mise upgrade` so later steps and binary
 /// lookups resolve the upgraded mise-managed tools. `mise env --json` reports the
 /// activated environment, which we apply to the `PATH`/vars that child commands inherit.
 /// See <https://github.com/topgrade-rs/topgrade/issues/2041>.
-fn refresh_mise_env(ctx: &ExecutionContext, mise: &Path) -> Result<()> {
+fn refresh_mise_env(ctx: &ExecutionContext, mise: &Path, neutral_cwd: &Path) -> Result<()> {
     if ctx.run_type().dry() {
         return Ok(());
     }
 
     let output = ctx
         .execute(mise)
+        .current_dir(neutral_cwd)
         .args(["env", "--json"])
         .output_checked()
         .wrap_err("failed to run `mise env --json`")?;


### PR DESCRIPTION
## What does this PR do

Fixes #2139.

This updates the Mise step to run from a neutral temporary directory to avoid project-local configs taking precedence over system/user-level configs. A temporary directory keeps the implementation simple and avoids relying on platform-specific root directory behavior.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.

Ran the following tests:

```shell
cargo fmt --check
cargo check
cargo clippy -- --deny warnings
cargo test
cargo build
```

All passed. `cargo` test reported 24 passed.

I also ran an operational smoke test through the built Topgrade binary. The test put a fake mise first in PATH, launched:

```shell
topgrade --only mise --run-type wet
```

from a temp project directory containing a local .mise.toml, and logged the cwd for each fake `mise` invocation. The log showed all four `mise` commands ran from Topgrade’s temp cwd:

```shell
.../.tmpGwS3cn :: plugins update
.../.tmpGwS3cn :: self-update
.../.tmpGwS3cn :: upgrade
.../.tmpGwS3cn :: env --json
```

- [ ] If this PR introduces new user-facing messages they are translated (N/A: No new or changed user-facing messages)

### AI involvement

I used Codex to help investigate the root cause, prepare the patch branch, and run validation, including the smoke test. I reviewed the implementation, asked for revisions, and am writing/submitting this PR myself.

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
