### PR TITLE
feat(claude): split plugin updates into a separate claude_code_plugins step

### DIFF
--- a/src/step.rs
+++ b/src/step.rs
@@ -47,6 +47,7 @@ pub enum Step {
     CinnamonSpices,
     ClamAvDb,
     ClaudeCode,
+    ClaudeCodePlugins,
     Colima,
     Composer,
     Conda,
@@ -299,6 +300,9 @@ impl Step {
             }
             ClamAvDb => runner.execute(*self, "ClamAV Databases", || generic::run_freshclam(ctx))?,
             ClaudeCode => runner.execute(*self, "Claude Code", || generic::run_claude_code(ctx))?,
+            ClaudeCodePlugins => {
+                runner.execute(*self, "Claude Code Plugins", || generic::run_claude_code_plugins(ctx))?
+            }
             Colima => runner.execute(*self, "Colima", || generic::run_colima(ctx))?,
             Composer => runner.execute(*self, "composer", || generic::run_composer_update(ctx))?,
             Conda => runner.execute(*self, "conda", || generic::run_conda_update(ctx))?,
@@ -927,6 +931,7 @@ pub(crate) fn default_steps() -> Vec<Step> {
         GitRepos,
         ClamAvDb,
         ClaudeCode,
+        ClaudeCodePlugins,
         Opencode,
         Colima,
         Skills,

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -2170,6 +2170,14 @@ pub fn run_typst(ctx: &ExecutionContext) -> Result<()> {
 }
 
 pub fn run_claude_code(ctx: &ExecutionContext) -> Result<()> {
+    let claude = require("claude")?;
+
+    print_separator("Claude Code");
+
+    ctx.execute(&claude).arg("update").status_checked()
+}
+
+pub fn run_claude_code_plugins(ctx: &ExecutionContext) -> Result<()> {
     #[derive(Deserialize)]
     #[serde(rename_all = "camelCase")]
     struct ClaudePlugin {
@@ -2181,9 +2189,7 @@ pub fn run_claude_code(ctx: &ExecutionContext) -> Result<()> {
 
     let claude = require("claude")?;
 
-    print_separator("Claude Code");
-
-    ctx.execute(&claude).arg("update").status_checked()?;
+    print_separator("Claude Code Plugins");
 
     ctx.execute(&claude)
         .args(["plugin", "marketplace", "update"])


### PR DESCRIPTION
## What does this PR do
Splits run_claude_code into claude_code (CLI self-update only) and a new claude_code_plugins step (marketplace + per-plugin updates), so each can be independently enabled/disabled via --only/--disable.

## Standards checklist

- [ ] I have read `CONTRIBUTING.md`
- [x] *Optional:* The PR title is a descriptive commit message (this will appear in release notes, leave unchecked if you want a maintainer to improve it)
- [ ] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [ ] If this PR introduces new user-facing messages they are translated

### AI involvement
I reviewed every line, but assisted by  Claude Sonnet 5

## For new steps

<!-- This section can be deleted if you are not adding a new step. -->

- [x] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by
  the underlying command

<!-- If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here. -->

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
