### PR TITLE
feat: add Zellij support

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -85,6 +85,12 @@
 # Run inside zellij (default: false)
 # run_in_zellij = true
 
+# Changes the way topgrade interacts with
+# the zellij session, creating the session
+# and only attaching to it if not inside zellij
+# (default: "attach_if_not_in_session", allowed values: "attach_if_not_in_session", "attach_always")
+# zellij_session_mode = "attach_if_not_in_session"
+
 # Cleanup temporary or old files (default: false)
 # cleanup = true
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -82,6 +82,9 @@
 # (default: "attach_if_not_in_session", allowed values: "attach_if_not_in_session", "attach_always")
 # tmux_session_mode = "attach_if_not_in_session"
 
+# Run inside zellij (default: false)
+# run_in_zellij = true
+
 # Cleanup temporary or old files (default: false)
 # cleanup = true
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -51,6 +51,9 @@
 # Arguments to pass tmux when pulling Repositories
 # tmux_arguments = "-S /var/tmux.sock"
 
+# Arguments to pass to zellij (no default value)
+# zellij_arguments = ""
+
 # Do not set the terminal title (default: true)
 # set_title = true
 

--- a/locales/app.yml
+++ b/locales/app.yml
@@ -104,14 +104,14 @@ _version: 2
   zh_CN: "已切换到 Shell 环境。请修复需要的内容，完成后退出 Shell 。"
   zh_TW: "已切換到 shell 環境。修復完畢後請退出 shell 以繼續。"
   de: "Wechsel zur Shell. Beheben Sie die Probleme und verlassen Sie dann die Shell."
-"Topgrade launched in a new tmux session":
-  en: "Topgrade launched in a new tmux session"
-  lt: "Topgrade paleistas naujoje tmux sesijoje"
-  es: "Topgrade lanzado en una nueva sesión tmux"
-  fr: "Topgrade lancé dans une nouvelle session tmux"
-  zh_CN: "Topgrade 已在新的 tmux 会话中启动"
-  zh_TW: "Topgrade 已啟動新 tmux 程式"
-  de: "Topgrade in einer neuen tmux-Sitzung gestartet"
+"Topgrade launched in a new {multiplexer} session":
+  en: "Topgrade launched in a new %{multiplexer} session"
+  lt: "Topgrade paleistas naujoje %{multiplexer} sesijoje"
+  es: "Topgrade lanzado en una nueva sesión %{multiplexer}"
+  fr: "Topgrade lancé dans une nouvelle session %{multiplexer}"
+  zh_CN: "Topgrade 已在新的 %{multiplexer} 会话中启动"
+  zh_TW: "Topgrade 已啟動新 %{multiplexer} 程式"
+  de: "Topgrade in einer neuen %{multiplexer}-Sitzung gestartet"
 "Topgrade upgraded from {from_version} to {to_version}:\n":
   en: "Topgrade upgraded from %{from_version} to %{to_version}:\n"
   lt: "Topgrade atnaujintas nuo %{from_version} iki %{to_version}:\n"

--- a/locales/app.yml
+++ b/locales/app.yml
@@ -366,14 +366,14 @@ _version: 2
   zh_CN: "尚未安装全局软件包"
   zh_TW: "尚未安裝全域套件"
   de: "Keine globalen Pakete installiert"
-"Remote Topgrade launched in Tmux":
-  en: "Remote Topgrade launched in Tmux"
-  lt: "Nuotolinis Topgrade paleistas Tmux sesijoje"
-  es: "Topgrade remoto lanzado en Tmux"
-  fr: "Topgrade distant lancé dans Tmux"
-  zh_CN: "已在 Tmux 中启动远程 Topgrade"
-  zh_TW: "已在 Tmux 中啟動遠端 Topgrade 程序"
-  de: "Remote-Topgrade in Tmux gestartet"
+"Remote Topgrade launched in {multiplexer}":
+  en: "Remote Topgrade launched in %{multiplexer}"
+  lt: "Nuotolinis Topgrade paleistas %{multiplexer} sesijoje"
+  es: "Topgrade remoto lanzado en %{multiplexer}"
+  fr: "Topgrade distant lancé dans %{multiplexer}"
+  zh_CN: "已在 %{multiplexer} 中启动远程 Topgrade"
+  zh_TW: "已在 %{multiplexer} 中啟動遠端 Topgrade 程序"
+  de: "Remote-Topgrade in %{multiplexer} gestartet"
 "Remote Topgrade launched in an external terminal":
   en: "Remote Topgrade launched in an external terminal"
   lt: "Nuotolinis Topgrade paleistas išoriniame terminale"

