### PR TITLE
refactor: remove unnecessary #[expect(clippy::wildcard_imports)]

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -23,10 +23,8 @@ use tracing::debug;
 use self::config::{CommandLineArgs, Config};
 use self::error::StepFailed;
 use self::runner::StepResult;
-#[expect(clippy::wildcard_imports)]
 use self::steps::{remote::*, *};
 use self::sudo::{Sudo, SudoCreateError, SudoKind};
-#[expect(clippy::wildcard_imports)]
 use self::terminal::*;
 use self::utils::{install_color_eyre, install_tracing, is_elevated, set_wsl_use_windows_path, update_tracing};
 

--- a/src/step.rs
+++ b/src/step.rs
@@ -10,7 +10,6 @@ use strum::{EnumCount, EnumIter, EnumString, VariantNames};
 #[cfg(feature = "self-update")]
 use crate::self_update;
 use crate::steps::remote::vagrant;
-#[expect(clippy::wildcard_imports)]
 use crate::steps::*;
 use crate::utils::hostname;
 


### PR DESCRIPTION
These were tripping up `cargo clippy --tests` for some reason, and they're not needed anyway since we haven't enabled `clippy::pedantic` (yet)