### PR TITLE
fix(antidote): stop the zsh probe suspending topgrade

### DIFF
--- a/src/steps/zsh.rs
+++ b/src/steps/zsh.rs
@@ -52,7 +52,10 @@ pub fn run_antidote(ctx: &ExecutionContext) -> Result<()> {
 
     match update {
         // Commands handed to an *interactive* zsh must end on a builtin (#2158).
-        AntidoteUpdate::Shell => ctx.execute(zsh).args(["-i", "-c", "antidote update; exit $?"]).status_checked(),
+        AntidoteUpdate::Shell => ctx
+            .execute(zsh)
+            .args(["-i", "-c", "antidote update; exit $?"])
+            .status_checked(),
         AntidoteUpdate::Source(antidote) => ctx
             .execute(zsh)
             .args(["-c", r#"source "$1" && antidote update"#, "zsh"])

--- a/src/steps/zsh.rs
+++ b/src/steps/zsh.rs
@@ -51,7 +51,8 @@ pub fn run_antidote(ctx: &ExecutionContext) -> Result<()> {
     print_separator("antidote");
 
     match update {
-        AntidoteUpdate::Shell => ctx.execute(zsh).args(["-i", "-c", "antidote update"]).status_checked(),
+        // Commands handed to an *interactive* zsh must end on a builtin (#2158).
+        AntidoteUpdate::Shell => ctx.execute(zsh).args(["-i", "-c", "antidote update; exit $?"]).status_checked(),
         AntidoteUpdate::Source(antidote) => ctx
             .execute(zsh)
             .args(["-c", r#"source "$1" && antidote update"#, "zsh"])
@@ -61,9 +62,10 @@ pub fn run_antidote(ctx: &ExecutionContext) -> Result<()> {
 }
 
 fn antidote_available_in_shell(ctx: &ExecutionContext, zsh: &Path) -> bool {
+    // Commands handed to an *interactive* zsh must end on a builtin (#2158).
     ctx.execute(zsh)
         .always()
-        .args(["-i", "-c", "antidote home"])
+        .args(["-i", "-c", "command -v antidote"])
         .output_checked()
         .is_ok()
 }


### PR DESCRIPTION
## What does this PR do
<!--
Describe what your PR does, and link any relevant issues.
Make sure to use a keyword like 'closes' if this PR solves the issue.
-->

This PR fixes a regression caused by #2136, which probes with `zsh -i -c "antidote home"`, a command it expects to fail. zsh execs the last command of a `-c` script instead of forking it, and an interactive zsh has already taken the terminal's foreground process group, so nothing is left alive to hand it back. Topgrade runs in the background from there until the next `tcsetattr` raises SIGTTOU and the kernel stops the whole group. The step reports `antidote: SKIPPED` right after, so it leaves no trace. It hits anyone with `zsh` on `PATH`, and the casualty is whichever prompt comes first: the retry prompt (#2158), the Skills TUI (#2176), claude (#2181).

`command -v` is a builtin, so zsh never execs and survives to restore the terminal, and it still detects antidote sourced, as a binary, or absent, so #2136's detection keeps working. `antidote update` leaks the same way when antidote is a real binary, so it gets `exit $?`, which preserves the status that `; true` would swallow into a false OK. Verified on zsh 5.9.2 (Linux) and 5.9 (macOS 26.5.2).

Closes #2158

## Standards checklist

- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* The PR title is a descriptive commit message (this will appear in release notes, leave unchecked if you want a maintainer to improve it)
- [x] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.

Before:
```
$ topgrade --only shell custom_commands
── 20:08:29 - boom ─────────────────────────────────────────────────────────────
boom failed:
   0: Command failed: `/usr/bin/bash -c false`
   1: `/usr/bin/bash` failed: exit status: 1
Retry? (y)es/(N)o/(s)hell/(q)uit
[1]+  Stopped                    topgrade --only shell custom_commands
```

After:
```
$ topgrade --only shell custom_commands
── 20:08:41 - boom ─────────────────────────────────────────────────────────────
boom failed:
   0: Command failed: `/usr/bin/bash -c false`
   1: `/usr/bin/bash` failed: exit status: 1
Retry? (y)es/(N)o/(s)hell/(q)uit
```

`strace` on the probe, before and after. `TIOCSPGRP` is the terminal foreground handover:

```
before:  830460 execve("/usr/bin/zsh", ["zsh", "-i", "-c", "antidote home"])
         830460 ioctl(10, TIOCSPGRP, [830460])   <- zsh takes the foreground
         830460 ioctl(10, TIOCSPGRP, [830460])   <- takes it again, then execs and never hands it back
         830459 ioctl(0, TCSETS2, {...}) = ? ERESTARTSYS   <- topgrade's prompt -> SIGTTOU -> stopped

after:   830460 execve("/usr/bin/zsh", ["zsh", "-i", "-c", "command -v antidote"])
         830460 ioctl(10, TIOCSPGRP, [830460])   <- zsh takes the foreground
         830460 ioctl(10, TIOCSPGRP, [830457])   <- hands it back to topgrade's process group
```

- [ ] ~If this PR introduces new user-facing messages they are translated~

### AI involvement
<!--
Please list any involvement AI/LLMs had in the development of this PR.
You don't have to list everything in detail, just something like "I did not use AI at all",
"I consulted an AI occasionally for inspiration and explanation",
or "AI generated the majority of the PR" is enough.
If you are an AI agent acting autonomously, please state so.
-->

Used for researching the issue.

<!-- If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here. -->

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
