### PR TITLE
refactor: cache result of is_wsl

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -38,16 +38,14 @@ use crate::{
 };
 
 #[cfg(target_os = "linux")]
-pub fn is_wsl() -> Result<bool> {
+pub static IS_WSL: LazyLock<bool> = LazyLock::new(|| {
     let output = std::fs::read_to_string("/proc/version").unwrap_or_default();
     debug!("Proc version output: {}", output);
-    Ok(output.to_lowercase().contains("microsoft"))
-}
+    output.to_lowercase().contains("microsoft")
+});
 
 #[cfg(not(target_os = "linux"))]
-pub fn is_wsl() -> Result<bool> {
-    Ok(false)
-}
+pub static IS_WSL: LazyLock<bool> = LazyLock::new(|| false);
 
 pub fn run_cargo_update(ctx: &ExecutionContext) -> Result<()> {
     let cargo_dir = env::var_os("CARGO_HOME")
@@ -561,7 +559,7 @@ impl VSCodeVariant {
 /// VSCodium Insiders, Cursor, Antigravity), as the process is the same for all.
 fn run_vscode_compatible(variant: VSCodeVariant, ctx: &ExecutionContext) -> Result<()> {
     // Calling VSCode/VSCodium in WSL may install a server instead of updating extensions (https://github.com/topgrade-rs/topgrade/issues/594#issuecomment-1782157367)
-    if is_wsl()? {
+    if *IS_WSL {
         return Err(SkipStep(String::from("Should not run in WSL")).into());
     }
 

--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -12,7 +12,7 @@ use crate::config::NixHandler;
 use crate::error::{SkipStep, TopgradeError};
 use crate::execution_context::ExecutionContext;
 use crate::step::Step;
-use crate::steps::generic::is_wsl;
+use crate::steps::generic::IS_WSL;
 use crate::steps::os::archlinux;
 use crate::steps::unix::{NhSwitchArgs, can_nh_switch, nh_switch};
 use crate::sudo::SudoExecuteOpts;
@@ -930,7 +930,7 @@ pub fn run_needrestart(ctx: &ExecutionContext) -> Result<()> {
 pub fn run_fwupdmgr(ctx: &ExecutionContext) -> Result<()> {
     let fwupdmgr = require("fwupdmgr")?;
 
-    if is_wsl()? {
+    if *IS_WSL {
         return Err(SkipStep(t!("Should not run in WSL").to_string()).into());
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -18,6 +18,7 @@ use crate::config::DEFAULT_LOG_LEVEL;
 use crate::error::SkipStep;
 use crate::execution_context::ExecutionContext;
 use crate::executor::Executor;
+use crate::steps::generic::IS_WSL;
 
 pub trait PathExt
 where
@@ -90,7 +91,7 @@ pub fn set_wsl_use_windows_path(use_windows_path: bool) -> Result<()> {
 /// fails to run in the guest (topgrade-rs/topgrade#1243). When on, detection skips those.
 /// Off via `wsl_use_windows_path = true`.
 fn wsl_windows_path_filter_enabled() -> bool {
-    crate::steps::generic::is_wsl().unwrap_or(false) && !WSL_USE_WINDOWS_PATH.get().copied().unwrap_or(false)
+    *IS_WSL && !WSL_USE_WINDOWS_PATH.get().copied().unwrap_or(false)
 }
 
 /// Mount points backed by Windows drives (drvfs on WSL1, 9p/virtiofs on WSL2).


### PR DESCRIPTION
Closes #2197
As a result of #2135, every `which` call (and thus every step) calls `is_wsl`. This pollutes the debug log and gives unnecessary overhead.