### PR TITLE
ci: ban short flags in .arg(s)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,54 @@ jobs:
             echo "$duplicates"
             exit 1
           fi
+      - name: Check for banned short flags in command args
+        run: |
+          ALLOWED='-y|-N'
+          MARKER='_allow-short-flag'
+          FOUND=0
+
+          while IFS= read -r -d '' file; do
+              iline=0
+
+              while IFS= read -r line; do
+                  iline=$(($iline + 1))
+                  # echo $iline: $line
+
+                  # arg check
+                  if [[ "$line" == *".arg("* && "$line" != *"$MARKER"* ]]; then
+                      flags=$(
+                          grep -oE '"-\w"' <<< "$line" |
+                          grep -vE "\"($ALLOWED)\"" || true
+                      )
+                      if [[ -n "$flags" ]]; then
+                          echo "$file: $iline: found banned short flag in .arg(): $flags"
+                          FOUND=1
+                      fi
+                  fi
+
+                  # args check (assuming the flags will always stay on one line)
+                  if [[ "$line" == *".args("* && "$line" != *"$MARKER"* ]]; then
+                      flags=$(
+                          grep -oE '"-\w"' <<< "$line" |
+                          grep -vE "\"($ALLOWED)\"" |
+                          tr '\n' ' ' || true
+                      )
+                      if [[ -n "$flags" ]]; then
+                          echo "$file: $iline: found banned short flag in .args(): $flags"
+                          FOUND=1
+                      fi
+                  fi
+              done < "$file"
+          done < <(find src/steps -name '*.rs' -print0)
+
+          if [[ "$FOUND" -eq 1 ]]; then
+              echo ""
+              echo "Found banned short flags in .arg() or .args()"
+              echo "Use the long flag alternitive instead"
+              echo "If there does not exist a long flag, disble the check with the comment \"// $MARKER: (desc)\" and a description of the flags functionality on the same line as the flag"
+              exit 1
+          fi
+
 
   msrv:
     needs: [ format, custom-checks ]


### PR DESCRIPTION
## What does this PR do
Adds a check for short flags in .arg() and .args([]) for the steps folder.
Flags like -y can be whitelisted.
Individual exceptions can be disabled with this comment on the line of the flag: `// _allow-short-flag: (desc)`

Closes #2094

