### PR TITLE
feat(mise): run `mise prune` if `cleanup = true`

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -2477,10 +2477,6 @@ pub fn run_mise(ctx: &ExecutionContext) -> Result<()> {
             cmd.arg("--yes");
         }
 
-        if ctx.run_type().dry() {
-            cmd.arg("--dry-run");
-        }
-
         cmd.status_checked()?;
     }
 

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -2469,6 +2469,21 @@ pub fn run_mise(ctx: &ExecutionContext) -> Result<()> {
 
     cmd.status_checked()?;
 
+    if ctx.config().cleanup() {
+        cmd = ctx.execute(&mise);
+        cmd.arg("prune");
+
+        if ctx.config().yes(Step::Mise) {
+            cmd.arg("--yes");
+        }
+
+        if ctx.run_type().dry() {
+            cmd.arg("--dry-run");
+        }
+
+        cmd.status_checked()?;
+    }
+
     refresh_mise_env(ctx, &mise, temp_dir.path())
 }
 


### PR DESCRIPTION
## What does this PR do
<!--
Describe what your PR does, and link any relevant issues.
Make sure to use a keyword like 'closes' if this PR solves the issue.
-->

Invoke `mise prune` if cleanup if asked.

## Standards checklist

- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* The PR title is a descriptive commit message (this will appear in release notes, leave unchecked if you want a maintainer to improve it)
- [x] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [ ] If this PR introduces new user-facing messages they are translated

```
$ cargo r -- --only mise
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.20s
warning: the following packages contain code that will be rejected by a future version of Rust: proc-macro-error2 v2.0.1
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
     Running `target/debug/topgrade --only mise`

── 23:47:08 - mise ─────────────────────────────────────────────────────────────
mise All tools are up to date
mise pruned configuration links

── 23:47:08 - Summary ──────────────────────────────────────────────────────────
mise: OK
```

### AI involvement
<!--
Please list any involvement AI/LLMs had in the development of this PR.
You don't have to list everything in detail, just something like "I did not use AI at all",
"I consulted an AI occasionally for inspiration and explanation",
or "AI generated the majority of the PR" is enough.
If you are an AI agent acting autonomously, please state so.
-->

Drafted using an LLM, cleaned up after it.

## For new steps

<!-- This section can be deleted if you are not adding a new step. -->

- [x] *Optional:* Topgrade skips this step where needed
- [x] *Optional:* The `--dry-run` option works with this step
- [x] *Optional:* The `--yes` option works with this step if it is supported by
  the underlying command

Aside, mise global options like `--yes`, `--dry-run`, `--silent`, `--quiet`, `--jobs`, `--verbose` etc could be implemented in a more DRY manner for all invoked mise commands, but I added added explicit `--yes` and `--dry-run` support for `prune`. I have not checked in detail where/how useful they might be for these, but all of them are lacking for `plugins update`,  and `self-update` altogether at time of writing.

<!-- If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here. -->

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
