### PR TITLE
fix(atom): fix conflict with Agent Package Manager

### DIFF
--- a/locales/app.yml
+++ b/locales/app.yml
@@ -726,6 +726,14 @@ _version: 2
   zh_CN: "桌面环境不是 GNOME"
   zh_TW: "桌面環境不是 GNOME"
   de: "Desktop scheint nicht GNOME zu sein"
+"Command `apm` does not appear to be Atom Package Manager":
+  en: "Command `apm` does not appear to be Atom Package Manager"
+  lt: "Panašu, kad komanda `apm` nėra „Atom Package Manager“"
+  es: "El comando `apm` no parece ser Atom Package Manager"
+  fr: "La commande `apm` ne semble pas être Atom Package Manager"
+  zh_CN: "`apm` 命令似乎不是 Atom Package Manager"
+  zh_TW: "`apm` 命令似乎不是 Atom Package Manager"
+  de: "Der Befehl `apm` scheint nicht der Atom Package Manager zu sein"
 "GNOME shell extensions are unregistered in DBus":
   en: "GNOME shell extensions are unregistered in DBus"
   lt: "GNOME Shell priedai nėra užregistruoti DBus'e"

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -251,7 +251,7 @@ pub fn run_apm(ctx: &ExecutionContext) -> Result<()> {
 
     let help = ctx.execute(&apm).always().arg("--help").output_checked_utf8()?;
     if !is_atom_apm_help(&help.stdout, &help.stderr) {
-        return Err(SkipStep("Command `apm` does not appear to be Atom Package Manager".to_string()).into());
+        return Err(SkipStep(t!("Command `apm` does not appear to be Atom Package Manager").to_string()).into());
     }
 
     print_separator("Atom Package Manager");

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -233,11 +233,43 @@ pub fn run_micro(ctx: &ExecutionContext) -> Result<()> {
     target_os = "netbsd",
     target_os = "dragonfly"
 )))]
-fn is_atom_apm_help(stdout: &str, stderr: &str) -> bool {
-    stdout
-        .split(|character: char| !character.is_alphanumeric())
-        .chain(stderr.split(|character: char| !character.is_alphanumeric()))
-        .any(|word| word.eq_ignore_ascii_case("atom"))
+enum Apm {
+    AtomPackageManager(PathBuf),
+    Other,
+}
+
+#[cfg(not(any(
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "dragonfly"
+)))]
+impl Apm {
+    fn atom_package_manager(self) -> Result<PathBuf> {
+        match self {
+            Self::AtomPackageManager(apm) => Ok(apm),
+            Self::Other => {
+                Err(SkipStep(t!("Command `apm` does not appear to be Atom Package Manager").to_string()).into())
+            }
+        }
+    }
+
+    fn get(ctx: &ExecutionContext) -> Result<Self> {
+        let apm = require("apm")?;
+        let output = ctx.execute(&apm).always().arg("--help").output_checked_utf8()?;
+
+        if output
+            .stdout
+            .split(|character: char| !character.is_alphanumeric())
+            .any(|word| word.eq_ignore_ascii_case("atom"))
+        {
+            debug!("Detected `apm` as Atom Package Manager");
+            Ok(Self::AtomPackageManager(apm))
+        } else {
+            debug!("Detected `apm` as another package manager");
+            Ok(Self::Other)
+        }
+    }
 }
 
 #[cfg(not(any(
@@ -247,41 +279,11 @@ fn is_atom_apm_help(stdout: &str, stderr: &str) -> bool {
     target_os = "dragonfly"
 )))]
 pub fn run_apm(ctx: &ExecutionContext) -> Result<()> {
-    let apm = require("apm")?;
-
-    let help = ctx.execute(&apm).always().arg("--help").output_checked_utf8()?;
-    if !is_atom_apm_help(&help.stdout, &help.stderr) {
-        return Err(SkipStep(t!("Command `apm` does not appear to be Atom Package Manager").to_string()).into());
-    }
+    let apm = Apm::get(ctx)?.atom_package_manager()?;
 
     print_separator("Atom Package Manager");
 
     ctx.execute(apm).args(["upgrade", "--confirm=false"]).status_checked()
-}
-
-#[cfg(all(
-    test,
-    not(any(
-        target_os = "freebsd",
-        target_os = "openbsd",
-        target_os = "netbsd",
-        target_os = "dragonfly"
-    ))
-))]
-mod apm_tests {
-    use super::is_atom_apm_help;
-
-    #[test]
-    fn detects_atom_package_manager_help() {
-        assert!(is_atom_apm_help("apm - Atom Package Manager", ""));
-        assert!(is_atom_apm_help("", "Usage: atom package manager"));
-    }
-
-    #[test]
-    fn rejects_other_apm_commands() {
-        assert!(!is_atom_apm_help("Agent Package Manager", ""));
-        assert!(!is_atom_apm_help("Manage application packages", ""));
-    }
 }
 
 enum Aqua {

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -233,12 +233,55 @@ pub fn run_micro(ctx: &ExecutionContext) -> Result<()> {
     target_os = "netbsd",
     target_os = "dragonfly"
 )))]
+fn is_atom_apm_help(stdout: &str, stderr: &str) -> bool {
+    stdout
+        .split(|character: char| !character.is_alphanumeric())
+        .chain(stderr.split(|character: char| !character.is_alphanumeric()))
+        .any(|word| word.eq_ignore_ascii_case("atom"))
+}
+
+#[cfg(not(any(
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "dragonfly"
+)))]
 pub fn run_apm(ctx: &ExecutionContext) -> Result<()> {
     let apm = require("apm")?;
+
+    let help = ctx.execute(&apm).always().arg("--help").output_checked_utf8()?;
+    if !is_atom_apm_help(&help.stdout, &help.stderr) {
+        return Err(SkipStep("Command `apm` does not appear to be Atom Package Manager".to_string()).into());
+    }
 
     print_separator("Atom Package Manager");
 
     ctx.execute(apm).args(["upgrade", "--confirm=false"]).status_checked()
+}
+
+#[cfg(all(
+    test,
+    not(any(
+        target_os = "freebsd",
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "dragonfly"
+    ))
+))]
+mod apm_tests {
+    use super::is_atom_apm_help;
+
+    #[test]
+    fn detects_atom_package_manager_help() {
+        assert!(is_atom_apm_help("apm - Atom Package Manager", ""));
+        assert!(is_atom_apm_help("", "Usage: atom package manager"));
+    }
+
+    #[test]
+    fn rejects_other_apm_commands() {
+        assert!(!is_atom_apm_help("Agent Package Manager", ""));
+        assert!(!is_atom_apm_help("Manage application packages", ""));
+    }
 }
 
 enum Aqua {


### PR DESCRIPTION
## What does this PR do

Prevents Topgrade from running the Atom Package Manager step when the `apm` executable belongs to a different tool.

Some unrelated package managers also use the `apm` command name. Topgrade previously assumed that any executable named `apm` was Atom Package Manager and attempted to run:

```text
apm upgrade --confirm=false
```

This change checks the output of `apm --help` first and only continues when it identifies Atom Package Manager. Otherwise, the step is skipped.

Tests cover Atom Package Manager output and unrelated `apm` commands such as Agent Package Manager.

Closes #2187

## Standards checklist

- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* The PR title is a descriptive commit message
- [ ] *Optional:* I have tested the code myself, with the relevant tools installed
- [x] If this PR introduces new user-facing messages they are translated

### AI involvement

AI assistance was used for investigation, a small self-contained implementation, tests, and validation. I reviewed the change and test results.

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->