### PR TITLE
refactor(sudo): use `true` as no-op instead of `echo`

### DIFF
--- a/src/sudo.rs
+++ b/src/sudo.rs
@@ -285,10 +285,9 @@ impl Sudo {
         match self.kind {
             SudoKind::Doas => {
                 // `doas` doesn't have anything like `sudo -v` to cache credentials,
-                // so we just execute a dummy `echo` command so we have something
-                // unobtrusive to run.
+                // so we just execute a no-op dummy command, `true`.
                 // See: https://man.openbsd.org/doas
-                cmd.arg("echo");
+                cmd.arg("true");
             }
             SudoKind::Sudo => {
                 // From `man sudo` on macOS:
@@ -322,14 +321,14 @@ impl Sudo {
                 // See the note for `doas` above.
                 //
                 // See: https://linux.die.net/man/1/pkexec
-                cmd.arg("echo");
+                cmd.arg("true");
             }
             SudoKind::Run0 => {
                 // `run0` uses polkit for authentication
                 // and thus has the same issues as `pkexec`.
                 //
                 // See: https://www.freedesktop.org/software/systemd/man/devel/run0.html
-                cmd.arg("echo");
+                cmd.arg("true");
             }
             SudoKind::Please => {
                 // From `man please`


### PR DESCRIPTION
## What does this PR do

Previously, `echo` with no arguments was used as a no-op (dummy command) for `doas` and some `sudo`s, but `echo` is not really a no-op; it prints one newline. This replaces it with `true`, which is a real no-op, is more idiomatic, and executes negligibly faster.

I believe this counts as a refactor, even though it fixes the newline printing, which is technically a minor unreported bug. Feel free to change the label.

## Standards checklist

- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* The PR title is a descriptive commit message (this will appear in release notes, leave unchecked if you want a maintainer to improve it)
- [x] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.

  With `doas`:

  <details><summary>Topgrade output</summary>

  ```
  $ cat /tmp/topgrade_config.toml
  [misc]
  pre_sudo=true
  sudo_command="doas"
  $ ./target/debug/topgrade --config=/tmp/topgrade_config.toml --only=flatpak --verbose
  DEBUG Current system locale is en-US
  DEBUG Loaded configuration: ConfigFile { include: None, misc: Some(Misc { allow_root: None, pre_sudo: Some(true), sudo_loop:   None, sudo_loop_interval: None, sudo_command: Some(Doas), disable: None, first: None, last: None, ignore_failures: None,   remote_topgrades: None, remote_topgrade_path: None, ssh_arguments: None, tmux_arguments: None, set_title: None, display_time:   None, assume_yes: None, ask_retry: None, auto_retry: None, no_retry: None, show_skipped: None, run_in_tmux: None,   tmux_session_mode: None, cleanup: None, notify_each_step: None, skip_notify: None, notify_end: None, bashit_branch: None,   only: None, no_self_update: None, log_filters: None, show_distribution_summary: None, nix_handler: None }), pre_commands:   None, post_commands: None, commands: None, conda: None, python: None, composer: None, brew: None, linux: None, mandb: None,   git: None, go: None, containers: None, windows: None, npm: None, chezmoi: None, mise: None, yarn: None, deno: None, vim:   None, firmware: None, vagrant: None, flatpak: None, pixi: None, distrobox: None, lensfun: None, julia: None, zigup: None,   vscode: None, doom: None, cargo: None, rustup: None, pkgfile: None, viteplus: None }
  DEBUG Version: 17.7.0
  DEBUG OS: x86_64-unknown-linux-gnu
  DEBUG Args { inner: ["./target/debug/topgrade", "--config=/tmp/topgrade_config.toml", "--only=flatpak", "--verbose"] }
  DEBUG Binary path: Ok("/home/gab/Documents/git/topgrade/target/debug/topgrade")
  DEBUG self-update Feature Enabled: false
  DEBUG Configuration: Config { opt: CommandLineArgs { edit_config: false, show_config_reference: false, run_in_tmux: false,   no_tmux: false, cleanup: false, dry_run: false, run_type: Wet, no_retry: false, no_ask_retry: false, auto_retry: None,   disable: [], only: [Flatpak], custom_commands: [], env: [], verbose: true, keep_at_end: false, skip_notify: false,   notify_end: Always, yes: None, disable_predefined_git_repos: false, config: Some("/tmp/topgrade_config.toml"),   remote_host_limit: None, show_skipped: false, allow_root: false, sudo_loop: false, sudo_loop_interval: None, log_filter:   "warn", gen_completion: None, gen_manpage: false, no_self_update: false }, config_file: ConfigFile { include: None, misc: Some  (Misc { allow_root: None, pre_sudo: Some(true), sudo_loop: None, sudo_loop_interval: None, sudo_command: Some(Doas), disable:   None, first: None, last: None, ignore_failures: None, remote_topgrades: None, remote_topgrade_path: None, ssh_arguments:   None, tmux_arguments: None, set_title: None, display_time: None, assume_yes: None, ask_retry: None, auto_retry: None,   no_retry: None, show_skipped: None, run_in_tmux: None, tmux_session_mode: None, cleanup: None, notify_each_step: None,   skip_notify: None, notify_end: None, bashit_branch: None, only: None, no_self_update: None, log_filters: None,   show_distribution_summary: None, nix_handler: None }), pre_commands: None, post_commands: None, commands: None, conda: None,   python: None, composer: None, brew: None, linux: None, mandb: None, git: None, go: None, containers: None, windows: None,   npm: None, chezmoi: None, mise: None, yarn: None, deno: None, vim: None, firmware: None, vagrant: None, flatpak: None, pixi:   None, distrobox: None, lensfun: None, julia: None, zigup: None, vscode: None, doom: None, cargo: None, rustup: None, pkgfile:   None, viteplus: None }, allowed_steps: [Flatpak] }
  DEBUG Running with euid: 1000
  DEBUG Proc version output: Linux version 7.1.3-arch1-3 (linux@archlinux) (gcc (GCC) 16.1.1 20260625, GNU ld (GNU Binutils) 2.  46.1) #1 SMP PREEMPT_DYNAMIC Mon, 13 Jul 2026 20:15:15 +0000

  DEBUG Detected "/usr/bin/doas" as "doas"
  DEBUG Sudo: Ok(Sudo { path: Some("/usr/bin/doas"), kind: Doas })

  ── 15:03:33 - Sudo ─────────────────────────────────────────────────────────────
  DEBUG Executing command `/usr/bin/doas true`
  DEBUG Step "Flatpak"
  DEBUG Proc version output: Linux version 7.1.3-arch1-3 (linux@archlinux) (gcc (GCC) 16.1.1 20260625, GNU ld (GNU Binutils) 2.  46.1) #1 SMP PREEMPT_DYNAMIC Mon, 13 Jul 2026 20:15:15 +0000

  DEBUG Detected "/usr/bin/flatpak" as "flatpak"

  ── 15:03:33 - Flatpak User Packages ────────────────────────────────────────────
  DEBUG Executing command `/usr/bin/flatpak update --user`
  Looking for updates…

  Nothing to update.

  ── 15:03:33 - Flatpak System Packages ──────────────────────────────────────────
  DEBUG Executing command `/usr/bin/flatpak update --system`
  Looking for updates…

  Nothing to update.

  ── 15:03:35 - Summary ──────────────────────────────────────────────────────────
  Flatpak: OK
  DEBUG Desktop notification: Topgrade finished successfully
  ```

  </details>

  When running the same command on `main`, we can see the extra newline:

  <details><summary>Topgrade output</summary>

  ```
  ── 15:14:04 - Sudo ─────────────────────────────────────────────────────────────
  DEBUG Executing command `/usr/bin/doas echo`

  DEBUG Step "Flatpak"
  ```

  </details>

- [x] If this PR introduces new user-facing messages they are translated

### AI involvement

I did not use AI at all.

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
