### PR TITLE
fix(zsh): drop redundant .zshrc source

### DIFF
--- a/src/steps/zsh.rs
+++ b/src/steps/zsh.rs
@@ -91,7 +91,6 @@ pub fn run_antibody(ctx: &ExecutionContext) -> Result<()> {
 
 pub fn run_antigen(ctx: &ExecutionContext) -> Result<()> {
     let zsh = require("zsh")?;
-    zshrc().require()?;
     env::var("ADOTDIR")
         .map_or_else(|_| HOME_DIR.join("antigen.zsh"), PathBuf::from)
         .require()?;
@@ -103,7 +102,6 @@ pub fn run_antigen(ctx: &ExecutionContext) -> Result<()> {
 
 pub fn run_zgenom(ctx: &ExecutionContext) -> Result<()> {
     let zsh = require("zsh")?;
-    zshrc().require()?;
     env::var("ZGEN_SOURCE")
         .map_or_else(|_| HOME_DIR.join(".zgenom"), PathBuf::from)
         .require()?;
@@ -115,7 +113,6 @@ pub fn run_zgenom(ctx: &ExecutionContext) -> Result<()> {
 
 pub fn run_zplug(ctx: &ExecutionContext) -> Result<()> {
     let zsh = require("zsh")?;
-    zshrc().require()?;
 
     env::var("ZPLUG_HOME")
         .map_or_else(|_| HOME_DIR.join(".zplug"), PathBuf::from)
@@ -128,7 +125,6 @@ pub fn run_zplug(ctx: &ExecutionContext) -> Result<()> {
 
 pub fn run_zinit(ctx: &ExecutionContext) -> Result<()> {
     let zsh = require("zsh")?;
-    zshrc().require()?;
 
     env::var("ZINIT_HOME")
         .map_or_else(|_| XDG_DIRS.data_dir().join("zinit"), PathBuf::from)
@@ -141,7 +137,6 @@ pub fn run_zinit(ctx: &ExecutionContext) -> Result<()> {
 
 pub fn run_zi(ctx: &ExecutionContext) -> Result<()> {
     let zsh = require("zsh")?;
-    zshrc().require()?;
 
     HOME_DIR.join(".zi").require()?;
 

--- a/src/steps/zsh.rs
+++ b/src/steps/zsh.rs
@@ -21,8 +21,7 @@ pub fn run_zr(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("zr");
 
-    let cmd = format!("source {} && zr --update", zshrc().display());
-    ctx.execute(zsh).args(["-l", "-c", cmd.as_str()]).status_checked()
+    ctx.execute(zsh).args(["-i", "-c", "zr --update"]).status_checked()
 }
 
 fn zdotdir() -> PathBuf {
@@ -79,28 +78,30 @@ pub fn run_antibody(ctx: &ExecutionContext) -> Result<()> {
 
 pub fn run_antigen(ctx: &ExecutionContext) -> Result<()> {
     let zsh = require("zsh")?;
-    let zshrc = zshrc().require()?;
+    zshrc().require()?;
     env::var("ADOTDIR")
         .map_or_else(|_| HOME_DIR.join("antigen.zsh"), PathBuf::from)
         .require()?;
 
     print_separator("antigen");
 
-    let cmd = format!("source {} && (antigen selfupdate ; antigen update)", zshrc.display());
-    ctx.execute(zsh).args(["-l", "-c", cmd.as_str()]).status_checked()
+    ctx.execute(zsh)
+        .args(["-i", "-c", "antigen selfupdate ; antigen update"])
+        .status_checked()
 }
 
 pub fn run_zgenom(ctx: &ExecutionContext) -> Result<()> {
     let zsh = require("zsh")?;
-    let zshrc = zshrc().require()?;
+    zshrc().require()?;
     env::var("ZGEN_SOURCE")
         .map_or_else(|_| HOME_DIR.join(".zgenom"), PathBuf::from)
         .require()?;
 
     print_separator("zgenom");
 
-    let cmd = format!("source {} && zgenom selfupdate && zgenom update", zshrc.display());
-    ctx.execute(zsh).args(["-l", "-c", cmd.as_str()]).status_checked()
+    ctx.execute(zsh)
+        .args(["-i", "-c", "zgenom selfupdate && zgenom update"])
+        .status_checked()
 }
 
 pub fn run_zplug(ctx: &ExecutionContext) -> Result<()> {
@@ -118,7 +119,7 @@ pub fn run_zplug(ctx: &ExecutionContext) -> Result<()> {
 
 pub fn run_zinit(ctx: &ExecutionContext) -> Result<()> {
     let zsh = require("zsh")?;
-    let zshrc = zshrc().require()?;
+    zshrc().require()?;
 
     env::var("ZINIT_HOME")
         .map_or_else(|_| XDG_DIRS.data_dir().join("zinit"), PathBuf::from)
@@ -126,20 +127,22 @@ pub fn run_zinit(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("zinit");
 
-    let cmd = format!("source {} && zinit self-update && zinit update --all", zshrc.display());
-    ctx.execute(zsh).args(["-i", "-c", cmd.as_str()]).status_checked()
+    ctx.execute(zsh)
+        .args(["-i", "-c", "zinit self-update && zinit update --all"])
+        .status_checked()
 }
 
 pub fn run_zi(ctx: &ExecutionContext) -> Result<()> {
     let zsh = require("zsh")?;
-    let zshrc = zshrc().require()?;
+    zshrc().require()?;
 
     HOME_DIR.join(".zi").require()?;
 
     print_separator("zi");
 
-    let cmd = format!("source {} && zi self-update && zi update --all", zshrc.display());
-    ctx.execute(zsh).args(["-i", "-c", &cmd]).status_checked()
+    ctx.execute(zsh)
+        .args(["-i", "-c", "zi self-update && zi update --all"])
+        .status_checked()
 }
 
 pub fn run_zim(ctx: &ExecutionContext) -> Result<()> {

--- a/src/steps/zsh.rs
+++ b/src/steps/zsh.rs
@@ -9,10 +9,23 @@ use crate::HOME_DIR;
 use crate::XDG_DIRS;
 use crate::command::CommandExt;
 use crate::execution_context::ExecutionContext;
+use crate::executor::Executor;
 use crate::git::RepoStep;
 use crate::terminal::print_separator;
 use crate::utils::{PathExt, require};
 use etcetera::base_strategy::BaseStrategy;
+
+/// Build an interactive `zsh -i -c` invocation with a trailing `exit $?`.
+///
+/// `zsh -i -c` execs (rather than forks) its last command, so an external final command leaves
+/// the tty foreground process group pointing at a dead pgrp. Forcing the builtin `exit` to be the
+/// last command sidesteps that. Drop this helper and restore plain `execute` once zsh fixes it.
+fn execute_interactive_zsh(ctx: &ExecutionContext, zsh: &Path, command: &str) -> Executor {
+    let script = format!("{command}; exit $?");
+    let mut exec = ctx.execute(zsh);
+    exec.args(["-i", "-c", &script]);
+    exec
+}
 
 pub fn run_zr(ctx: &ExecutionContext) -> Result<()> {
     let zsh = require("zsh")?;
@@ -21,9 +34,7 @@ pub fn run_zr(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("zr");
 
-    ctx.execute(zsh)
-        .args(["-i", "-c", "zr --update; exit $?"])
-        .status_checked()
+    execute_interactive_zsh(ctx, &zsh, "zr --update").status_checked()
 }
 
 fn zdotdir() -> PathBuf {
@@ -87,9 +98,7 @@ pub fn run_antigen(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("antigen");
 
-    ctx.execute(zsh)
-        .args(["-i", "-c", "antigen selfupdate ; antigen update; exit $?"])
-        .status_checked()
+    execute_interactive_zsh(ctx, &zsh, "antigen selfupdate ; antigen update").status_checked()
 }
 
 pub fn run_zgenom(ctx: &ExecutionContext) -> Result<()> {
@@ -101,9 +110,7 @@ pub fn run_zgenom(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("zgenom");
 
-    ctx.execute(zsh)
-        .args(["-i", "-c", "zgenom selfupdate && zgenom update; exit $?"])
-        .status_checked()
+    execute_interactive_zsh(ctx, &zsh, "zgenom selfupdate && zgenom update").status_checked()
 }
 
 pub fn run_zplug(ctx: &ExecutionContext) -> Result<()> {
@@ -129,9 +136,7 @@ pub fn run_zinit(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("zinit");
 
-    ctx.execute(zsh)
-        .args(["-i", "-c", "zinit self-update && zinit update --all; exit $?"])
-        .status_checked()
+    execute_interactive_zsh(ctx, &zsh, "zinit self-update && zinit update --all").status_checked()
 }
 
 pub fn run_zi(ctx: &ExecutionContext) -> Result<()> {
@@ -142,9 +147,7 @@ pub fn run_zi(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("zi");
 
-    ctx.execute(zsh)
-        .args(["-i", "-c", "zi self-update && zi update --all; exit $?"])
-        .status_checked()
+    execute_interactive_zsh(ctx, &zsh, "zi self-update && zi update --all").status_checked()
 }
 
 pub fn run_zim(ctx: &ExecutionContext) -> Result<()> {

--- a/src/steps/zsh.rs
+++ b/src/steps/zsh.rs
@@ -21,7 +21,9 @@ pub fn run_zr(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("zr");
 
-    ctx.execute(zsh).args(["-i", "-c", "zr --update"]).status_checked()
+    ctx.execute(zsh)
+        .args(["-i", "-c", "zr --update; exit $?"])
+        .status_checked()
 }
 
 fn zdotdir() -> PathBuf {
@@ -86,7 +88,7 @@ pub fn run_antigen(ctx: &ExecutionContext) -> Result<()> {
     print_separator("antigen");
 
     ctx.execute(zsh)
-        .args(["-i", "-c", "antigen selfupdate ; antigen update"])
+        .args(["-i", "-c", "antigen selfupdate ; antigen update; exit $?"])
         .status_checked()
 }
 
@@ -100,7 +102,7 @@ pub fn run_zgenom(ctx: &ExecutionContext) -> Result<()> {
     print_separator("zgenom");
 
     ctx.execute(zsh)
-        .args(["-i", "-c", "zgenom selfupdate && zgenom update"])
+        .args(["-i", "-c", "zgenom selfupdate && zgenom update; exit $?"])
         .status_checked()
 }
 
@@ -128,7 +130,7 @@ pub fn run_zinit(ctx: &ExecutionContext) -> Result<()> {
     print_separator("zinit");
 
     ctx.execute(zsh)
-        .args(["-i", "-c", "zinit self-update && zinit update --all"])
+        .args(["-i", "-c", "zinit self-update && zinit update --all; exit $?"])
         .status_checked()
 }
 
@@ -141,7 +143,7 @@ pub fn run_zi(ctx: &ExecutionContext) -> Result<()> {
     print_separator("zi");
 
     ctx.execute(zsh)
-        .args(["-i", "-c", "zi self-update && zi update --all"])
+        .args(["-i", "-c", "zi self-update && zi update --all; exit $?"])
         .status_checked()
 }
 


### PR DESCRIPTION
## What does this PR do
<!--
Describe what your PR does, and link any relevant issues.
Make sure to use a keyword like 'closes' if this PR solves the issue.
-->

Fixes #2152 

This PR removes sourcing of `.zshrc` on startup, because `zsh -i` already does that and the explicit `source` tripped zsh plugin-manager guards. This affects 5 steps, all now run `zsh -i -c '{something}'`. `zplug`, `zim` and `antidote` already did it like that before.

`zr`, `antigen` and `zgenom` steps now do `-i` instead of `-l`. That flag doesn't source `.zshrc`, so this PR would otherwise break them. This change means only that  `.zprofile` and `.zlogin` stop sourcing automatically. `.zshenv` and `.zshrc` still load and plugin managers also define their functions only in `.zshrc`.

Verified on Linux and macOS zsh 5.9: `zsh -i -c 'source zshrc && cmd'` double-sources and the guard exits 1; `zsh -i -c 'cmd'` sources once and exits 0.

## Standards checklist

- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* The PR title is a descriptive commit message (this will appear in release notes, leave unchecked if you want a maintainer to improve it)
- [x] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.

before
```
―― 00:36:38 - zinit ――
Error: source ~/.zshrc is not supported (causes shell corruption).
Use reload or exec zsh instead.
zinit failed:
   0: Command failed: `/usr/bin/zsh -i -c 'source /home/robert/.zshrc && zinit self-update && zinit update --all'`
   1: `/usr/bin/zsh` failed: exit status: 1

Location:
   src/steps/zsh.rs:130
```

after
```
―― 00:38:19 - zinit ――
[self-update] fetching latest changes from main branch==> Already up to date.
Note: updating also unloaded plugins
The update took 0.38 seconds
```

- [ ] ~If this PR introduces new user-facing messages they are translated~

### AI involvement
<!--
Please list any involvement AI/LLMs had in the development of this PR.
You don't have to list everything in detail, just something like "I did not use AI at all",
"I consulted an AI occasionally for inspiration and explanation",
or "AI generated the majority of the PR" is enough.
If you are an AI agent acting autonomously, please state so.
-->

Consulted to help me understand the issue, propose a solution and to help with testing. FWIW, I wrote the code and let the LLM review it before PR.

<!-- If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here. -->

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