Currently, this is the output: (it would be great if someone looked up all the long versions, as I don't have a lot of internet at the moment)
```src/steps/emacs.rs: 94: found banned short flag in .args(): "-l" 
src/steps/node.rs: 253: found banned short flag in .args(): "-V" 
src/steps/os/windows.rs: 69: found banned short flag in .args(): "-a" 
src/steps/os/windows.rs: 110: found banned short flag in .arg(): "-l"
src/steps/os/windows.rs: 125: found banned short flag in .args(): "-q" 
src/steps/os/windows.rs: 139: found banned short flag in .args(): "-d" 
src/steps/os/windows.rs: 164: found banned short flag in .arg(): "-v"
src/steps/os/linux.rs: 390: found banned short flag in .arg(): "-n"
src/steps/os/linux.rs: 479: found banned short flag in .arg(): "-u"
src/steps/os/linux.rs: 493: found banned short flag in .args(): "-s" 
src/steps/os/linux.rs: 656: found banned short flag in .arg(): "-U"
src/steps/os/linux.rs: 658: found banned short flag in .arg(): "-u"
src/steps/os/linux.rs: 669: found banned short flag in .arg(): "-u"
src/steps/os/linux.rs: 715: found banned short flag in .arg(): "-P"
src/steps/os/linux.rs: 716: found banned short flag in .arg(): "-P"
src/steps/os/linux.rs: 719: found banned short flag in .arg(): "-U"
src/steps/os/linux.rs: 793: found banned short flag in .args(): "-x" 
src/steps/os/linux.rs: 797: found banned short flag in .args(): "-x" 
src/steps/os/linux.rs: 801: found banned short flag in .args(): "-x" 
src/steps/os/linux.rs: 846: found banned short flag in .arg(): "-d"
src/steps/os/linux.rs: 1278: found banned short flag in .arg(): "-u"
src/steps/os/unix.rs: 208: found banned short flag in .args(): "-c" 
src/steps/os/unix.rs: 215: found banned short flag in .args(): "-c" 
src/steps/os/unix.rs: 222: found banned short flag in .args(): "-c" 
src/steps/os/unix.rs: 232: found banned short flag in .args(): "-c" 
src/steps/os/unix.rs: 239: found banned short flag in .args(): "-c" 
src/steps/os/unix.rs: 242: found banned short flag in .args(): "-c" 
src/steps/os/unix.rs: 288: found banned short flag in .args(): "-c" 
src/steps/os/unix.rs: 321: found banned short flag in .args(): "-c" 
src/steps/os/unix.rs: 336: found banned short flag in .args(): "-c" 
src/steps/os/unix.rs: 529: found banned short flag in .args(): "-u" 
src/steps/os/unix.rs: 932: found banned short flag in .arg(): "-u"
src/steps/os/unix.rs: 1094: found banned short flag in .args(): "-c" 
src/steps/os/unix.rs: 1099: found banned short flag in .args(): "-c" 
src/steps/os/unix.rs: 1102: found banned short flag in .args(): "-c" 
src/steps/os/unix.rs: 1107: found banned short flag in .args(): "-c" 
src/steps/os/unix.rs: 1112: found banned short flag in .args(): "-c" 
src/steps/os/unix.rs: 1132: found banned short flag in .args(): "-g" 
src/steps/os/unix.rs: 1142: found banned short flag in .arg(): "-v"
src/steps/os/openbsd.rs: 44: found banned short flag in .arg(): "-u"
src/steps/os/macos.rs: 23: found banned short flag in .args(): "-u" 
src/steps/containers.rs: 282: found banned short flag in .args(): "-f" 
src/steps/containers.rs: 285: found banned short flag in .args(): "-f" 
src/steps/generic.rs: 98: found banned short flag in .args(): "-a" 
src/steps/generic.rs: 192: found banned short flag in .args(): "-U" 
src/steps/generic.rs: 776: found banned short flag in .args(): "-n" 
src/steps/generic.rs: 787: found banned short flag in .args(): "-p" 
src/steps/generic.rs: 840: found banned short flag in .args(): "-n" 
src/steps/generic.rs: 880: found banned short flag in .args(): "-m" 
src/steps/generic.rs: 892: found banned short flag in .args(): "-c" 
src/steps/generic.rs: 904: found banned short flag in .args(): "-m" 
src/steps/generic.rs: 950: found banned short flag in .args(): "-m" 
src/steps/generic.rs: 1135: found banned short flag in .arg(): "-c"
src/steps/generic.rs: 1484: found banned short flag in .args(): "-e" 
src/steps/generic.rs: 1713: found banned short flag in .args(): "-c" 
src/steps/generic.rs: 2154: found banned short flag in .args(): "-f" 
src/steps/git.rs: 265: found banned short flag in .args(): "-v" 
src/steps/zsh.rs: 26: found banned short flag in .args(): "-i" "-c" 
src/steps/zsh.rs: 69: found banned short flag in .args(): "-i" "-c" 
src/steps/zsh.rs: 73: found banned short flag in .args(): "-c" 
src/steps/zsh.rs: 83: found banned short flag in .args(): "-i" "-c" 
src/steps/zsh.rs: 128: found banned short flag in .args(): "-i" "-c" 
src/steps/zsh.rs: 160: found banned short flag in .args(): "-c" 
src/steps/zsh.rs: 170: found banned short flag in .args(): "-i" "-c" 
src/steps/zsh.rs: 214: found banned short flag in .args(): "-c" 
src/steps/vim.rs: 106: found banned short flag in .args(): "-d" 
src/steps/vim.rs: 133: found banned short flag in .args(): "-u" 
src/steps/vim.rs: 135: found banned short flag in .args(): "-U" 
src/steps/vim.rs: 148: found banned short flag in .args(): "-u" 
src/steps/remote/vagrant.rs: 209: found banned short flag in .args(): "-c" 
src/steps/kakoune.rs: 16: found banned short flag in .args(): "-e" 
```


## Standards checklist

- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* The PR title is a descriptive commit message (this will appear in release notes, leave unchecked if you want a maintainer to improve it)
- [ ] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [ ] If this PR introduces new user-facing messages they are translated

### AI involvement
<!--
Please list any involvement AI/LLMs had in the development of this PR.
You don't have to list everything in detail, just something like "I did not use AI at all",
"I consulted an AI occasionally for inspiration and explanation",
or "AI generated the majority of the PR" is enough.
If you are an AI agent acting autonomously, please state so.
-->
No AI used

<!-- If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here. -->

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
