### PR TITLE
fix(macports): fix passing of -N for assume_yes

### DIFF
--- a/src/steps/os/macos.rs
+++ b/src/steps/os/macos.rs
@@ -19,7 +19,7 @@ pub fn run_macports(ctx: &ExecutionContext) -> Result<()> {
     let sudo = ctx.require_sudo()?;
 
     sudo.execute(ctx, &port)?.arg("selfupdate").status_checked()?;
-    
+
     let yes = ctx.config().yes(Step::Macports);
 
     let mut cmd = sudo.execute(ctx, &port)?;

--- a/src/steps/os/macos.rs
+++ b/src/steps/os/macos.rs
@@ -22,16 +22,21 @@ pub fn run_macports(ctx: &ExecutionContext) -> Result<()> {
     
     let yes = ctx.config().yes(Step::Macports);
 
-    sudo.execute(ctx, &port)?
-        .args(["-u", "upgrade", "outdated"])
-        .map(|cmd| if yes { cmd.arg("-N") } else { cmd })
-        .status_checked()?;
+    let mut cmd = sudo.execute(ctx, &port)?;
+    cmd.args(["-u", "upgrade", "outdated"]);
+    if yes {
+        cmd.arg("-N");
+    }
+    cmd.status_checked()?;
+    
 
     if ctx.config().cleanup() {
-        sudo.execute(ctx, &port)?
-            .arg("reclaim")
-            .map(|cmd| if yes { cmd.arg("-N") } else { cmd })
-            .status_checked()?;
+        let mut cmd = sudo.execute(ctx, &port)?;
+        cmd.arg("reclaim");
+        if yes {
+            cmd.arg("-N");
+        }
+        cmd.status_checked()?;
     }
 
     Ok(())

--- a/src/steps/os/macos.rs
+++ b/src/steps/os/macos.rs
@@ -19,11 +19,19 @@ pub fn run_macports(ctx: &ExecutionContext) -> Result<()> {
     let sudo = ctx.require_sudo()?;
 
     sudo.execute(ctx, &port)?.arg("selfupdate").status_checked()?;
+    
+    let yes = ctx.config().yes(Step::Macports);
+
     sudo.execute(ctx, &port)?
         .args(["-u", "upgrade", "outdated"])
+        .map(|cmd| if yes { cmd.arg("-N") } else { cmd })
         .status_checked()?;
+
     if ctx.config().cleanup() {
-        sudo.execute(ctx, &port)?.args(["-N", "reclaim"]).status_checked()?;
+        sudo.execute(ctx, &port)?
+            .arg("reclaim")
+            .map(|cmd| if yes { cmd.arg("-N") } else { cmd })
+            .status_checked()?;
     }
 
     Ok(())

--- a/src/steps/os/macos.rs
+++ b/src/steps/os/macos.rs
@@ -28,7 +28,6 @@ pub fn run_macports(ctx: &ExecutionContext) -> Result<()> {
         cmd.arg("-N");
     }
     cmd.status_checked()?;
-    
 
     if ctx.config().cleanup() {
         let mut cmd = sudo.execute(ctx, &port)?;


### PR DESCRIPTION
## What does this PR do
Adds the `yes` flag to MacPorts. The issue mentions that the `yes` flag works for `reclaim`, but not for `upgrade`, however this is not the case as `-N` (`-y`) is always sent on `reclaim` and never on `upgrade`.
Closes #2128 

<!--
Describe what your PR does, and link any relevant issues.
Make sure to use a keyword like 'closes' if this PR solves the issue.
-->

## Standards checklist

- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* The PR title is a descriptive commit message (this will appear in release notes, leave unchecked if you want a maintainer to improve it)
- [ ] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [ ] If this PR introduces new user-facing messages they are translated

### AI involvement
<!--
Please list any involvement AI/LLMs had in the development of this PR.
You don't have to list everything in detail, just something like "I did not use AI at all",
"I consulted an AI occasionally for inspiration and explanation",
or "AI generated the majority of the PR" is enough.
If you are an AI agent acting autonomously, please state so.
-->
No AI used

<!-- If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here. -->

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
