### PR TITLE
NOSQUASH: fix(wsl): preserve bash command arguments when calling WSL

### DIFF
--- a/src/steps/os/windows.rs
+++ b/src/steps/os/windows.rs
@@ -134,24 +134,30 @@ fn upgrade_wsl_distribution(wsl: &Path, dist: &str, ctx: &ExecutionContext) -> R
         .trim_end()
         .to_owned();
 
+    // WSL joins the arguments following the Linux command into a command line,
+    // so arguments appended after the `bash -lc` script are not reliably passed
+    // through as Bash positional parameters. Keep the complete script in one
+    // argument and shell-quote the values that originated outside this function.
+    let script = wsl_topgrade_script(dist, &topgrade, ctx.config().verbose(), ctx.config().yes(Step::Wsl));
+
     ctx.execute(wsl)
-        // Pass the distro name, discovered topgrade path, and forwarded flags as
-        // positional parameters so the inner `bash -lc` receives them as single argv
-        // elements instead of parsing their contents. `"${@:3}"` forwards the flags
-        // to `topgrade` (not `bash`) and expands to nothing when there are none.
-        .args([
-            "-d",
-            dist,
-            "bash",
-            "-lc",
-            r#"TOPGRADE_PREFIX="$1" exec "$2" "${@:3}""#,
-            "bash",
-        ])
-        .arg(dist)
-        .arg(&topgrade)
-        .arg_if(ctx.config().verbose(), "-v")
-        .arg_if(ctx.config().yes(Step::Wsl), "-y")
+        .args(["-d", dist, "bash", "-lc", &script])
         .status_checked()
+}
+
+fn wsl_topgrade_script(dist: &str, topgrade: &str, verbose: bool, yes: bool) -> String {
+    let mut script = format!(
+        "TOPGRADE_PREFIX={} exec {}",
+        shell_words::quote(dist),
+        shell_words::quote(topgrade)
+    );
+    if verbose {
+        script.push_str(" -v");
+    }
+    if yes {
+        script.push_str(" -y");
+    }
+    script
 }
 
 pub fn run_wsl_topgrade(ctx: &ExecutionContext) -> Result<()> {
@@ -264,4 +270,17 @@ pub fn insert_startup_scripts(ctx: &ExecutionContext, git_repos: &mut RepoStep) 
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::wsl_topgrade_script;
+
+    #[test]
+    fn wsl_topgrade_script_quotes_dynamic_values_and_forwards_flags() {
+        assert_eq!(
+            wsl_topgrade_script("Distro's name", "/home/user/top grade", true, true),
+            "TOPGRADE_PREFIX='Distro'\\''s name' exec '/home/user/top grade' -v -y"
+        );
+    }
 }

--- a/src/steps/os/windows.rs
+++ b/src/steps/os/windows.rs
@@ -168,21 +168,27 @@ pub fn run_wsl_topgrade(ctx: &ExecutionContext) -> Result<()> {
     let wsl = require("wsl")?;
     let wsl_distributions = get_wsl_distributions(ctx, &wsl)?;
     let mut ran = false;
+    let mut first_error = None;
 
     debug!("WSL distributions: {:?}", wsl_distributions);
 
     for distribution in wsl_distributions {
         let result = upgrade_wsl_distribution(&wsl, &distribution, ctx);
         debug!("Upgrading {:?}: {:?}", distribution, result);
-        if let Err(e) = result
-            && e.is::<SkipStep>()
-        {
-            continue;
+        match result {
+            Ok(()) => ran = true,
+            Err(e) if e.is::<SkipStep>() => continue,
+            Err(e) => {
+                if first_error.is_none() {
+                    first_error = Some(e);
+                }
+            }
         }
-        ran = true
     }
 
-    if ran {
+    if let Some(error) = first_error {
+        Err(error)
+    } else if ran {
         Ok(())
     } else {
         Err(SkipStep(t!("Could not find Topgrade in any WSL distribution").to_string()).into())


### PR DESCRIPTION
Fixes: https://github.com/topgrade-rs/topgrade/issues/2184

## What does this PR do
During the 'wsl' step of Topgrade, `wsl.exe` does not reliably pass arguments appended after a `bash -lc` script as positional parameters. This left the `topgrade` path in `$2` empty and produced `bash: line 1:  exec: command not found` lines for each WSL distro call.

A new regression test covers spaces and single quotes when building the commandline.

We now also track if at least one WSL distro `topgrade` call returned an error. So we can show WSL as failed at the summary at the end. All while still continueing to check all WSL distros in the list.

## Standards checklist

- [x] I have read [the relevant parts of] `CONTRIBUTING.md`
- [ ] *Optional:* The PR title is a descriptive commit message (this will appear in release notes, leave unchecked if you want a maintainer to improve it)
- [x] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [none] If this PR introduces new user-facing messages they are translated

### AI involvement
I used Codex app for Windows with GPT 5.6 Sol.

I did read and understood the generated code. It's just a few lines.

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
