### PR TITLE
fix(nix): avoid symlink resolution when determining sudo user

### DIFF
--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -34,26 +34,23 @@ use crate::step::Step;
 use crate::terminal::print_separator;
 use crate::utils::{PathExt, require};
 
-fn get_sudo_uid<P: AsRef<Path>>(path: P) -> Option<u32> {
-    if let Ok(metadata) = fs::metadata(&path) {
-        let owner_id = metadata.uid();
-        let current_id = nix::unistd::Uid::effective();
-        // print debug these two values
-        debug!(
-            "path: {path:?}, owner_id: {owner_id}, current_id: {current_id}",
-            path = path.as_ref()
-        );
-        return if owner_id == current_id.as_raw() {
-            None // no need for sudo if path is owned by the current user
-        } else {
-            Some(owner_id) // otherwise use sudo to run as the owner
-        };
+fn get_sudo_uid_from_metadata<P: AsRef<Path>>(path: P, metadata: fs::Metadata) -> Option<u32> {
+    let owner_id = metadata.uid();
+    let current_id = nix::unistd::Uid::effective();
+    // print debug these two values
+    debug!(
+        "path: {path:?}, owner_id: {owner_id}, current_id: {current_id}",
+        path = path.as_ref()
+    );
+    if owner_id == current_id.as_raw() {
+        None // no need for sudo if path is owned by the current user
+    } else {
+        Some(owner_id) // otherwise use sudo to run as the owner
     }
-    None
 }
 
-fn get_sudo_user<P: AsRef<Path>>(path: P) -> Option<String> {
-    let sudo_uid = get_sudo_uid(path);
+fn get_sudo_user_from_metadata<P: AsRef<Path>>(path: P, metadata: fs::Metadata) -> Option<String> {
+    let sudo_uid = get_sudo_uid_from_metadata(path, metadata);
     // if path is owned by another user, execute "sudo -Hu <user> <binary_name>"
     if let Some(user_id) = sudo_uid {
         let uid = nix::unistd::Uid::from_raw(user_id);
@@ -64,6 +61,20 @@ fn get_sudo_user<P: AsRef<Path>>(path: P) -> Option<String> {
         }
     }
     None
+}
+
+fn get_sudo_user<P: AsRef<Path>>(path: P) -> Option<String> {
+    match fs::metadata(&path) {
+        Ok(metadata) => get_sudo_user_from_metadata(path, metadata),
+        Err(_) => None,
+    }
+}
+
+fn get_symlink_sudo_user<P: AsRef<Path>>(path: P) -> Option<String> {
+    match fs::symlink_metadata(&path) {
+        Ok(metadata) => get_sudo_user_from_metadata(path, metadata),
+        Err(_) => None,
+    }
 }
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
@@ -702,7 +713,7 @@ pub fn run_nix(ctx: &ExecutionContext) -> Result<()> {
             warn!("`nix-channel --update` failed: {e}");
         }
         print_separator("Nix Profiles");
-        let mut command = match &get_sudo_user(profile_path) {
+        let mut command = match &get_symlink_sudo_user(profile_path) {
             None => ctx.execute(nix),
             Some(user) => {
                 let sudo = ctx.require_sudo()?;
@@ -722,7 +733,7 @@ pub fn run_nix(ctx: &ExecutionContext) -> Result<()> {
         let nix_env = require("nix-env")?;
         print_separator("Nix");
 
-        let mut command = match &get_sudo_user(profile_path) {
+        let mut command = match &get_symlink_sudo_user(profile_path) {
             None => ctx.execute(nix_env),
             Some(user) => {
                 let sudo = ctx.require_sudo()?;

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -63,6 +63,7 @@ fn get_sudo_user_from_metadata<P: AsRef<Path>>(path: P, metadata: fs::Metadata) 
     None
 }
 
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 fn get_sudo_user<P: AsRef<Path>>(path: P) -> Option<String> {
     match fs::metadata(&path) {
         Ok(metadata) => get_sudo_user_from_metadata(path, metadata),


### PR DESCRIPTION
## What does this PR do
This PR should fix #2177.
I reproduced it and have found that, while I did write #2076 with symlinks in mind, I overlooked that the `get_sudo_user()` function I repurposed resolves the symlink. I added a new `get_symlink_sudo_user()` function that does not follow symlinks. I reworked the common functions between them to accept the `fs::Metadata` structure, which is taken either from `fs::metadata()` (`get_sudo_user()`) or `fs::symlink_metadata()` (`get_symlink_sudo_user()`). The `path` parameter is technically only needed by the debug statement, but I think that this debug message is useful, so I chose to keep it.

<details>
<summary>Before</summary>

```
[vm@localhost ~]$ topgrade --only nix --verbose
DEBUG Current system locale is en-US
DEBUG Configuration directory /home/vm/.config/ does not exist
DEBUG Version: 17.8.0
DEBUG OS: x86_64-unknown-linux-gnu
DEBUG Args { inner: ["./topgrade", "--only", "nix", "--verbose"] }
DEBUG Binary path: Ok("/home/vm/topgrade")
DEBUG self-update Feature Enabled: true
DEBUG Configuration: Config { opt: CommandLineArgs { edit_config: false, show_config_reference: false, run_in_tmux: false, no_tmux: false, cleanup: false, dry_run: false, run_type: Wet, no_retry: false, no_ask_retry: false, auto_retry: None, disable: [], only: [Nix], custom_commands: [], env: [], verbose: true, keep_at_end: false, skip_notify: false, notify_end: Always, yes: None, disable_predefined_git_repos: false, config: None, remote_host_limit: None, show_skipped: false, allow_root: false, sudo_loop: false, sudo_loop_interval: None, log_filter: "warn", gen_completion: None, gen_manpage: false, no_self_update: false }, config_file: ConfigFile { include: None, misc: None, pre_commands: None, post_commands: None, commands: None, conda: None, python: None, composer: None, brew: None, linux: None, mandb: None, git: None, go: None, containers: None, windows: None, npm: None, chezmoi: None, mise: None, yarn: None, deno: None, vim: None, firmware: None, vagrant: None, flatpak: None, pixi: None, distrobox: None, lensfun: None, julia: None, zigup: None, vscode: None, doom: None, cargo: None, rustup: None, pkgfile: None, viteplus: None }, allowed_steps: [Nix] }
DEBUG Running with euid: 1000
DEBUG Proc version output: Linux version 6.19.10-300.fc44.x86_64 (mockbuild@4ae50e2f6b614b1a809cc64e77352d92) (gcc (GCC) 16.0.1 20260321 (Red Hat 16.0.1-0), GNU ld version 2.46-1.fc44) #1 SMP PREEMPT_DYNAMIC Wed Mar 25 18:23:49 UTC 2026

DEBUG Cannot find "doas"
DEBUG Proc version output: Linux version 6.19.10-300.fc44.x86_64 (mockbuild@4ae50e2f6b614b1a809cc64e77352d92) (gcc (GCC) 16.0.1 20260321 (Red Hat 16.0.1-0), GNU ld version 2.46-1.fc44) #1 SMP PREEMPT_DYNAMIC Wed Mar 25 18:23:49 UTC 2026

DEBUG Detected "/usr/bin/sudo" as "sudo"
DEBUG Sudo: Ok(Sudo { path: Some("/usr/bin/sudo"), kind: Sudo })
DEBUG Step "nix"
DEBUG Proc version output: Linux version 6.19.10-300.fc44.x86_64 (mockbuild@4ae50e2f6b614b1a809cc64e77352d92) (gcc (GCC) 16.0.1 20260321 (Red Hat 16.0.1-0), GNU ld version 2.46-1.fc44) #1 SMP PREEMPT_DYNAMIC Wed Mar 25 18:23:49 UTC 2026

DEBUG Detected "/usr/bin/nix" as "nix"
DEBUG Executing command `/usr/bin/nix --extra-experimental-features nix-command config show use-xdg-base-directories`
DEBUG `nix config show use-xdg-base-directories` output output=false

DEBUG nix user profile link: "/home/vm/.nix-profile"
DEBUG nix current profile: "/home/vm/.local/state/nix/profiles/profile"
DEBUG Executing command `/usr/bin/nix --version`
DEBUG `nix --version` output output=nix (Nix) 2.34.7

DEBUG Raw Nix version: 2.34.7
DEBUG Corrected raw Nix version: 2.34.7
DEBUG Nix version: Version { major: 2, minor: 34, patch: 7 }
DEBUG is_lix=false
DEBUG Proc version output: Linux version 6.19.10-300.fc44.x86_64 (mockbuild@4ae50e2f6b614b1a809cc64e77352d92) (gcc (GCC) 16.0.1 20260321 (Red Hat 16.0.1-0), GNU ld version 2.46-1.fc44) #1 SMP PREEMPT_DYNAMIC Wed Mar 25 18:23:49 UTC 2026

DEBUG Detected "/usr/bin/nix-channel" as "nix-channel"

── 22:02:02 - Nix Channels ─────────────────────────────────────────────────────
DEBUG Executing command `/usr/bin/nix-channel --update`
unpacking 0 channels...

── 22:02:02 - Nix Profiles ─────────────────────────────────────────────────────
DEBUG path: "/home/vm/.local/state/nix/profiles/profile", owner_id: 0, current_id: 1000
DEBUG Executing command `/usr/bin/sudo -i -H -u root /usr/bin/nix --extra-experimental-features nix-command profile upgrade --all --impure --verbose`
warning: There are no packages in the profile.
warning: No packages to upgrade. Use 'nix profile list' to see the current profile.
DEBUG Step "nix upgrade-nix"
DEBUG Proc version output: Linux version 6.19.10-300.fc44.x86_64 (mockbuild@4ae50e2f6b614b1a809cc64e77352d92) (gcc (GCC) 16.0.1 20260321 (Red Hat 16.0.1-0), GNU ld version 2.46-1.fc44) #1 SMP PREEMPT_DYNAMIC Wed Mar 25 18:23:49 UTC 2026

DEBUG Detected "/usr/bin/nix" as "nix"
DEBUG Executing command `/usr/bin/nix --version`
DEBUG `nix --version` output output=nix (Nix) 2.34.7

DEBUG is_determinate_nix=false
DEBUG Found Nix in "/usr"
DEBUG Found Nix profile "/usr"

── 22:02:02 - Summary ──────────────────────────────────────────────────────────
nix: OK
nix upgrade-nix: SKIPPED: `nix upgrade-nix` cannot be run when Nix is installed in a profile
DEBUG Desktop notification: Topgrade finished successfully
```

</details>

<details>
<summary>After</summary>

```
[vm@localhost ~]$ topgrade --only nix --verbose
DEBUG Current system locale is en-US
DEBUG Configuration directory /home/vm/.config/ does not exist
DEBUG Version: 17.8.0
DEBUG OS: x86_64-unknown-linux-gnu
DEBUG Args { inner: ["topgrade", "--only", "nix", "--verbose"] }
DEBUG Binary path: Ok("/home/vm/.cargo/bin/topgrade")
DEBUG self-update Feature Enabled: false
DEBUG Configuration: Config { opt: CommandLineArgs { edit_config: false, show_config_reference: false, run_in_tmux: false, no_tmux: false, cleanup: false, dry_run: false, run_type: Wet, no_retry: false, no_ask_retry: false, auto_retry: None, disable: [], only: [Nix], custom_commands: [], env: [], verbose: true, keep_at_end: false, skip_notify: false, notify_end: Always, yes: None, disable_predefined_git_repos: false, config: None, remote_host_limit: None, show_skipped: false, allow_root: false, sudo_loop: false, sudo_loop_interval: None, log_filter: "warn", gen_completion: None, gen_manpage: false, no_self_update: false }, config_file: ConfigFile { include: None, misc: None, pre_commands: None, post_commands: None, commands: None, conda: None, python: None, composer: None, brew: None, linux: None, mandb: None, git: None, go: None, containers: None, windows: None, npm: None, chezmoi: None, mise: None, yarn: None, deno: None, vim: None, firmware: None, vagrant: None, flatpak: None, pixi: None, distrobox: None, lensfun: None, julia: None, zigup: None, vscode: None, doom: None, cargo: None, rustup: None, pkgfile: None, viteplus: None }, allowed_steps: [Nix] }
DEBUG Running with euid: 1000
DEBUG Proc version output: Linux version 6.19.10-300.fc44.x86_64 (mockbuild@4ae50e2f6b614b1a809cc64e77352d92) (gcc (GCC) 16.0.1 20260321 (Red Hat 16.0.1-0), GNU ld version 2.46-1.fc44) #1 SMP PREEMPT_DYNAMIC Wed Mar 25 18:23:49 UTC 2026

DEBUG Cannot find "doas"
DEBUG Proc version output: Linux version 6.19.10-300.fc44.x86_64 (mockbuild@4ae50e2f6b614b1a809cc64e77352d92) (gcc (GCC) 16.0.1 20260321 (Red Hat 16.0.1-0), GNU ld version 2.46-1.fc44) #1 SMP PREEMPT_DYNAMIC Wed Mar 25 18:23:49 UTC 2026

DEBUG Detected "/usr/bin/sudo" as "sudo"
DEBUG Sudo: Ok(Sudo { path: Some("/usr/bin/sudo"), kind: Sudo })
DEBUG Step "nix"
DEBUG Proc version output: Linux version 6.19.10-300.fc44.x86_64 (mockbuild@4ae50e2f6b614b1a809cc64e77352d92) (gcc (GCC) 16.0.1 20260321 (Red Hat 16.0.1-0), GNU ld version 2.46-1.fc44) #1 SMP PREEMPT_DYNAMIC Wed Mar 25 18:23:49 UTC 2026

DEBUG Detected "/usr/bin/nix" as "nix"
DEBUG Executing command `/usr/bin/nix --extra-experimental-features nix-command config show use-xdg-base-directories`
DEBUG `nix config show use-xdg-base-directories` output output=false

DEBUG nix user profile link: "/home/vm/.nix-profile"
DEBUG nix current profile: "/home/vm/.local/state/nix/profiles/profile"
DEBUG Executing command `/usr/bin/nix --version`
DEBUG `nix --version` output output=nix (Nix) 2.34.7

DEBUG Raw Nix version: 2.34.7
DEBUG Corrected raw Nix version: 2.34.7
DEBUG Nix version: Version { major: 2, minor: 34, patch: 7 }
DEBUG is_lix=false
DEBUG Proc version output: Linux version 6.19.10-300.fc44.x86_64 (mockbuild@4ae50e2f6b614b1a809cc64e77352d92) (gcc (GCC) 16.0.1 20260321 (Red Hat 16.0.1-0), GNU ld version 2.46-1.fc44) #1 SMP PREEMPT_DYNAMIC Wed Mar 25 18:23:49 UTC 2026

DEBUG Detected "/usr/bin/nix-channel" as "nix-channel"

── 22:00:35 - Nix Channels ─────────────────────────────────────────────────────
DEBUG Executing command `/usr/bin/nix-channel --update`
unpacking 0 channels...

── 22:00:35 - Nix Profiles ─────────────────────────────────────────────────────
DEBUG path: "/home/vm/.local/state/nix/profiles/profile", owner_id: 1000, current_id: 1000
DEBUG Executing command `/usr/bin/nix --extra-experimental-features nix-command profile upgrade --all --impure --verbose`
unpacking 'https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz' into the Git cache...
upgrading 'legacyPackages.x86_64-linux.flyctl' from flake 'https://releases.nixos.org/nixpkgs/nixpkgs-26.11pre1035098.35d3407a3816/nixexprs.tar.xz?narHash=sha256-sV32iDQooUstJItsEiqRmWuhOuMcOR/vkMpHsT%2B87fI%3D' to 'https://releases.nixos.org/nixpkgs/nixpkgs-26.11pre1035098.35d3407a3816/nixexprs.tar.xz?narHash=sha256-sV32iDQooUstJItsEiqRmWuhOuMcOR/vkMpHsT%2B87fI%3D'
DEBUG Step "nix upgrade-nix"
DEBUG Proc version output: Linux version 6.19.10-300.fc44.x86_64 (mockbuild@4ae50e2f6b614b1a809cc64e77352d92) (gcc (GCC) 16.0.1 20260321 (Red Hat 16.0.1-0), GNU ld version 2.46-1.fc44) #1 SMP PREEMPT_DYNAMIC Wed Mar 25 18:23:49 UTC 2026

DEBUG Detected "/usr/bin/nix" as "nix"
DEBUG Executing command `/usr/bin/nix --version`
DEBUG `nix --version` output output=nix (Nix) 2.34.7

DEBUG is_determinate_nix=false
DEBUG Found Nix in "/usr"
DEBUG Found Nix profile "/usr"

── 22:00:37 - Summary ──────────────────────────────────────────────────────────
nix: OK
nix upgrade-nix: SKIPPED: `nix upgrade-nix` cannot be run when Nix is installed in a profile
DEBUG Desktop notification: Topgrade finished successfully
```

</details>

## Standards checklist

- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* The PR title is a descriptive commit message (this will appear in release notes, leave unchecked if you want a maintainer to improve it)
- [x] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [ ] If this PR introduces new user-facing messages they are translated

### AI involvement
I did not use AI at all.

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
