### PR TITLE
feat(flutter): add config for force option

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -393,6 +393,12 @@
 # upgrade = true
 
 
+[flutter]
+# If this is set to true, the `--force` flag is added to `flutter upgrade`.
+# (default: false)
+# force = true
+
+
 [vagrant]
 # Vagrant directories
 # directories = []

--- a/src/config.rs
+++ b/src/config.rs
@@ -576,6 +576,13 @@ pub struct DoomConfig {
 
 #[derive(Deserialize, Default, Debug, Merge)]
 #[serde(deny_unknown_fields)]
+pub struct Flutter {
+    #[merge(strategy = merge::option::overwrite_none)]
+    force: Option<bool>,
+}
+
+#[derive(Deserialize, Default, Debug, Merge)]
+#[serde(deny_unknown_fields)]
 pub struct Cargo {
     #[merge(strategy = merge::option::overwrite_none)]
     git: Option<bool>,
@@ -668,6 +675,9 @@ pub struct ConfigFile {
 
     #[merge(strategy = crate::utils::merge_strategies::inner_merge_opt)]
     firmware: Option<Firmware>,
+
+    #[merge(strategy = crate::utils::merge_strategies::inner_merge_opt)]
+    flutter: Option<Flutter>,
 
     #[merge(strategy = crate::utils::merge_strategies::inner_merge_opt)]
     vagrant: Option<Vagrant>,
@@ -1930,6 +1940,14 @@ impl Config {
             .cargo
             .as_ref()
             .and_then(|cargo| cargo.locked)
+            .unwrap_or(false)
+    }
+
+    pub fn flutter_force(&self) -> bool {
+        self.config_file
+            .flutter
+            .as_ref()
+            .and_then(|flutter| flutter.force)
             .unwrap_or(false)
     }
 

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -113,7 +113,14 @@ pub fn run_flutter_upgrade(ctx: &ExecutionContext) -> Result<()> {
     let flutter = require("flutter")?;
 
     print_separator("Flutter");
-    ctx.execute(flutter).arg("upgrade").status_checked()
+    let mut command = ctx.execute(flutter);
+    command.arg("upgrade");
+
+    if ctx.config().flutter_force() {
+        command.arg("--force");
+    }
+
+    command.status_checked()
 }
 
 pub fn run_gem(ctx: &ExecutionContext) -> Result<()> {


### PR DESCRIPTION
## What does this PR do

This PR adds support for `flutter upgrade --force` flag. With almost all recent versions, the default upgrade fails due to changes to the Git checkouts that Flutter creates.

## Standards checklist

- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* The PR title is a descriptive commit message (this will appear in release notes, leave unchecked if you want a maintainer to improve it)
- [x] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [ ] If this PR introduces new user-facing messages they are translated

### AI involvement
I consulted JetBrains Junie to write tests for the `--force` flag support. 

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