--- a/src/config.rs
+++ b/src/config.rs
@@ -417,6 +417,8 @@ pub struct Misc {
 
     tmux_session_mode: Option<TmuxSessionMode>,
 
+    run_in_zellij: Option<bool>,
+
     cleanup: Option<bool>,
 
     notify_each_step: Option<bool>,
@@ -990,6 +992,10 @@ pub struct CommandLineArgs {
     /// Run inside zellij
     #[arg(short = 'z', long = "zellij")]
     run_in_zellij: bool,
+
+    /// Don't run inside zellij
+    #[arg(long = "no-zellij")]
+    no_zellij: bool,
 }
 
 fn env_args_parser(arg: &str) -> Result<(String, String)> {
@@ -1224,7 +1230,14 @@ impl Config {
                     .as_ref()
                     .and_then(|misc| misc.run_in_tmux)
                     .unwrap_or(false));
-        let zellij_requested = self.opt.run_in_zellij;
+        let zellij_requested = !self.opt.no_zellij
+            && (self.opt.run_in_zellij
+                || self
+                    .config_file
+                    .misc
+                    .as_ref()
+                    .and_then(|misc| misc.run_in_zellij)
+                    .unwrap_or(false));
         match (tmux_requested, zellij_requested) {
             (false, false) => Ok(Multiplexer::No),
             (true, false) => Ok(Multiplexer::Tmux),

--- a/src/config.rs
+++ b/src/config.rs
@@ -398,6 +398,9 @@ pub struct Misc {
     #[merge(strategy = crate::utils::merge_strategies::string_append_opt)]
     tmux_arguments: Option<String>,
 
+    #[merge(strategy = crate::utils::merge_strategies::string_append_opt)]
+    zellij_arguments: Option<String>,
+
     set_title: Option<bool>,
 
     display_time: Option<bool>,
@@ -1408,8 +1411,14 @@ impl Config {
     }
     /// Extra zellij arguments
     fn zellij_arguments(&self) -> Result<Vec<String>> {
-        // TODO: zellij args
-        Ok(Vec::new())
+        let args = &self
+            .config_file
+            .misc
+            .as_ref()
+            .and_then(|misc| misc.zellij_arguments.as_ref())
+            .map(String::to_owned)
+            .unwrap_or_default();
+        shell_words::split(args).with_context(|| format!("Failed to parse `zellij_arguments`: `{args}`"))
     }
 
     /// Prompt for a key before exiting

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,8 +9,8 @@ use std::{env, fmt, fs};
 
 use clap::{Parser, ValueEnum};
 use clap_complete::Shell;
-use color_eyre::eyre::Result;
 use color_eyre::eyre::{Context, OptionExt};
+use color_eyre::eyre::{Result, eyre};
 use etcetera::base_strategy::BaseStrategy;
 use indexmap::IndexMap;
 use merge2::Merge;
@@ -986,6 +986,10 @@ pub struct CommandLineArgs {
     /// Don't update Topgrade
     #[arg(long = "no-self-update")]
     pub no_self_update: bool,
+
+    /// Run inside zellij
+    #[arg(short = 'z', long = "zellij")]
+    run_in_zellij: bool,
 }
 
 fn env_args_parser(arg: &str) -> Result<(String, String)> {
@@ -1211,20 +1215,21 @@ impl Config {
     }
 
     /// Tell whether we should run in a multiplexer.
-    pub fn run_in_multiplexer(&self) -> Multiplexer {
-        // TODO: better resolution of multiplexers
-        match !self.opt.no_tmux
+    pub fn run_in_multiplexer(&self) -> Result<Multiplexer> {
+        let tmux_requested = !self.opt.no_tmux
             && (self.opt.run_in_tmux
                 || self
                     .config_file
                     .misc
                     .as_ref()
                     .and_then(|misc| misc.run_in_tmux)
-                    .unwrap_or(false))
-        {
-            true => Multiplexer::Tmux,
-            // TODO: use zellij only on --zellij flag
-            false => Multiplexer::Zellij,
+                    .unwrap_or(false));
+        let zellij_requested = self.opt.run_in_zellij;
+        match (tmux_requested, zellij_requested) {
+            (false, false) => Ok(Multiplexer::No),
+            (true, false) => Ok(Multiplexer::Tmux),
+            (false, true) => Ok(Multiplexer::Zellij),
+            _ => Err(eyre!("Multiple multiplexers specified")),
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -107,6 +107,13 @@ pub enum UpdatesAutoReboot {
     Ask,
 }
 
+#[derive(Debug, Copy, Clone)]
+pub enum Multiplexer {
+    Tmux,
+    Zellij,
+    No,
+}
+
 #[derive(Deserialize, Default, Debug, Merge)]
 #[serde(deny_unknown_fields)]
 pub struct Windows {
@@ -442,6 +449,16 @@ pub enum TmuxSessionMode {
     AttachAlways,
 }
 
+#[derive(Clone, Copy, Debug)]
+// #[derive(Clone, Copy, Debug, Deserialize, ValueEnum, Default)]
+// #[clap(rename_all = "snake_case")]
+// #[serde(rename_all = "snake_case")]
+pub enum ZellijSessionMode {
+    // #[default]
+    // AttachIfNotInSession,
+    AttachAlways,
+}
+
 /// Controls when the end-of-run desktop notification is sent.
 #[derive(Clone, Copy, Debug, Deserialize, ValueEnum, Default)]
 #[clap(rename_all = "snake_case")]
@@ -459,6 +476,11 @@ pub enum NotifyEnd {
 pub struct TmuxConfig {
     pub args: Vec<String>,
     pub session_mode: TmuxSessionMode,
+}
+
+pub struct ZellijConfig {
+    pub args: Vec<String>,
+    pub session_mode: ZellijSessionMode,
 }
 
 #[derive(Deserialize, Default, Debug, Merge)]
@@ -1188,9 +1210,10 @@ impl Config {
                 .unwrap_or(false)
     }
 
-    /// Tell whether we should run in tmux.
-    pub fn run_in_tmux(&self) -> bool {
-        !self.opt.no_tmux
+    /// Tell whether we should run in a multiplexer.
+    pub fn run_in_multiplexer(&self) -> Multiplexer {
+        // TODO: better resolution of multiplexers
+        match !self.opt.no_tmux
             && (self.opt.run_in_tmux
                 || self
                     .config_file
@@ -1198,6 +1221,11 @@ impl Config {
                     .as_ref()
                     .and_then(|misc| misc.run_in_tmux)
                     .unwrap_or(false))
+        {
+            true => Multiplexer::Tmux,
+            // TODO: use zellij only on --zellij flag
+            false => Multiplexer::Zellij,
+        }
     }
 
     /// The preferred way to run the new tmux session.
@@ -1324,6 +1352,15 @@ impl Config {
             session_mode: self.tmux_session_mode(),
         })
     }
+    pub fn zellij_config(&self) -> Result<ZellijConfig> {
+        let args = self.zellij_arguments()?;
+        Ok(ZellijConfig {
+            args,
+            // TODO: zellij session mode
+            // session_mode: self.zellij_session_mode(),
+            session_mode: ZellijSessionMode::AttachAlways,
+        })
+    }
 
     /// Extra Tmux arguments
     fn tmux_arguments(&self) -> Result<Vec<String>> {
@@ -1342,6 +1379,11 @@ impl Config {
             //     Caused by:
             //         missing closing quote
             .with_context(|| format!("Failed to parse `tmux_arguments`: `{args}`"))
+    }
+    /// Extra zellij arguments
+    fn zellij_arguments(&self) -> Result<Vec<String>> {
+        // TODO: zellij args
+        Ok(Vec::new())
     }
 
     /// Prompt for a key before exiting

--- a/src/config.rs
+++ b/src/config.rs
@@ -419,6 +419,8 @@ pub struct Misc {
 
     run_in_zellij: Option<bool>,
 
+    zellij_session_mode: Option<ZellijSessionMode>,
+
     cleanup: Option<bool>,
 
     notify_each_step: Option<bool>,
@@ -451,13 +453,12 @@ pub enum TmuxSessionMode {
     AttachAlways,
 }
 
-#[derive(Clone, Copy, Debug)]
-// #[derive(Clone, Copy, Debug, Deserialize, ValueEnum, Default)]
-// #[clap(rename_all = "snake_case")]
-// #[serde(rename_all = "snake_case")]
+#[derive(Clone, Copy, Debug, Deserialize, ValueEnum, Default)]
+#[clap(rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
 pub enum ZellijSessionMode {
-    // #[default]
-    // AttachIfNotInSession,
+    #[default]
+    AttachIfNotInSession,
     AttachAlways,
 }
 
@@ -1255,6 +1256,15 @@ impl Config {
             .unwrap_or_default()
     }
 
+    /// The preferred way to run the new zellij session.
+    fn zellij_session_mode(&self) -> ZellijSessionMode {
+        self.config_file
+            .misc
+            .as_ref()
+            .and_then(|misc| misc.zellij_session_mode)
+            .unwrap_or_default()
+    }
+
     /// Tell whether we should perform cleanup steps.
     pub fn cleanup(&self) -> bool {
         self.opt.cleanup
@@ -1374,9 +1384,7 @@ impl Config {
         let args = self.zellij_arguments()?;
         Ok(ZellijConfig {
             args,
-            // TODO: zellij session mode
-            // session_mode: self.zellij_session_mode(),
-            session_mode: ZellijSessionMode::AttachAlways,
+            session_mode: self.zellij_session_mode(),
         })
     }
 

--- a/src/execution_context.rs
+++ b/src/execution_context.rs
@@ -60,6 +60,10 @@ pub struct ExecutionContext<'a> {
     /// This is used in `./steps/remote/ssh.rs`, where we want to run `topgrade` in a new
     /// tmux window for each remote.
     tmux_session: Mutex<Option<String>>,
+    /// Name of a zellij session to execute commands in, if any.
+    /// This is used in `./steps/remote/ssh.rs`, where we want to run `topgrade` in a new
+    /// zellij tab for each remote.
+    zellij_session: Mutex<Option<String>>,
     /// True if topgrade is running under ssh.
     under_ssh: bool,
     #[cfg(target_os = "linux")]
@@ -80,6 +84,7 @@ impl<'a> ExecutionContext<'a> {
             sudo,
             config,
             tmux_session: Mutex::new(None),
+            zellij_session: Mutex::new(None),
             under_ssh,
             #[cfg(target_os = "linux")]
             distribution,
@@ -122,6 +127,14 @@ impl<'a> ExecutionContext<'a> {
 
     pub fn get_tmux_session(&self) -> Option<String> {
         self.tmux_session.lock().unwrap().clone()
+    }
+
+    pub fn set_zellij_session(&self, session_name: String) {
+        self.zellij_session.lock().unwrap().replace(session_name);
+    }
+
+    pub fn get_zellij_session(&self) -> Option<String> {
+        self.zellij_session.lock().unwrap().clone()
     }
 
     #[cfg(target_os = "linux")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ use rust_i18n::{i18n, t};
 use std::sync::LazyLock;
 use tracing::debug;
 
-use self::config::{CommandLineArgs, Config};
+use self::config::{CommandLineArgs, Config, Multiplexer};
 use self::error::StepFailed;
 use self::runner::StepResult;
 use self::steps::{remote::*, *};
@@ -47,6 +47,8 @@ mod terminal;
 #[cfg(unix)]
 mod tmux;
 mod utils;
+#[cfg(unix)]
+mod zellij;
 
 // Users without home directory are possible, but no-one has complained yet
 pub(crate) static HOME_DIR: LazyLock<PathBuf> = LazyLock::new(|| home_dir().expect("No home directory"));
@@ -122,11 +124,25 @@ fn run() -> Result<()> {
     debug!("self-update Feature Enabled: {:?}", cfg!(feature = "self-update"));
     debug!("Configuration: {:?}", config);
 
-    if config.run_in_tmux() && env::var("TOPGRADE_INSIDE_TMUX").is_err() {
-        #[cfg(unix)]
-        {
-            tmux::run_in_tmux(config.tmux_config()?)?;
-            return Ok(());
+    match config.run_in_multiplexer() {
+        Multiplexer::No => {},
+        Multiplexer::Tmux => {
+            if env::var("TOPGRADE_INSIDE_TMUX").is_err() {
+                #[cfg(unix)]
+                {
+                    tmux::run_in_tmux(config.tmux_config()?)?;
+                    return Ok(());
+                }
+            }
+        }
+        Multiplexer::Zellij => {
+            if env::var("TOPGRADE_INSIDE_ZELLIJ").is_err() {
+                #[cfg(unix)]
+                {
+                    zellij::run_in_zellij(config.zellij_config()?)?;
+                    return Ok(());
+                }
+            }
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,8 +124,8 @@ fn run() -> Result<()> {
     debug!("self-update Feature Enabled: {:?}", cfg!(feature = "self-update"));
     debug!("Configuration: {:?}", config);
 
-    match config.run_in_multiplexer() {
-        Multiplexer::No => {},
+    match config.run_in_multiplexer()? {
+        Multiplexer::No => {}
         Multiplexer::Tmux => {
             if env::var("TOPGRADE_INSIDE_TMUX").is_err() {
                 #[cfg(unix)]

--- a/src/steps/remote/ssh.rs
+++ b/src/steps/remote/ssh.rs
@@ -29,8 +29,8 @@ pub fn ssh_step(ctx: &ExecutionContext, hostname: &str) -> Result<()> {
     // run remotes in the multiplexer if one is specified
     #[cfg(unix)]
     if !ctx.run_type().dry() {
-        match ctx.config().run_in_multiplexer() {
-            Multiplexer::No => { }
+        match ctx.config().run_in_multiplexer()? {
+            Multiplexer::No => {}
             Multiplexer::Tmux => {
                 prepare_async_ssh_command(&mut args);
                 crate::tmux::run_command(ctx, hostname, &shell_words::join(args))?;

--- a/src/steps/remote/ssh.rs
+++ b/src/steps/remote/ssh.rs
@@ -5,6 +5,9 @@ use crate::{
     command::CommandExt, error::SkipStep, execution_context::ExecutionContext, terminal::print_separator, utils,
 };
 
+#[cfg(unix)]
+use crate::config::Multiplexer;
+
 fn prepare_async_ssh_command(args: &mut Vec<&str>) {
     args.insert(0, "ssh");
     args.push("--keep");
@@ -23,11 +26,18 @@ pub fn ssh_step(ctx: &ExecutionContext, hostname: &str) -> Result<()> {
     let env = format!("TOPGRADE_PREFIX={hostname}");
     args.extend(["env", &env, "$SHELL", "-lc", topgrade]);
 
+    // run remotes in the multiplexer if one is specified
     #[cfg(unix)]
-    if ctx.config().run_in_tmux() && !ctx.run_type().dry() {
-        prepare_async_ssh_command(&mut args);
-        crate::tmux::run_command(ctx, hostname, &shell_words::join(args))?;
-        return Err(SkipStep(String::from(t!("Remote Topgrade launched in Tmux"))).into());
+    if !ctx.run_type().dry() {
+        match ctx.config().run_in_multiplexer() {
+            Multiplexer::No => { }
+            Multiplexer::Tmux => {
+                prepare_async_ssh_command(&mut args);
+                crate::tmux::run_command(ctx, hostname, &shell_words::join(args))?;
+                return Err(SkipStep(String::from(t!("Remote Topgrade launched in Tmux"))).into());
+            }
+            Multiplexer::Zellij => !todo!(),
+        }
     }
 
     if ctx.config().open_remotes_in_new_terminal() && !ctx.run_type().dry() && cfg!(windows) {

--- a/src/steps/remote/ssh.rs
+++ b/src/steps/remote/ssh.rs
@@ -32,11 +32,26 @@ pub fn ssh_step(ctx: &ExecutionContext, hostname: &str) -> Result<()> {
         match ctx.config().run_in_multiplexer()? {
             Multiplexer::No => {}
             Multiplexer::Tmux => {
+                // FIXME: here, we ask tmux to run `ssh ... $SHELL -lc (topgrade) --keep`
+                // and $SHELL does not pass the last --keep to topgrade. we'd need to wire in
+                // format!("'{topgrade} --keep'") as a single arg, conditional on tmux.
                 prepare_async_ssh_command(&mut args);
                 crate::tmux::run_command(ctx, hostname, &shell_words::join(args))?;
-                return Err(SkipStep(String::from(t!("Remote Topgrade launched in Tmux"))).into());
+                return Err(SkipStep(String::from(t!(
+                    "Remote Topgrade launched in {multiplexer}",
+                    multiplexer = "Tmux"
+                )))
+                .into());
             }
-            Multiplexer::Zellij => !todo!(),
+            Multiplexer::Zellij => {
+                // NB: no need to --keep, since zellij keeps panes on exit
+                crate::zellij::run_command(ctx, hostname, "ssh", &args)?;
+                return Err(SkipStep(String::from(t!(
+                    "Remote Topgrade launched in {multiplexer}",
+                    multiplexer = "Zellij"
+                )))
+                .into());
+            }
         }
     }
 

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -142,7 +142,10 @@ pub fn run_in_tmux(config: TmuxConfig) -> Result<()> {
         TmuxSessionMode::AttachIfNotInSession => {
             if is_inside_tmux {
                 // Only attach to the newly-created session if we're not currently in a tmux session.
-                println!("{}", t!("Topgrade launched in a new tmux session"));
+                println!(
+                    "{}",
+                    t!("Topgrade launched in a new {multiplexer} session", multiplexer = "tmux")
+                );
                 return Ok(());
             } else {
                 tmux.build().args(["attach-session", "-t", &session]).exec()

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -33,6 +33,7 @@ impl Tmux {
     fn build(&self) -> Command {
         let mut command = Command::new(&self.tmux);
         if let Some(args) = self.args.as_ref() {
+            // NB: tmux suggests that $TMUX must be unset when running tmux from inside tmux.
             command.args(args).env_remove("TMUX");
         }
         command

--- a/src/zellij.rs
+++ b/src/zellij.rs
@@ -11,6 +11,7 @@ use crate::config::ZellijConfig;
 use crate::config::ZellijSessionMode;
 use crate::utils::which;
 
+use rust_i18n::t;
 #[cfg(unix)]
 use std::os::unix::process::CommandExt as _;
 
@@ -99,16 +100,21 @@ pub fn run_in_zellij(config: ZellijConfig) -> Result<()> {
 
     let is_inside_zellij = env::var("ZELLIJ").is_ok();
     let err = match config.session_mode {
-        // TODO: zellij AttachIfNotInSession
-        // ZellijSessionMode::AttachIfNotInSession => {
-        //     if is_inside_zellij {
-        //         // Only attach to the newly-created session if we're not currently in a zellij session.
-        //         println!("{}", t!("Topgrade launched in a new zellij session"));
-        //         return Ok(());
-        //     } else {
-        //         zellij.build().args(["attach-session", "-t", &session]).exec()
-        //     }
-        // }
+        ZellijSessionMode::AttachIfNotInSession => {
+            if is_inside_zellij {
+                // Only attach to the newly-created session if we're not currently in a zellij session.
+                println!(
+                    "{}",
+                    t!(
+                        "Topgrade launched in a new {multiplexer} session",
+                        multiplexer = "zellij"
+                    )
+                );
+                return Ok(());
+            } else {
+                zellij.build().args(["attach", &session]).exec()
+            }
+        }
         ZellijSessionMode::AttachAlways => {
             if is_inside_zellij {
                 zellij.build().args(["action", "switch-session", &session]).exec()

--- a/src/zellij.rs
+++ b/src/zellij.rs
@@ -1,0 +1,122 @@
+use std::env;
+use std::path::PathBuf;
+use std::process::Command;
+
+use color_eyre::eyre::Context;
+use color_eyre::eyre::Result;
+use color_eyre::eyre::eyre;
+
+use crate::command::CommandExt;
+use crate::config::ZellijConfig;
+use crate::config::ZellijSessionMode;
+use crate::utils::which;
+
+#[cfg(unix)]
+use std::os::unix::process::CommandExt as _;
+
+struct Zellij {
+    zellij: PathBuf,
+    args: Option<Vec<String>>,
+}
+
+impl Zellij {
+    fn new(args: Vec<String>) -> Self {
+        Self {
+            zellij: which("zellij").expect("Could not find zellij"),
+            args: if args.is_empty() { None } else { Some(args) },
+        }
+    }
+
+    #[allow(clippy::disallowed_methods)]
+    fn build(&self) -> Command {
+        let mut command = Command::new(&self.zellij);
+        // NB: unlike tmux, zellij seems to nest fine without any env-var wrangling.
+        if let Some(args) = self.args.as_ref() {
+            command.args(args);
+        }
+        command
+    }
+    /// Create a new zellij session with the given name, running the given command.
+    fn new_session(&self, session_name: &str) -> Result<()> {
+        self.build()
+            // see https://zellij.dev/documentation/programmatic-control.html#1-create-a-session
+            .args(["attach", "--create-background", session_name])
+            .output_checked()?;
+        // zellij can create a new background session with the layout we want,
+        // but only if given a path to a file with the layout.
+        // rather than make a temp-file, we spawn zellij with a default layout, then replace it with ours.
+
+        // for that, we'll need a layout string approximately of form:
+        // `layout {tab {pane command="env" {args (env args) "topgrade" (topgrade args);};};}`
+        // with all args double-quoted.
+        // see https://zellij.dev/documentation/creating-a-layout.html for reference.
+
+        // NB: we don't need to TOPGRADE_KEEP_END like in tmux, since zellij keeps the pane on finish
+        let mut env_args = "args \"TOPGRADE_INSIDE_ZELLIJ=1\"".to_owned();
+        for arg in env::args() {
+            // append double-quoted ` "arg"`, escaping double-quotes inside arg itself
+            env_args.push_str(&format!(" \"{}\"", arg.replace("\"", "\\\"")));
+        }
+        let layout_string =
+            format!(r#"layout {{ tab name="topgrade" {{ pane name="topgrade" command="env" {{{env_args};}};}};}}"#);
+        self.build()
+            .env("ZELLIJ_SESSION_NAME", session_name)
+            .args(["action", "override-layout", "--layout-string", &layout_string])
+            .output_checked()?;
+        Ok(())
+    }
+    /// Like [`new_session`] but it appends a digit to the session name (if necessary) to
+    /// avoid duplicate session names.
+    ///
+    /// The session name is returned.
+    fn new_unique_session(&self, session_name: &str) -> Result<String> {
+        self.new_session(session_name)
+            .context("Error running Topgrade in zellij")?;
+        Ok(session_name.to_owned())
+        // TODO: new_unique_session
+        // let mut session = session_name.to_owned();
+        // for i in 1.. {
+        //     if !self
+        //         .has_session(&session)
+        //         .context("Error determining if a tmux session exists")?
+        //     {
+        //         self.new_session(&session, command)
+        //             .context("Error running Topgrade in tmux")?;
+        //         return Ok(session);
+        //     }
+        //     session = format!("{session_name}-{i}");
+        // }
+        // unreachable!()
+    }
+}
+
+pub fn run_in_zellij(config: ZellijConfig) -> Result<()> {
+    let zellij = Zellij::new(config.args);
+
+    // Find an unused session and run `topgrade` in it with the current command's arguments.
+    let session_name = "topgrade";
+    let session = zellij.new_unique_session(session_name)?;
+
+    let is_inside_zellij = env::var("ZELLIJ").is_ok();
+    let err = match config.session_mode {
+        // TODO: zellij AttachIfNotInSession
+        // ZellijSessionMode::AttachIfNotInSession => {
+        //     if is_inside_zellij {
+        //         // Only attach to the newly-created session if we're not currently in a zellij session.
+        //         println!("{}", t!("Topgrade launched in a new zellij session"));
+        //         return Ok(());
+        //     } else {
+        //         zellij.build().args(["attach-session", "-t", &session]).exec()
+        //     }
+        // }
+        ZellijSessionMode::AttachAlways => {
+            if is_inside_zellij {
+                zellij.build().args(["action", "switch-session", &session]).exec()
+            } else {
+                zellij.build().args(["attach", &session]).exec()
+            }
+        }
+    };
+
+    Err(eyre!("{err}")).context("Failed to `execvp(3)` zellij")
+}

--- a/src/zellij.rs
+++ b/src/zellij.rs
@@ -10,6 +10,7 @@ use color_eyre::eyre::eyre;
 use crate::command::CommandExt;
 use crate::config::ZellijConfig;
 use crate::config::ZellijSessionMode;
+use crate::execution_context::ExecutionContext;
 use crate::utils::which;
 
 use rust_i18n::t;
@@ -38,8 +39,9 @@ impl Zellij {
         }
         command
     }
-    /// Create a new zellij session with the given name, running the given command.
-    fn new_session(&self, session_name: &str) -> Result<()> {
+    /// Create a new zellij session with the given name, running `command` with `args` in a tab
+    /// (and pane) named `tab_name`.
+    fn new_session(&self, session_name: &str, tab_name: &str, command: &str, args: &[&str]) -> Result<()> {
         self.build()
             // see https://zellij.dev/documentation/programmatic-control.html#1-create-a-session
             .args(["attach", "--create-background", session_name])
@@ -52,21 +54,31 @@ impl Zellij {
         // `layout {tab {pane command="env" {args (env args) "topgrade" (topgrade args);};};}`
         // with all args double-quoted.
         // see https://zellij.dev/documentation/creating-a-layout.html for reference.
-
-        // NB: we don't need to TOPGRADE_KEEP_END like in tmux, since zellij keeps the pane on finish
-        let mut env_args = "args \"TOPGRADE_INSIDE_ZELLIJ=1\"".to_owned();
-        for arg in env::args() {
+        let mut args_kdl = String::new();
+        for arg in args {
             // append double-quoted ` "arg"`, escaping double-quotes inside arg itself
-            env_args.push_str(&format!(" \"{}\"", arg.replace("\"", "\\\"")));
+            args_kdl.push_str(&format!(" \"{}\"", arg.replace("\"", "\\\"")));
         }
-        let layout_string =
-            format!(r#"layout {{ tab name="topgrade" {{ pane name="topgrade" command="env" {{{env_args};}};}};}}"#);
+        let layout_string = format!(
+            r#"layout {{ tab name="{tab_name}" {{ pane name="{tab_name}" command="{command}" {{ args {args_kdl}; }}; }}; }}"#
+        );
         self.build()
             .env("ZELLIJ_SESSION_NAME", session_name)
             .args(["action", "override-layout", "--layout-string", &layout_string])
             .output_checked()?;
         Ok(())
     }
+    /// Add a new tab named `tab_name` to the (possibly background) session `session_name`,
+    /// running `command` with `args`.
+    fn new_tab(&self, session_name: &str, tab_name: &str, command: &str, args: &[&str]) -> Result<()> {
+        self.build()
+            .env("ZELLIJ_SESSION_NAME", session_name)
+            .args(["action", "new-tab", "-n", tab_name, "--", command])
+            .args(args)
+            .output_checked()?;
+        Ok(())
+    }
+
     /// Names of all zellij sessions, including EXITED ones (which still occupy their name).
     fn session_names(&self) -> Result<HashSet<String>> {
         let output = self
@@ -82,12 +94,13 @@ impl Zellij {
     /// avoid duplicate session names.
     ///
     /// The session name is returned.
-    fn new_unique_session(&self, session_name: &str) -> Result<String> {
+    fn new_unique_session(&self, session_name: &str, tab_name: &str, command: &str, args: &[&str]) -> Result<String> {
         let existing = self.session_names().context("Error listing zellij sessions")?;
         let mut session = session_name.to_owned();
         for i in 1.. {
             if !existing.contains(&session) {
-                self.new_session(&session).context("Error running Topgrade in zellij")?;
+                self.new_session(&session, tab_name, command, args)
+                    .context("Error running Topgrade in zellij")?;
                 return Ok(session);
             }
             session = format!("{session_name}-{i}");
@@ -101,7 +114,13 @@ pub fn run_in_zellij(config: ZellijConfig) -> Result<()> {
 
     // Find an unused session and run `topgrade` in it with the current command's arguments.
     let session_name = "topgrade";
-    let session = zellij.new_unique_session(session_name)?;
+    // we want zellij to run a "env TOPGRADE_INSIDE_ZELLIJ=1 (current topgrade invocation)".
+    // "env" we supply as a command separately, and the invocation we get from env::args().
+    // NB: we don't need to TOPGRADE_KEEP_END like in tmux, since zellij keeps the pane on finish
+    let mut relaunch_args = vec!["TOPGRADE_INSIDE_ZELLIJ=1".to_owned()];
+    relaunch_args.extend(env::args());
+    let relaunch_args: Vec<&str> = relaunch_args.iter().map(String::as_str).collect();
+    let session = zellij.new_unique_session(session_name, "topgrade", "env", &relaunch_args)?;
 
     let is_inside_zellij = env::var("ZELLIJ").is_ok();
     let err = match config.session_mode {
@@ -130,4 +149,19 @@ pub fn run_in_zellij(config: ZellijConfig) -> Result<()> {
     };
 
     Err(eyre!("{err}")).context("Failed to `execvp(3)` zellij")
+}
+
+/// Run `command` with `args` in a new zellij tab named `tab_name`, reusing the session tracked
+/// on `ctx` (across `ssh_step` calls for successive remotes) if one exists, or starting one
+/// otherwise.
+pub fn run_command(ctx: &ExecutionContext, tab_name: &str, command: &str, args: &[&str]) -> Result<()> {
+    let zellij = Zellij::new(ctx.config().zellij_config()?.args);
+
+    if let Some(session_name) = ctx.get_zellij_session() {
+        zellij.new_tab(&session_name, tab_name, command, args)?;
+    } else {
+        let name = zellij.new_unique_session("topgrade", tab_name, command, args)?;
+        ctx.set_zellij_session(name);
+    }
+    Ok(())
 }

--- a/src/zellij.rs
+++ b/src/zellij.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::env;
 use std::path::PathBuf;
 use std::process::Command;
@@ -66,28 +67,32 @@ impl Zellij {
             .output_checked()?;
         Ok(())
     }
+    /// Names of all zellij sessions, including EXITED ones (which still occupy their name).
+    fn session_names(&self) -> Result<HashSet<String>> {
+        let output = self
+            .build()
+            .args(["list-sessions", "--short", "--no-formatting"])
+            // exits with status 1 when there are no sessions, which is fine
+            .output_checked_with_utf8(|_| Ok(()))
+            .context("Error listing zellij sessions")?;
+        Ok(output.stdout.lines().map(str::to_owned).collect())
+    }
+
     /// Like [`new_session`] but it appends a digit to the session name (if necessary) to
     /// avoid duplicate session names.
     ///
     /// The session name is returned.
     fn new_unique_session(&self, session_name: &str) -> Result<String> {
-        self.new_session(session_name)
-            .context("Error running Topgrade in zellij")?;
-        Ok(session_name.to_owned())
-        // TODO: new_unique_session
-        // let mut session = session_name.to_owned();
-        // for i in 1.. {
-        //     if !self
-        //         .has_session(&session)
-        //         .context("Error determining if a tmux session exists")?
-        //     {
-        //         self.new_session(&session, command)
-        //             .context("Error running Topgrade in tmux")?;
-        //         return Ok(session);
-        //     }
-        //     session = format!("{session_name}-{i}");
-        // }
-        // unreachable!()
+        let existing = self.session_names().context("Error listing zellij sessions")?;
+        let mut session = session_name.to_owned();
+        for i in 1.. {
+            if !existing.contains(&session) {
+                self.new_session(&session).context("Error running Topgrade in zellij")?;
+                return Ok(session);
+            }
+            session = format!("{session_name}-{i}");
+        }
+        unreachable!()
     }
 }
 


### PR DESCRIPTION
## What does this PR do

This implements zellij support parallel to that of tmux. In particular (following the commits):
- [x] topgrade can now run itself inside a new zellij session
- [x] there's the -z/--zellij flag to control this
- [x] there's a run_in_zellij config option and a --no-zellij flag to override it
- [x] there's a zellij_session_mode config option parallel to tmux_session_mode
- [x] there's a zellij_arguments config option parallel to tmux_arguments
- [x] topgrade runs a fresh zellij session on each run, preserving the previous ones
- [x] ssh_step runs remote topgrade sessions in zellij if asked for, parallel to the same logic for tmux

Closes #864.

## Standards checklist

- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* The PR title is a descriptive commit message (this will appear in release notes, leave unchecked if you want a maintainer to improve it)
- [x] I have tested the code myself. topgrade's output is i think irrelevant, since what i'm testing is whether it runs in a multiplexer on various configs. here are the tests that i did and results i expected (and got), for convenience of reproduction.
    - (all tests assume an installed zellij; see https://zellij.dev/documentation/installation)
    - `topgrade --zellij` runs in a new zellij session called `topgrade`, with a single tab in a single pane. (`zellij ls` to list all sessions.) when topgrade finishes, the session output persists.
    - (regression test: absent `--zellij`, topgrade runs where launched)
    - with `run_in_zellij=true` in the config, plain `topgrade` also runs in zellij
    - with `run_in_zellij=true` in the config, `topgrade --no-zellij` runs where launched
    - with `zellij_session_mode = "attach_if_not_in_session"` in the config (default), when run inside a zellij session, topgrade runs in a new background session (and reports that it does so)
    - with `zellij_session_mode = "attach_always"` in the config, when run inside a zellij session, topgrades switches zellij to the newly launched session
    - with `zellij_arguments = "--help"`, topgrade indeed passes `--help` to zellij, which results in zellij's help being printed and no topgrade-inside-zellij being run. (i have not tested zellij_arguments beyond this, since i don't have a use-case for it to hand.)
    - when run multiple times, `topgrade --zellij` uses uniquely named sessions so as to not override old ones
    - (TODO) when run with an ssh step, `topgrade --zellij` runs topgrade on individual remotes in their named tabs/panes in zellij's session. this, i don't have remotes at hand to test with.
    - when run with both --tmux and --zellij, topgrade fails, reporting that it was required to run in two multiplexers at once.
- [x] If this PR introduces new user-facing messages they are translated
    - for "Topgrade launched in a new zellij session", i reused the tmux message, parametrizing the translation
    - likewise for "Remote Topgrade launched in Zellij"
- [ ] If this PR introduces new user-facing messages they are translated
    - there's a new error message, "Multiple multiplexers specified", untranslated. other fatal configuration failures are also untranslated, but perhaps a new one should be.
    - likewise for "Failed to parse `zellij_arguments`"
    - likewise for "Error running Topgrade in zellij"
    - likewise for "Failed to `execvp(3)` zellij"
    - likewise for "Could not find zellij", though this one can be easily fixed: there's a translation of "Could not find sudo" that can be parametrized with an arbitrary not-found binary

### AI involvement
For the first five commits/subfeatures, I did not use AI/LLMs. The last two (new_unique_window and ssh_step), I pair-programmed with claude code and reviewed myself. All of this is code and comments I would write, or did write.

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
