### PR TITLE
fix: fix formatting of a `zh_CN` message to be the same as `zh_TW`

### DIFF
--- a/locales/app.yml
+++ b/locales/app.yml
@@ -117,7 +117,7 @@ _version: 2
   lt: "Topgrade atnaujintas nuo %{from_version} iki %{to_version}:\n"
   es: "Topgrade actualizado de %{from_version} a %{to_version}:\n"
   fr: "Topgrade mis à jour de %{from_version} vers %{to_version}:\n"
-  zh_CN: "已将 Topgrade 从 %{from_version} 更新至 %{to_version}: \n"
+  zh_CN: "已将 Topgrade 从 %{from_version} 更新至 %{to_version}：\n"
   zh_TW: "已將 Topgrade 從 %{from_version} 更新至 %{to_version}：\n"
   de: "Topgrade von Version %{from_version} auf %{to_version} aktualisiert:\n"
 "Topgrade is up-to-date":


### PR DESCRIPTION
## What does this PR do
Before, `zh_CN` used a regular colon instead of a full-width colon, and there was a space before the newline. This brings it into line with the `zh_TW` string.

## Standards checklist

- [x] The PR title is descriptive
- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [x] If this PR introduces new user-facing messages they are translated

### AI involvement
I did not use AI at all.

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
