### PR TITLE
fix(config)!: ignore config's `only` if `--only` is provided

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1211,16 +1211,14 @@ impl Config {
         let mut enabled_steps = (!opt.only.is_empty())
             .then(|| opt.only.clone())
             .or_else(|| {
-                config_file.misc.as_ref()
+                config_file
+                    .misc
+                    .as_ref()
                     .and_then(|m| m.only.as_ref())
                     .filter(|v| !v.is_empty())
                     .cloned()
             })
-            .unwrap_or_else(|| {
-                Step::iter()
-                    .filter(|x| !step_is_deprecated(*x))
-                    .collect()
-        });
+            .unwrap_or_else(|| Step::iter().filter(|x| !step_is_deprecated(*x)).collect());
 
         let mut disabled_steps: Vec<Step> = Vec::new();
         disabled_steps.extend(&opt.disable);

--- a/src/config.rs
+++ b/src/config.rs
@@ -1203,28 +1203,24 @@ impl Config {
     }
 
     fn allowed_steps(opt: &CommandLineArgs, config_file: &ConfigFile) -> Vec<Step> {
-        // The enabled steps are
-        let mut enabled_steps: Vec<Step> = Vec::new();
-        // Any steps that are passed with `--only`
-        enabled_steps.extend(&opt.only);
-
-        // Plus any steps in the config file's `misc.only`
-        if let Some(misc) = config_file.misc.as_ref()
-            && let Some(only) = misc.only.as_ref()
-        {
-            enabled_steps.extend(only);
-        }
-
         let step_is_deprecated = |x| DEPRECATED_STEPS.contains(&x);
 
-        // If neither of those contain anything
-        if enabled_steps.is_empty() {
-            // All steps are enabled
-            enabled_steps.extend(Step::iter());
-            // Handle deprecated steps. Disable automatically when not explicitly mentioned in the
-            // config, so that the warning doesn't print.
-            enabled_steps.retain(|x| !step_is_deprecated(*x));
-        }
+        // the --only flag has priority over the config file
+        // if there aren't any only steps specified all steps must be ran
+        // deprecated steps are disabled when not explicitly mentioned in only
+        let mut enabled_steps = (!opt.only.is_empty())
+            .then(|| opt.only.clone())
+            .or_else(|| {
+                config_file.misc.as_ref()
+                    .and_then(|m| m.only.as_ref())
+                    .filter(|v| !v.is_empty())
+                    .cloned()
+            })
+            .unwrap_or_else(|| {
+                Step::iter()
+                    .filter(|x| !step_is_deprecated(*x))
+                    .collect()
+        });
 
         let mut disabled_steps: Vec<Step> = Vec::new();
         disabled_steps.extend(&opt.disable);

--- a/src/config.rs
+++ b/src/config.rs
@@ -1205,9 +1205,9 @@ impl Config {
     fn allowed_steps(opt: &CommandLineArgs, config_file: &ConfigFile) -> Vec<Step> {
         let step_is_deprecated = |x| DEPRECATED_STEPS.contains(&x);
 
-        // the --only flag has priority over the config file
-        // if there aren't any only steps specified all steps must be ran
-        // deprecated steps are disabled when not explicitly mentioned in only
+        // The --only flag has priority over the config file.
+        // If there aren't any only steps specified all steps must be ran.
+        // Deprecated steps are disabled when not explicitly mentioned in only.
         let mut enabled_steps = (!opt.only.is_empty())
             .then(|| opt.only.clone())
             .or_else(|| {


### PR DESCRIPTION
## What does this PR do
Changes the behaviour of enabled steps from including steps in the config `only` as well as steps from the `--only` flag to skipping the config `only` steps if the `--only` flag is provided
Closes #1930
<!--
Describe what your PR does, and link any relevant issues.
Make sure to use a keyword like 'closes' if this PR solves the issue.
-->

## Standards checklist

- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* The PR title is a descriptive commit message (this will appear in release notes, leave unchecked if you want a maintainer to improve it)
- [ ] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [ ] If this PR introduces new user-facing messages they are translated

### AI involvement
<!--
Please list any involvement AI/LLMs had in the development of this PR.
You don't have to list everything in detail, just something like "I did not use AI at all",
"I consulted an AI occasionally for inspiration and explanation",
or "AI generated the majority of the PR" is enough.
If you are an AI agent acting autonomously, please state so.
-->
No AI used

<!-- If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here. -->

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
