### PR TITLE
NOSQUASH: fix(sudo): non-interactive sudo loop refresh and cache credentials upfront

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -18,7 +18,7 @@
 # (default: false)
 # pre_sudo = false
 
-# Periodically runs `sudo -v` or `please -w` to avoid password re-prompts during updates (default: false)
+# Periodically runs `sudo -n -v` or `please -w` to avoid password re-prompts during updates (default: false)
 # WARNING: This is a potential security risk; if you walk away from the computer while topgrade is running,
 # another person can come by, CTRL+C, and gain access to a sudo session.
 # sudo_loop = true

--- a/src/config.rs
+++ b/src/config.rs
@@ -2023,7 +2023,8 @@ impl Config {
             .unwrap_or(false)
     }
 
-    /// If `true`, periodically run `sudo -v` to keep credentials alive during the run
+    /// If `true`, credentials are cached at the start of the run (as with `pre_sudo`)
+    /// and refreshed (`sudo -v`) to keep them alive during the run
     pub fn sudo_loop(&self) -> bool {
         self.opt.sudo_loop
             || self

--- a/src/config.rs
+++ b/src/config.rs
@@ -2024,7 +2024,7 @@ impl Config {
     }
 
     /// If `true`, credentials are cached at the start of the run (as with `pre_sudo`)
-    /// and refreshed (`sudo -v`) to keep them alive during the run
+    /// and refreshed non-interactively (`sudo -n -v`) to keep them alive during the run
     pub fn sudo_loop(&self) -> bool {
         self.opt.sudo_loop
             || self
@@ -2035,7 +2035,7 @@ impl Config {
                 .unwrap_or(false)
     }
 
-    /// Interval in seconds between `sudo -v` invocations when sudo_loop is active
+    /// Interval in seconds between `sudo -n -v` invocations when sudo_loop is active
     pub fn sudo_loop_interval(&self) -> u16 {
         self.opt
             .sudo_loop_interval

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,8 +183,8 @@ fn run() -> Result<()> {
         None
     };
 
-    if config.pre_sudo()
-        && let Some(sudo) = ctx.sudo()
+    if let Some(sudo) = ctx.sudo()
+        && (config.pre_sudo() || (config.sudo_loop() && sudo.can_refresh()))
     {
         sudo.elevate(&ctx)?;
     }

--- a/src/sudo.rs
+++ b/src/sudo.rs
@@ -341,6 +341,22 @@ impl Sudo {
         cmd.status_checked().wrap_err("Failed to elevate permissions")
     }
 
+    /// Refresh arguments for the sudo kinds that can cache credentials.
+    fn refresh_args(&self) -> Option<&'static [&'static str]> {
+        match self.kind {
+            // `-v`: on a still-valid timestamp, extends it without touching PAM.
+            SudoKind::Sudo => Some(&["-v"]),
+            // `-w`: refreshes a still-valid token without prompting; only prompts once cold.
+            SudoKind::Please => Some(&["-w"]),
+            _ => None,
+        }
+    }
+
+    /// Whether this sudo kind supports credential cache refresh
+    pub fn can_refresh(&self) -> bool {
+        self.refresh_args().is_some()
+    }
+
     /// Silently refresh cached superuser credentials.
     ///
     /// Only for sudo kinds that support credential caching (`sudo -v`, `please -w`).
@@ -349,18 +365,15 @@ impl Sudo {
         let Some(path) = self.path.as_deref() else {
             return Ok(());
         };
+        let Some(args) = self.refresh_args() else {
+            return Ok(());
+        };
 
-        let mut cmd = run_type.execute(path);
-        match self.kind {
-            SudoKind::Sudo => {
-                cmd.arg("-v");
-            }
-            SudoKind::Please => {
-                cmd.arg("-w");
-            }
-            _ => return Ok(()),
-        }
-        cmd.status_checked().wrap_err("Failed to refresh sudo credentials")
+        run_type
+            .execute(path)
+            .args(args)
+            .status_checked()
+            .wrap_err("Failed to refresh sudo credentials")
     }
 
     /// Execute a command with `sudo`.

--- a/src/sudo.rs
+++ b/src/sudo.rs
@@ -344,9 +344,11 @@ impl Sudo {
     /// Refresh arguments for the sudo kinds that can cache credentials.
     fn refresh_args(&self) -> Option<&'static [&'static str]> {
         match self.kind {
-            // `-v`: on a still-valid timestamp, extends it without touching PAM.
-            SudoKind::Sudo => Some(&["-v"]),
-            // `-w`: refreshes a still-valid token without prompting; only prompts once cold.
+            // `-n`: refresh runs on a background thread, so a cold credential must fail fast rather than prompt.
+            // `-v`: on a still-valid timestamp extends it without touching PAM.
+            SudoKind::Sudo => Some(&["-n", "-v"]),
+            // `-w`: refreshes a still-valid token without prompting; it only prompts once the token has gone cold.
+            // `-n`: warm path skips the token update entirely, silently stopping the keep-alive.
             SudoKind::Please => Some(&["-w"]),
             _ => None,
         }
@@ -359,7 +361,7 @@ impl Sudo {
 
     /// Silently refresh cached superuser credentials.
     ///
-    /// Only for sudo kinds that support credential caching (`sudo -v`, `please -w`).
+    /// Only for sudo kinds that support credential caching (`sudo -n -v`, `please -w`).
     /// For others it's a no-op.
     pub fn refresh(&self, run_type: RunType) -> Result<()> {
         let Some(path) = self.path.as_deref() else {


### PR DESCRIPTION
## What does this PR do
<!--
Describe what your PR does, and link any relevant issues.
Make sure to use a keyword like 'closes' if this PR solves the issue.
-->

This PR changes `sudo -v` -> `sudo -n -v`, which doesn't re-prompt for password if it expired. The reasoning behind this is that if the cache expires for any reason, we should not re-prompt just for the sake of doing that; let the next step that actually needs those credentials re-prompt (if there even is one). We could maybe surface a warning when the cache expires but I'm unsure.

Flags that we use are documented in comments now.

Topgrade now also prompts for sudo password at the start (so the loop is guaranteed to have credentials to refresh) if:

```toml
# pre_sudo = true
sudo_loop = true
```

## Standards checklist

- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* The PR title is a descriptive commit message (this will appear in release notes, leave unchecked if you want a maintainer to improve it)
- [x] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [ ] ~If this PR introduces new user-facing messages they are translated~

### AI involvement
<!--
Please list any involvement AI/LLMs had in the development of this PR.
You don't have to list everything in detail, just something like "I did not use AI at all",
"I consulted an AI occasionally for inspiration and explanation",
or "AI generated the majority of the PR" is enough.
If you are an AI agent acting autonomously, please state so.
-->

I let Claude diagnose the issue, describe the solution, write only some failing tests and then review (and fix) my code after I got it to pass the tests. It also split changes in two commits.

<!-- If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here. -->

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
