### PR TITLE
fix(pi): skip self update if disabled or installed with homebrew

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -685,11 +685,23 @@ pub fn run_pi(ctx: &ExecutionContext) -> Result<()> {
     let supports_explicit_update_targets =
         pi_update_help.stdout.contains("--self") && pi_update_help.stdout.contains("--extensions");
 
+    // `pi update --self` errors when PI_SKIP_VERSION_CHECK is set. Homebrew sets it when it runs.
+    let pi_skip_version_check_env = std::env::var("PI_SKIP_VERSION_CHECK").is_ok();
+    let pi_installed_through_homebrew = pi
+        .canonicalize()
+        .is_ok_and(|p| p.to_string_lossy().contains("/Cellar/"));
+
     if supports_explicit_update_targets {
-        ctx.execute(&pi)
-            .current_dir(temp_dir.path())
-            .args(["update", "--self"])
-            .status_checked()?;
+        if pi_skip_version_check_env {
+            debug!("Skipping `pi update --self`: PI_SKIP_VERSION_CHECK is set");
+        } else if pi_installed_through_homebrew {
+            debug!("Skipping `pi update --self`: pi is installed via Homebrew");
+        } else {
+            ctx.execute(&pi)
+                .current_dir(temp_dir.path())
+                .args(["update", "--self"])
+                .status_checked()?;
+        }
 
         ctx.execute(&pi)
             .current_dir(temp_dir.path())


### PR DESCRIPTION
## What does this PR do
<!--
Describe what your PR does, and link any relevant issues.
Make sure to use a keyword like 'closes' if this PR solves the issue.
-->
If the Pi coding agent is installed via a package manager (such as homebrew) or the system has `PI_SKIP_VERSION_CHECK` var on then `pi update --self` will error. This PR adds a check to skip it when that's the case.

Closes #2154 

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [x] If this PR introduces new user-facing messages they are translated
  - PR does include new debug text
 
### Output
<details>
<pre>
❱ ./target/debug/topgrade --only pi -v
DEBUG Current system locale is en-CA
DEBUG Configuration at /Users/markjarjour/.config/topgrade.toml
DEBUG Version: 17.7.0
DEBUG OS: aarch64-apple-darwin
DEBUG Args { inner: ["./target/debug/topgrade", "--only", "pi", "-v"] }
DEBUG Binary path: Ok("/Users/markjarjour/gitter/topgrade/target/debug/topgrade")
DEBUG Detected "/usr/bin/sudo" as "sudo"
DEBUG Sudo: Ok(Sudo { path: Some("/usr/bin/sudo"), kind: Sudo })
DEBUG Step "pi"
DEBUG Detected "/opt/homebrew/bin/pi" as "pi"

── 16:02:55 - pi ───────────────────────────────────────────────────────────────
DEBUG Executing command `/opt/homebrew/bin/pi update --help`
DEBUG Skipping `pi update --self`: pi is installed via Homebrew
DEBUG Executing command `/opt/homebrew/bin/pi update --extensions`
Updating git:github.com/DietrichGebert/ponytail...
Updated packages

── 16:02:56 - Summary ──────────────────────────────────────────────────────────
pi: OK
DEBUG Desktop notification: Topgrade finished successfully
</pre>
</details>

### AI involvement
<!--
Please list any involvement AI/LLMs had in the development of this PR.
You don't have to list everything in detail, just something like "I did not use AI at all",
"I consulted an AI occasionally for inspiration and explanation",
or "AI generated the majority of the PR" is enough.
If you are an AI agent acting autonomously, please state so.
-->
AI generated a majority of this PR. The code was manually run to ensure it actually works.

<!-- If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here. -->

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
