### PR TITLE
Draft: proof of concept for overide step path

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -21,7 +21,7 @@ use strum::IntoEnumIterator;
 use tracing::{debug, error};
 
 use crate::execution_context::RunType;
-use crate::step::{DEPRECATED_STEPS, Step};
+use crate::step::{Binaries, DEPRECATED_STEPS, Step};
 use crate::sudo::SudoKind;
 use crate::terminal::print_warning;
 use crate::utils::string_prepend_str;
@@ -61,6 +61,12 @@ pub struct Containers {
     runtime: Option<ContainerRuntime>,
     system_prune: Option<bool>,
     use_sudo: Option<bool>,
+}
+
+#[derive(Deserialize, Default, Debug, Merge)]
+pub struct AltPath {
+    name: Option<String>,
+    path: Option<String>,
 }
 
 #[derive(Deserialize, Default, Debug, Merge)]
@@ -351,6 +357,9 @@ pub struct Misc {
     sudo_loop_interval: Option<u16>,
 
     sudo_command: Option<SudoKind>,
+
+    #[merge(strategy = crate::utils::merge_strategies::vec_prepend_opt)]
+    alt_paths: Option<Vec<AltPath>>,
 
     #[merge(strategy = crate::utils::merge_strategies::vec_prepend_opt)]
     disable: Option<Vec<Step>>,
@@ -1795,6 +1804,24 @@ impl Config {
                     .filter(move |s| !specified.contains(s)),
             )
             .chain(last.iter().copied()))
+    }
+
+    pub fn path_name(&self, bin: Binaries) -> &str {
+        let bin_name = bin.to_string();
+        self.config_file
+            .misc
+            .as_ref()
+            .and_then(|misc| misc.alt_paths.as_ref())
+            .and_then(|p| p
+                .iter()
+                .find_map(|x| x
+                    .name
+                    .as_deref()
+                    .filter(|&n| n==bin_name)
+                    .and_then(|_| x.path.as_deref() )
+                )
+            )
+            .unwrap_or(bin.default_name())
     }
 
     /// Determine if we should ignore failures for this step

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -78,6 +78,114 @@ impl Executor {
         self
     }
 
+    /// See `std::process::Command::arg`
+    #[allow(dead_code)]
+    pub fn arg_if<S: AsRef<OsStr>>(&mut self, cond: bool, arg: S) -> &mut Executor {
+        if !cond {
+            return self;
+        }
+
+        match self {
+            Executor::Wet(c) | Executor::Damp(c) => {
+                c.arg(arg);
+            }
+            Executor::Dry(c) => {
+                c.args.push(arg.as_ref().into());
+            }
+        }
+
+        self
+    }
+
+    #[allow(dead_code)]
+    /// See `std::process::Command::args`
+    #[allow(dead_code)]
+    pub fn args_if<I, S>(&mut self, cond: bool, args: I) -> &mut Executor
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        if !cond {
+            return self;
+        }
+
+        match self {
+            Executor::Wet(c) | Executor::Damp(c) => {
+                c.args(args);
+            }
+            Executor::Dry(c) => {
+                c.args.extend(args.into_iter().map(|arg| arg.as_ref().into()));
+            }
+        }
+
+        self
+    }
+
+    #[allow(dead_code)]
+    /// See `std::process::Command::arg`
+    pub fn arg_if_else<S: AsRef<OsStr>>(&mut self, cond: bool, true_arg: S, false_arg: S) -> &mut Executor {
+        let arg = if cond { true_arg } else { false_arg };
+
+        match self {
+            Executor::Wet(c) | Executor::Damp(c) => {
+                c.arg(arg);
+            }
+            Executor::Dry(c) => {
+                c.args.push(arg.as_ref().into());
+            }
+        }
+
+        self
+    }
+
+    #[allow(dead_code)]
+    /// See `std::process::Command::args`
+    pub fn args_if_else<I, S>(&mut self, cond: bool, true_args: I, false_args: I) -> &mut Executor
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        let args = if cond { true_args } else { false_args };
+
+        match self {
+            Executor::Wet(c) | Executor::Damp(c) => {
+                c.args(args);
+            }
+            Executor::Dry(c) => {
+                c.args.extend(args.into_iter().map(|arg| arg.as_ref().into()));
+            }
+        }
+
+        self
+    }
+
+    #[allow(dead_code)]
+    /// See `std::process::Command::arg`
+    pub fn arg_if_some<T, F, S>(&mut self, opt: Option<T>, f: F) -> &mut Executor
+    where
+        F: FnOnce(T) -> S,
+        S: AsRef<OsStr>,
+    {
+        if let Some(val) = opt {
+            self.arg(f(val));
+        }
+        self
+    }
+
+    #[allow(dead_code)]
+    /// See `std::process::Command::args`
+    pub fn args_if_some<T, F, I, S>(&mut self, opt: Option<T>, f: F) -> &mut Executor
+    where
+        F: FnOnce(T) -> I,
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        if let Some(val) = opt {
+            self.args(f(val));
+        }
+        self
+    }
+
     #[allow(dead_code)]
     /// See `std::process::Command::current_dir`
     pub fn current_dir<P: AsRef<Path>>(&mut self, dir: P) -> &mut Executor {
@@ -132,6 +240,29 @@ impl Executor {
         K: AsRef<OsStr>,
         V: AsRef<OsStr>,
     {
+        match self {
+            Executor::Wet(c) | Executor::Damp(c) => {
+                c.env(key, val);
+            }
+            Executor::Dry(c) => {
+                c.envs.push((key.as_ref().to_os_string(), val.as_ref().to_os_string()));
+            }
+        }
+
+        self
+    }
+
+    #[allow(dead_code)]
+    /// See `std::process::Command::env`
+    pub fn env_if<K, V>(&mut self, cond: bool, key: K, val: V) -> &mut Executor
+    where
+        K: AsRef<OsStr>,
+        V: AsRef<OsStr>,
+    {
+        if !cond {
+            return self;
+        }
+
         match self {
             Executor::Wet(c) | Executor::Damp(c) => {
                 c.env(key, val);

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -81,20 +81,11 @@ impl Executor {
     /// See `std::process::Command::arg`
     #[allow(dead_code)]
     pub fn arg_if<S: AsRef<OsStr>>(&mut self, cond: bool, arg: S) -> &mut Executor {
-        if !cond {
-            return self;
+        if cond {
+            self.arg(arg)
+        } else {
+            self
         }
-
-        match self {
-            Executor::Wet(c) | Executor::Damp(c) => {
-                c.arg(arg);
-            }
-            Executor::Dry(c) => {
-                c.args.push(arg.as_ref().into());
-            }
-        }
-
-        self
     }
 
     /// See `std::process::Command::args`
@@ -104,59 +95,13 @@ impl Executor {
         I: IntoIterator<Item = S>,
         S: AsRef<OsStr>,
     {
-        if !cond {
-            return self;
+        if cond {
+            self.args(args)
+        } else {
+            self
         }
-
-        match self {
-            Executor::Wet(c) | Executor::Damp(c) => {
-                c.args(args);
-            }
-            Executor::Dry(c) => {
-                c.args.extend(args.into_iter().map(|arg| arg.as_ref().into()));
-            }
-        }
-
-        self
     }
 
-    #[allow(dead_code)]
-    /// See `std::process::Command::arg`
-    pub fn arg_if_else<S: AsRef<OsStr>>(&mut self, cond: bool, true_arg: S, false_arg: S) -> &mut Executor {
-        let arg = if cond { true_arg } else { false_arg };
-
-        match self {
-            Executor::Wet(c) | Executor::Damp(c) => {
-                c.arg(arg);
-            }
-            Executor::Dry(c) => {
-                c.args.push(arg.as_ref().into());
-            }
-        }
-
-        self
-    }
-
-    #[allow(dead_code)]
-    /// See `std::process::Command::args`
-    pub fn args_if_else<I, S>(&mut self, cond: bool, true_args: I, false_args: I) -> &mut Executor
-    where
-        I: IntoIterator<Item = S>,
-        S: AsRef<OsStr>,
-    {
-        let args = if cond { true_args } else { false_args };
-
-        match self {
-            Executor::Wet(c) | Executor::Damp(c) => {
-                c.args(args);
-            }
-            Executor::Dry(c) => {
-                c.args.extend(args.into_iter().map(|arg| arg.as_ref().into()));
-            }
-        }
-
-        self
-    }
 
     #[allow(dead_code)]
     /// See `std::process::Command::arg`
@@ -258,20 +203,11 @@ impl Executor {
         K: AsRef<OsStr>,
         V: AsRef<OsStr>,
     {
-        if !cond {
-            return self;
+        if cond {
+            self.env(key,val)
+        } else {
+            self
         }
-
-        match self {
-            Executor::Wet(c) | Executor::Damp(c) => {
-                c.env(key, val);
-            }
-            Executor::Dry(c) => {
-                c.envs.push((key.as_ref().to_os_string(), val.as_ref().to_os_string()));
-            }
-        }
-
-        self
     }
 
     /// See `std::process::Command::spawn`

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -81,11 +81,7 @@ impl Executor {
     /// See `std::process::Command::arg`
     #[allow(dead_code)]
     pub fn arg_if<S: AsRef<OsStr>>(&mut self, cond: bool, arg: S) -> &mut Executor {
-        if cond {
-            self.arg(arg)
-        } else {
-            self
-        }
+        if cond { self.arg(arg) } else { self }
     }
 
     /// See `std::process::Command::args`
@@ -95,13 +91,8 @@ impl Executor {
         I: IntoIterator<Item = S>,
         S: AsRef<OsStr>,
     {
-        if cond {
-            self.args(args)
-        } else {
-            self
-        }
+        if cond { self.args(args) } else { self }
     }
-
 
     #[allow(dead_code)]
     /// See `std::process::Command::arg`
@@ -203,11 +194,7 @@ impl Executor {
         K: AsRef<OsStr>,
         V: AsRef<OsStr>,
     {
-        if cond {
-            self.env(key,val)
-        } else {
-            self
-        }
+        if cond { self.env(key, val) } else { self }
     }
 
     /// See `std::process::Command::spawn`

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -97,7 +97,6 @@ impl Executor {
         self
     }
 
-    #[allow(dead_code)]
     /// See `std::process::Command::args`
     #[allow(dead_code)]
     pub fn args_if<I, S>(&mut self, cond: bool, args: I) -> &mut Executor

--- a/src/step.rs
+++ b/src/step.rs
@@ -1,3 +1,5 @@
+use core::fmt;
+
 use crate::execution_context::ExecutionContext;
 use crate::runner::Runner;
 use clap::ValueEnum;
@@ -783,6 +785,25 @@ impl Step {
         }
 
         Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub enum Binaries {
+    Rustup,
+}
+
+impl Binaries {
+    pub fn default_name(&self) -> &'static str {
+        match self {
+            Binaries::Rustup => "rustup",
+        }
+    }
+}
+
+impl fmt::Display for Binaries {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
     }
 }
 

--- a/src/steps/emacs.rs
+++ b/src/steps/emacs.rs
@@ -60,18 +60,11 @@ impl Emacs {
     fn update_doom(doom: &Path, ctx: &ExecutionContext) -> Result<()> {
         print_separator("Doom Emacs");
 
-        let mut command = ctx.execute(doom);
-        if ctx.config().yes(Step::Emacs) {
-            command.arg("--force");
-        }
-
-        command.arg("upgrade");
-
-        if ctx.config().doom_aot() {
-            command.arg("--aot");
-        }
-
-        command.status_checked()
+        ctx.execute(doom)
+            .arg_if(ctx.config().yes(Step::Emacs), "--force")
+            .arg("upgrade")
+            .arg_if(ctx.config().doom_aot(), "--aot")
+            .status_checked()
     }
 
     pub fn upgrade(&self, ctx: &ExecutionContext) -> Result<()> {

--- a/src/steps/emacs.rs
+++ b/src/steps/emacs.rs
@@ -81,24 +81,19 @@ impl Emacs {
 
         print_separator("Emacs");
 
-        let mut command = ctx.execute(emacs);
+        #[cfg(unix)]
+        let emacs_upgrade_arg = EMACS_UPGRADE
+            .chars()
+            .map(|c| if c.is_whitespace() { '\u{00a0}' } else { c })
+            .collect::<String>();
+        #[cfg(not(unix))]
+        let emacs_upgrade_arg = EMACS_UPGRADE;
 
-        command
+        ctx.execute(emacs)
             .args(["--batch", "--debug-init", "-l"])
             .arg(init_file)
-            .arg("--eval");
-
-        #[cfg(unix)]
-        command.arg(
-            EMACS_UPGRADE
-                .chars()
-                .map(|c| if c.is_whitespace() { '\u{00a0}' } else { c })
-                .collect::<String>(),
-        );
-
-        #[cfg(not(unix))]
-        command.arg(EMACS_UPGRADE);
-
-        command.status_checked()
+            .arg("--eval")
+            .arg(emacs_upgrade_arg)
+            .status_checked()
     }
 }

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -77,18 +77,12 @@ pub fn run_cargo_update(ctx: &ExecutionContext) -> Result<()> {
         return Err(SkipStep(message).into());
     };
 
-    let mut command = ctx.execute(cargo_update);
-    command.args(["install-update", "--all"]);
-    if ctx.config().cargo_update_git() {
-        command.arg("--git");
-    }
-    if ctx.config().cargo_update_quiet() {
-        command.arg("--quiet");
-    }
-    if ctx.config().cargo_update_locked() {
-        command.arg("--locked");
-    }
-    command.status_checked()?;
+    ctx.execute(cargo_update)
+        .args(["install-update", "--all"])
+        .arg_if(ctx.config().cargo_update_git(), "--git")
+        .arg_if(ctx.config().cargo_update_quiet(), "--quiet")
+        .arg_if(ctx.config().cargo_update_locked(), "--locked")
+        .status_checked()?;
 
     if ctx.config().cleanup() {
         let cargo_cache = require("cargo-cache")
@@ -111,14 +105,11 @@ pub fn run_flutter_upgrade(ctx: &ExecutionContext) -> Result<()> {
     let flutter = require("flutter")?;
 
     print_separator("Flutter");
-    let mut command = ctx.execute(flutter);
-    command.arg("upgrade");
 
-    if ctx.config().flutter_force() {
-        command.arg("--force");
-    }
-
-    command.status_checked()
+    ctx.execute(flutter)
+        .arg("upgrade")
+        .arg_if(ctx.config().flutter_force(), "--force")
+        .status_checked()
 }
 
 pub fn run_gem(ctx: &ExecutionContext) -> Result<()> {
@@ -817,34 +808,28 @@ pub fn run_conda_update(ctx: &ExecutionContext) -> Result<()> {
     let env_names = once(&base_env_name).chain(addl_env_names);
 
     for env_name in env_names {
-        let mut command = ctx.execute(&conda);
-        command.args(["update", "--all", "-n", env_name]);
-        if ctx.config().yes(Step::Conda) {
-            command.arg("--yes");
-        }
-        command.status_checked()?;
+        ctx.execute(&conda)
+            .args(["update", "--all", "-n", env_name])
+            .arg_if(ctx.config().yes(Step::Conda), "--yes")
+            .status_checked()?;
     }
 
     // Update any environments given by path
     if let Some(env_paths) = ctx.config().conda_env_paths() {
         for env_path in env_paths.iter() {
-            let mut command = ctx.execute(&conda);
-            command.args(["update", "--all", "-p", env_path]);
-            if ctx.config().yes(Step::Conda) {
-                command.arg("--yes");
-            }
-            command.status_checked()?;
+            ctx.execute(&conda)
+                .args(["update", "--all", "-p", env_path])
+                .arg_if(ctx.config().yes(Step::Conda), "--yes")
+                .status_checked()?;
         }
     }
 
     // Cleanup (conda clean) is global (not tied to a particular environment)
     if ctx.config().cleanup() {
-        let mut command = ctx.execute(conda);
-        command.args(["clean", "--all"]);
-        if ctx.config().yes(Step::Conda) {
-            command.arg("--yes");
-        }
-        command.status_checked()?;
+        ctx.execute(conda)
+            .args(["clean", "--all"])
+            .arg_if(ctx.config().yes(Step::Conda), "--yes")
+            .status_checked()?;
     }
 
     Ok(())
@@ -864,13 +849,14 @@ pub fn run_pixi_update(ctx: &ExecutionContext) -> Result<()> {
             .always()
             .args(["self-update", "--help"])
             .output_checked_utf8()?;
-        let mut cmd = ctx.execute(&pixi);
-        cmd.arg("self-update");
-        // check if help mentions --no-release-note to check if it is supported
-        if self_update_help_output.stdout.contains("--no-release-note") && !ctx.config().show_pixi_release_notes() {
-            cmd.arg("--no-release-note");
-        }
-        cmd.status_checked()?;
+        ctx.execute(&pixi)
+            .arg("self-update")
+            // check if help mentions --no-release-note to check if it is supported
+            .arg_if(
+                self_update_help_output.stdout.contains("--no-release-note") && !ctx.config().show_pixi_release_notes(),
+                "--no-release-note",
+            )
+            .status_checked()?;
     }
 
     ctx.execute(&pixi).args(["global", "update"]).status_checked()
@@ -881,20 +867,16 @@ pub fn run_mamba_update(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("Mamba");
 
-    let mut command = ctx.execute(&mamba);
-    command.args(["update", "--all", "-n", "base"]);
-    if ctx.config().yes(Step::Mamba) {
-        command.arg("--yes");
-    }
-    command.status_checked()?;
+    ctx.execute(&mamba)
+        .args(["update", "--all", "-n", "base"])
+        .arg_if(ctx.config().yes(Step::Mamba), "--yes")
+        .status_checked()?;
 
     if ctx.config().cleanup() {
-        let mut command = ctx.execute(&mamba);
-        command.args(["clean", "--all"]);
-        if ctx.config().yes(Step::Mamba) {
-            command.arg("--yes");
-        }
-        command.status_checked()?;
+        ctx.execute(&mamba)
+            .args(["clean", "--all"])
+            .arg_if(ctx.config().yes(Step::Mamba), "--yes")
+            .status_checked()?;
     }
 
     Ok(())
@@ -1130,17 +1112,13 @@ pub fn run_chezmoi_update(ctx: &ExecutionContext) -> Result<()> {
     )
     .require()?;
 
-    let mut cmd = ctx.execute(&chezmoi);
-
+    // does order matter?
     print_separator("chezmoi");
 
-    cmd.arg("update");
-
-    if ctx.config().chezmoi_exclude_encrypted() {
-        cmd.arg("--exclude=encrypted");
-    }
-
-    cmd.status_checked()
+    ctx.execute(&chezmoi)
+        .arg("update")
+        .arg_if(ctx.config().chezmoi_exclude_encrypted(), "--exclude=encrypted")
+        .status_checked()
 }
 
 pub fn run_myrepos_update(ctx: &ExecutionContext) -> Result<()> {
@@ -1518,15 +1496,14 @@ pub fn update_julia_packages(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator(t!("Julia Packages"));
 
-    let mut executor = ctx.execute(julia);
-
-    executor.arg(if ctx.config().julia_use_startup_file() {
-        "--startup-file=yes"
-    } else {
-        "--startup-file=no"
-    });
-
-    executor.args(["-e", "using Pkg; Pkg.update()"]).status_checked()
+    ctx.execute(julia)
+        .arg_if_else(
+            ctx.config().julia_use_startup_file(),
+            "--startup-file=yes",
+            "--startup-file=no",
+        )
+        .args(["-e", "using Pkg; Pkg.update()"])
+        .status_checked()
 }
 
 pub fn run_helm_repo_update(ctx: &ExecutionContext) -> Result<()> {
@@ -2311,15 +2288,10 @@ pub fn run_skills(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("Skills");
 
-    let mut command = ctx.execute(npx);
-
-    if ctx.config().yes(Step::Skills) {
-        command.arg("--yes");
-    }
-
-    command.args(["skills", "update", "--global"]);
-
-    command.status_checked()
+    ctx.execute(npx)
+        .arg_if(ctx.config().yes(Step::Skills), "--yes")
+        .args(["skills", "update", "--global"])
+        .status_checked()
 }
 
 pub fn run_opencode(ctx: &ExecutionContext) -> Result<()> {
@@ -2490,50 +2462,25 @@ pub fn run_mise(ctx: &ExecutionContext) -> Result<()> {
         }
     }
 
-    let mut cmd = ctx.execute(&mise);
-
-    cmd.arg("upgrade");
-    cmd.current_dir(temp_dir.path());
-
-    if ctx.config().mise_interactive() {
-        cmd.arg("--interactive");
-    }
-
-    if ctx.config().mise_bump() {
-        cmd.arg("--bump");
-    }
-
-    if ctx.config().mise_silent() {
-        cmd.arg("--silent");
-    }
-
-    if ctx.config().mise_quiet() {
-        cmd.arg("--quiet");
-    }
-
-    if ctx.config().mise_verbose() {
-        cmd.arg("--verbose");
-    }
-
-    if ctx.config().yes(Step::Mise) {
-        cmd.arg("--yes");
-    }
-
-    if let Some(jobs) = ctx.config().mise_jobs() {
-        cmd.args(["--jobs", &jobs.to_string()]);
-    }
-
-    cmd.status_checked()?;
+    ctx.execute(&mise)
+        .arg("upgrade")
+        .current_dir(temp_dir.path())
+        .arg_if(ctx.config().mise_interactive(), "--interactive")
+        .arg_if(ctx.config().mise_bump(), "--bump")
+        .arg_if(ctx.config().mise_silent(), "--silent")
+        .arg_if(ctx.config().mise_quiet(), "--quiet")
+        .arg_if(ctx.config().mise_verbose(), "--verbose")
+        .arg_if(ctx.config().yes(Step::Mise), "--yes")
+        .args_if_some(ctx.config().mise_jobs(), |jobs| {
+            ["--jobs".to_string(), jobs.to_string()]
+        })
+        .status_checked()?;
 
     if ctx.config().cleanup() {
-        cmd = ctx.execute(&mise);
-        cmd.arg("prune");
-
-        if ctx.config().yes(Step::Mise) {
-            cmd.arg("--yes");
-        }
-
-        cmd.status_checked()?;
+        ctx.execute(&mise)
+            .arg("prune")
+            .arg_if(ctx.config().yes(Step::Mise), "--yes")
+            .status_checked()?;
     }
 
     refresh_mise_env(ctx, &mise, temp_dir.path())

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -118,16 +118,14 @@ pub fn run_gem(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("Gems");
 
-    let mut command = ctx.execute(gem);
-    command.arg("update");
-
-    if env::var_os("RBENV_SHELL").is_none() {
-        command.arg("--user-install");
-    } else {
+    if !env::var_os("RBENV_SHELL").is_none() {
         debug!("Detected rbenv. Avoiding --user-install");
     }
 
-    command.status_checked()
+    ctx.execute(gem)
+        .arg("update")
+        .arg_if(env::var_os("RBENV_SHELL").is_none(), "--user-install")
+        .status_checked()
 }
 
 pub fn run_rubygems(ctx: &ExecutionContext) -> Result<()> {
@@ -500,12 +498,10 @@ pub fn run_opam_update(ctx: &ExecutionContext) -> Result<()> {
 
     ctx.execute(&opam).arg("update").status_checked()?;
 
-    let mut command = ctx.execute(&opam);
-    command.arg("upgrade");
-    if ctx.config().yes(Step::Opam) {
-        command.arg("--yes");
-    }
-    command.status_checked()?;
+    ctx.execute(&opam)
+        .arg("upgrade")
+        .arg_if(ctx.config().yes(Step::Opam), "--yes")
+        .status_checked()?;
 
     if ctx.config().cleanup() {
         ctx.execute(&opam).arg("clean").status_checked()?;
@@ -660,17 +656,18 @@ fn run_vscode_compatible(variant: VSCodeVariant, ctx: &ExecutionContext) -> Resu
 
     print_separator(variant.display_name());
 
-    let mut cmd = ctx.execute(bin);
-    // If the variant supports profiles
-    if variant.supports_profiles() {
-        // And we have configured use of a profile
-        if let Some(profile) = ctx.config().vscode_profile() {
-            // Add the profile argument
-            cmd.arg("--profile").arg(profile);
-        }
-    }
-
-    cmd.arg("--update-extensions").status_checked()
+    ctx.execute(bin)
+        .args_if_some(
+            // If the variant supports profiles and we have configured use of a profile
+            if variant.supports_profiles() {
+                ctx.config().vscode_profile()
+            } else {
+                None
+            },
+            |profile| ["--profile", profile],
+        )
+        .arg("--update-extensions")
+        .status_checked()
 }
 
 /// Make VSCodium a separate step because:
@@ -1141,21 +1138,23 @@ pub fn run_myrepos_update(ctx: &ExecutionContext) -> Result<()> {
 
 pub fn run_custom_command(name: &str, command: &str, ctx: &ExecutionContext) -> Result<()> {
     print_separator(name);
-    let mut exec = ctx.execute(shell());
+
     #[cfg(unix)]
-    let command = if let Some(command) = command.strip_prefix("-i ") {
-        exec.arg("-i");
-        command
-    } else {
-        command
-    };
-    if ctx.config().yes(Step::CustomCommands) {
-        exec.env("TOPGRADE_YES", "1");
-    }
-    if ctx.config().cleanup() {
-        exec.env("TOPGRADE_CLEANUP", "1");
-    }
-    exec.arg("-c").arg(command).status_checked()
+    let put_i = command.strip_prefix("-i ").is_some();
+    #[cfg(not(unix))]
+    let put_i = false;
+
+    ctx.execute(shell())
+        .arg_if(put_i, "-i")
+        .env_if(ctx.config().yes(Step::CustomCommands), "TOPGRADE_YES", "1")
+        .env_if(ctx.config().cleanup(), "TOPGRADE_CLEANUP", "1")
+        .arg("-c")
+        .arg(if put_i {
+            command.strip_prefix("-i ").unwrap()
+        } else {
+            command
+        })
+        .status_checked()
 }
 
 pub fn run_composer_update(ctx: &ExecutionContext) -> Result<()> {
@@ -1497,11 +1496,11 @@ pub fn update_julia_packages(ctx: &ExecutionContext) -> Result<()> {
     print_separator(t!("Julia Packages"));
 
     ctx.execute(julia)
-        .arg_if_else(
-            ctx.config().julia_use_startup_file(),
-            "--startup-file=yes",
-            "--startup-file=no",
-        )
+        .arg(if ctx.config().julia_use_startup_file() {
+            "--startup-file=yes"
+        } else {
+            "--startup-file=no"
+        })
         .args(["-e", "using Pkg; Pkg.update()"])
         .status_checked()
 }
@@ -1727,13 +1726,14 @@ pub fn run_poetry(ctx: &ExecutionContext) -> Result<()> {
         debug!("poetry interpreter: {:?}, args: {:?}", interp, interp_args);
 
         let check_official_install_script = "import sys; from os import path; print('Y') if path.isfile(path.join(sys.prefix, 'poetry_env')) else print('N')";
-        let mut command = ctx.execute(&interp).always();
-        if let Some(args) = interp_args {
-            command.arg(args);
-        }
-        let output = command
+
+        let output = ctx
+            .execute(&interp)
+            .always()
+            .arg_if_some(interp_args, |args| args)
             .args(["-c", check_official_install_script])
             .output_checked_utf8()?;
+
         let stdout = output.stdout.trim();
         let official_install = match stdout {
             "N" => false,
@@ -2230,12 +2230,13 @@ pub fn run_claude_code_plugins(ctx: &ExecutionContext) -> Result<()> {
 
     let mut success = true;
     for plugin in &plugins {
-        let mut cmd = ctx.execute(&claude);
-        cmd.args(["plugin", "update", &plugin.id, "--scope", &plugin.scope]);
+        let mut exec = ctx.execute(&claude);
+        exec.args(["plugin", "update", &plugin.id, "--scope", &plugin.scope]);
+
         if let Some(path) = &plugin.project_path {
-            cmd.current_dir(path);
+            exec.current_dir(path);
         }
-        if let Err(e) = cmd.status_checked() {
+        if let Err(e) = exec.status_checked() {
             error!("Updating plugin {} failed: {e}", plugin.id);
             success = false;
         }

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -28,6 +28,7 @@ use crate::command::{CommandExt, Utf8Output};
 use crate::execution_context::ExecutionContext;
 use crate::executor::{ExecutorChild, ExecutorOutput};
 use crate::output_changed_message;
+use crate::step::Binaries;
 use crate::step::Step;
 use crate::sudo::SudoExecuteOpts;
 use crate::terminal::{print_separator, shell};
@@ -331,7 +332,7 @@ pub fn run_aqua(ctx: &ExecutionContext) -> Result<()> {
 }
 
 pub fn run_rustup(ctx: &ExecutionContext) -> Result<()> {
-    let rustup = require("rustup")?;
+    let rustup = require(ctx.config().path_name(Binaries::Rustup))?;
 
     print_separator("rustup");
 

--- a/src/steps/git.rs
+++ b/src/steps/git.rs
@@ -259,12 +259,13 @@ impl RepoStep {
 
     /// Check if `repo` has a remote.
     fn has_remotes<P: AsRef<Path>>(&self, ctx: &ExecutionContext, repo: P) -> Option<bool> {
-        let mut cmd = ctx.execute(&self.git).always();
-        cmd.stdin(Stdio::null())
+        let res = ctx
+            .execute(&self.git)
+            .always()
+            .stdin(Stdio::null())
             .current_dir(repo.as_ref())
-            .args(["remote", "-v"]);
-
-        let res = cmd.output_checked_utf8();
+            .args(["remote", "-v"])
+            .output_checked_utf8();
 
         res.map(|output| {
             output

--- a/src/steps/go.rs
+++ b/src/steps/go.rs
@@ -23,14 +23,15 @@ pub fn run_go_gup(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("gup");
 
-    let mut command = ctx.execute(gup);
-    command.arg("update");
-
-    for exclude in ctx.config().gup_exclude() {
-        command.args(["--exclude", exclude]);
-    }
-
-    command.status_checked()
+    ctx.execute(gup)
+        .arg("update")
+        .args(
+            ctx.config()
+                .gup_exclude()
+                .iter()
+                .flat_map(|exclude| ["--exclude", exclude]),
+        )
+        .status_checked()
 }
 
 /// Get the path of a Go binary.

--- a/src/steps/os/android.rs
+++ b/src/steps/os/android.rs
@@ -14,24 +14,20 @@ pub fn upgrade_packages(ctx: &ExecutionContext) -> Result<()> {
 
     let is_nala = pkg.ends_with("nala");
 
-    let mut command = ctx.execute(&pkg);
-    command.arg("upgrade");
-
-    if ctx.config().yes(Step::System) {
-        command.arg("-y");
-    }
-    command.status_checked()?;
+    ctx.execute(&pkg)
+        .arg("upgrade")
+        .arg_if(ctx.config().yes(Step::System), "-y")
+        .status_checked()?;
 
     if !is_nala && ctx.config().cleanup() {
         ctx.execute(&pkg).arg("clean").status_checked()?;
 
         let apt = require("apt")?;
-        let mut command = ctx.execute(apt);
-        command.arg("autoremove");
-        if ctx.config().yes(Step::System) {
-            command.arg("-y");
-        }
-        command.status_checked()?;
+
+        ctx.execute(apt)
+            .arg("autoremove")
+            .arg_if(ctx.config().yes(Step::System), "-y")
+            .status_checked()?;
     }
 
     Ok(())

--- a/src/steps/os/archlinux.rs
+++ b/src/steps/os/archlinux.rs
@@ -29,26 +29,21 @@ impl ArchPackageManager for YayParu {
                 .status_checked_with_codes(&[1, 0])?;
         }
 
-        let mut command = ctx.execute(&self.executable);
-
-        command
+        ctx.execute(&self.executable)
             .arg("--pacman")
             .arg(&self.pacman)
             .arg("-Syu")
-            .args(ctx.config().yay_arguments().split_whitespace());
-
-        if ctx.config().yes(Step::System) {
-            command.arg("--noconfirm");
-        }
-        command.status_checked()?;
+            .args(ctx.config().yay_arguments().split_whitespace())
+            .arg_if(ctx.config().yes(Step::System), "--noconfirm")
+            .status_checked()?;
 
         if ctx.config().cleanup() {
-            let mut command = ctx.execute(&self.executable);
-            command.arg("--pacman").arg(&self.pacman).arg("-Scc");
-            if ctx.config().yes(Step::System) {
-                command.arg("--noconfirm");
-            }
-            command.status_checked()?;
+            ctx.execute(&self.executable)
+                .arg("--pacman")
+                .arg(&self.pacman)
+                .arg("-Scc")
+                .arg_if(ctx.config().yes(Step::System), "--noconfirm")
+                .status_checked()?;
         }
 
         Ok(())
@@ -70,15 +65,12 @@ pub struct GarudaUpdate {
 
 impl ArchPackageManager for GarudaUpdate {
     fn upgrade(&self, ctx: &ExecutionContext) -> Result<()> {
-        let mut command = ctx.execute(&self.executable);
-
-        command.env("UPDATE_AUR", "1").env("SKIP_MIRRORLIST", "1");
-
-        if ctx.config().yes(Step::System) {
-            command.env("PACMAN_NOCONFIRM", "1");
-        }
-        command.args(ctx.config().garuda_update_arguments().split_whitespace());
-        command.status_checked()?;
+        ctx.execute(&self.executable)
+            .env("UPDATE_AUR", "1")
+            .env("SKIP_MIRRORLIST", "1")
+            .env_if(ctx.config().yes(Step::System), "PACMAN_NOCONFIRM", "1")
+            .args(ctx.config().garuda_update_arguments().split_whitespace())
+            .status_checked()?;
 
         Ok(())
     }
@@ -98,24 +90,17 @@ pub struct Trizen {
 
 impl ArchPackageManager for Trizen {
     fn upgrade(&self, ctx: &ExecutionContext) -> Result<()> {
-        let mut command = ctx.execute(&self.executable);
-
-        command
+        ctx.execute(&self.executable)
             .arg("-Syu")
-            .args(ctx.config().trizen_arguments().split_whitespace());
-
-        if ctx.config().yes(Step::System) {
-            command.arg("--noconfirm");
-        }
-        command.status_checked()?;
+            .args(ctx.config().trizen_arguments().split_whitespace())
+            .arg_if(ctx.config().yes(Step::System), "--noconfirm")
+            .status_checked()?;
 
         if ctx.config().cleanup() {
-            let mut command = ctx.execute(&self.executable);
-            command.arg("-Sc");
-            if ctx.config().yes(Step::System) {
-                command.arg("--noconfirm");
-            }
-            command.status_checked()?;
+            ctx.execute(&self.executable)
+                .arg("-Sc")
+                .arg_if(ctx.config().yes(Step::System), "--noconfirm")
+                .status_checked()?;
         }
 
         Ok(())
@@ -137,20 +122,16 @@ pub struct Pacman {
 impl ArchPackageManager for Pacman {
     fn upgrade(&self, ctx: &ExecutionContext) -> Result<()> {
         let sudo = ctx.require_sudo()?;
-        let mut command = sudo.execute(ctx, &self.executable)?;
-        command.arg("-Syu");
-        if ctx.config().yes(Step::System) {
-            command.arg("--noconfirm");
-        }
-        command.status_checked()?;
+        sudo.execute(ctx, &self.executable)?
+            .arg("-Syu")
+            .arg_if(ctx.config().yes(Step::System), "--noconfirm")
+            .status_checked()?;
 
         if ctx.config().cleanup() {
-            let mut command = sudo.execute(ctx, &self.executable)?;
-            command.arg("-Scc");
-            if ctx.config().yes(Step::System) {
-                command.arg("--noconfirm");
-            }
-            command.status_checked()?;
+            sudo.execute(ctx, &self.executable)?
+                .arg("-Scc")
+                .arg_if(ctx.config().yes(Step::System), "--noconfirm")
+                .status_checked()?;
         }
 
         Ok(())
@@ -179,25 +160,17 @@ impl Pikaur {
 
 impl ArchPackageManager for Pikaur {
     fn upgrade(&self, ctx: &ExecutionContext) -> Result<()> {
-        let mut command = ctx.execute(&self.executable);
-
-        command
+        ctx.execute(&self.executable)
             .arg("-Syu")
-            .args(ctx.config().pikaur_arguments().split_whitespace());
-
-        if ctx.config().yes(Step::System) {
-            command.arg("--noconfirm");
-        }
-
-        command.status_checked()?;
+            .args(ctx.config().pikaur_arguments().split_whitespace())
+            .arg_if(ctx.config().yes(Step::System), "--noconfirm")
+            .status_checked()?;
 
         if ctx.config().cleanup() {
-            let mut command = ctx.execute(&self.executable);
-            command.arg("-Sc");
-            if ctx.config().yes(Step::System) {
-                command.arg("--noconfirm");
-            }
-            command.status_checked()?;
+            ctx.execute(&self.executable)
+                .arg("-Sc")
+                .arg_if(ctx.config().yes(Step::System), "--noconfirm")
+                .status_checked()?;
         }
 
         Ok(())
@@ -217,25 +190,17 @@ impl Pamac {
 }
 impl ArchPackageManager for Pamac {
     fn upgrade(&self, ctx: &ExecutionContext) -> Result<()> {
-        let mut command = ctx.execute(&self.executable);
-
-        command
+        ctx.execute(&self.executable)
             .arg("upgrade")
-            .args(ctx.config().pamac_arguments().split_whitespace());
-
-        if ctx.config().yes(Step::System) {
-            command.arg("--no-confirm");
-        }
-
-        command.status_checked()?;
+            .args(ctx.config().pamac_arguments().split_whitespace())
+            .arg_if(ctx.config().yes(Step::System), "--no-confirm")
+            .status_checked()?;
 
         if ctx.config().cleanup() {
-            let mut command = ctx.execute(&self.executable);
-            command.arg("clean");
-            if ctx.config().yes(Step::System) {
-                command.arg("--no-confirm");
-            }
-            command.status_checked()?;
+            ctx.execute(&self.executable)
+                .arg("clean")
+                .arg_if(ctx.config().yes(Step::System), "--no-confirm")
+                .status_checked()?;
         }
 
         Ok(())
@@ -275,39 +240,31 @@ impl ArchPackageManager for Aura {
         let version_no_sudo = Version::new(4, 0, 6);
 
         if version >= version_no_sudo {
-            let mut cmd = ctx.execute(&self.executable);
-            cmd.arg("-Au")
-                .args(ctx.config().aura_aur_arguments().split_whitespace());
-            if ctx.config().yes(Step::System) {
-                cmd.arg("--noconfirm");
-            }
-            cmd.status_checked()?;
+            ctx.execute(&self.executable)
+                .arg("-Au")
+                .args(ctx.config().aura_aur_arguments().split_whitespace())
+                .arg_if(ctx.config().yes(Step::System), "--noconfirm")
+                .status_checked()?;
 
-            let mut cmd = ctx.execute(&self.executable);
-            cmd.arg("-Syu")
-                .args(ctx.config().aura_pacman_arguments().split_whitespace());
-            if ctx.config().yes(Step::System) {
-                cmd.arg("--noconfirm");
-            }
-            cmd.status_checked()?;
+            ctx.execute(&self.executable)
+                .arg("-Syu")
+                .args(ctx.config().aura_pacman_arguments().split_whitespace())
+                .arg_if(ctx.config().yes(Step::System), "--noconfirm")
+                .status_checked()?;
         } else {
             let sudo = ctx.require_sudo()?;
 
-            let mut cmd = sudo.execute(ctx, &self.executable)?;
-            cmd.arg("-Au")
-                .args(ctx.config().aura_aur_arguments().split_whitespace());
-            if ctx.config().yes(Step::System) {
-                cmd.arg("--noconfirm");
-            }
-            cmd.status_checked()?;
+            sudo.execute(ctx, &self.executable)?
+                .arg("-Au")
+                .args(ctx.config().aura_aur_arguments().split_whitespace())
+                .arg_if(ctx.config().yes(Step::System), "--noconfirm")
+                .status_checked()?;
 
-            let mut cmd = sudo.execute(ctx, &self.executable)?;
-            cmd.arg("-Syu")
-                .args(ctx.config().aura_pacman_arguments().split_whitespace());
-            if ctx.config().yes(Step::System) {
-                cmd.arg("--noconfirm");
-            }
-            cmd.status_checked()?;
+            sudo.execute(ctx, &self.executable)?
+                .arg("-Syu")
+                .args(ctx.config().aura_pacman_arguments().split_whitespace())
+                .arg_if(ctx.config().yes(Step::System), "--noconfirm")
+                .status_checked()?;
         }
 
         Ok(())
@@ -329,36 +286,23 @@ impl Shelly {
 impl ArchPackageManager for Shelly {
     fn upgrade(&self, ctx: &ExecutionContext) -> Result<()> {
         if ctx.config().show_arch_news() {
-            let mut cmd = ctx.execute(&self.executable);
-            cmd.arg("news");
-            if ctx.config().yes(Step::System) {
-                cmd.arg("--no-confirm");
-            }
-            cmd.status_checked()?;
+            ctx.execute(&self.executable)
+                .arg("news")
+                .arg_if(ctx.config().yes(Step::System), "--no-confirm")
+                .status_checked()?;
         }
 
-        let mut cmd = ctx.execute(&self.executable);
-        cmd.arg("sync");
+        ctx.execute(&self.executable)
+            .arg("sync")
+            .arg_if(ctx.config().yes(Step::System), "--no-confirm")
+            .status_checked()?;
 
-        if ctx.config().yes(Step::System) {
-            cmd.arg("--no-confirm");
-        }
-
-        cmd.status_checked()?;
-
-        let mut cmd = ctx.execute(&self.executable);
-        cmd.arg("upgrade-all")
-            .args(ctx.config().shelly_arguments().split_whitespace());
-
-        if ctx.config().should_run(Step::Flatpak) {
-            cmd.arg("--no-flatpak");
-        }
-
-        if ctx.config().yes(Step::System) {
-            cmd.arg("--no-confirm");
-        }
-
-        cmd.status_checked()?;
+        ctx.execute(&self.executable)
+            .arg("upgrade-all")
+            .args(ctx.config().shelly_arguments().split_whitespace())
+            .arg_if(ctx.config().should_run(Step::Flatpak), "--no-flatpak")
+            .arg_if(ctx.config().yes(Step::System), "--no-confirm")
+            .status_checked()?;
 
         Ok(())
     }

--- a/src/steps/os/dragonfly.rs
+++ b/src/steps/os/dragonfly.rs
@@ -9,12 +9,10 @@ pub fn upgrade_packages(ctx: &ExecutionContext) -> Result<()> {
     print_separator(t!("DragonFly BSD Packages"));
 
     let sudo = ctx.require_sudo()?;
-    let mut cmd = sudo.execute(ctx, "/usr/local/sbin/pkg")?;
-    cmd.arg("upgrade");
-    if ctx.config().yes(Step::System) {
-        cmd.arg("-y");
-    }
-    cmd.status_checked()
+    sudo.execute(ctx, "/usr/local/sbin/pkg")?
+        .arg("upgrade")
+        .arg_if(ctx.config().yes(Step::System), "-y")
+        .status_checked()
 }
 
 pub fn audit_packages(ctx: &ExecutionContext) -> Result<()> {

--- a/src/steps/os/freebsd.rs
+++ b/src/steps/os/freebsd.rs
@@ -18,12 +18,10 @@ pub fn upgrade_packages(ctx: &ExecutionContext) -> Result<()> {
     print_separator(t!("FreeBSD Packages"));
 
     let sudo = ctx.require_sudo()?;
-    let mut command = sudo.execute(ctx, "/usr/sbin/pkg")?;
-    command.arg("upgrade");
-    if ctx.config().yes(Step::System) {
-        command.arg("-y");
-    }
-    command.status_checked()
+    sudo.execute(ctx, "/usr/sbin/pkg")?
+        .arg("upgrade")
+        .arg_if(ctx.config().yes(Step::System), "-y")
+        .status_checked()
 }
 
 pub fn audit_packages(ctx: &ExecutionContext) -> Result<()> {

--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -207,14 +207,10 @@ fn upgrade_aosc(ctx: &ExecutionContext) -> Result<()> {
     let oma = require("oma")?;
     let sudo = ctx.require_sudo()?;
 
-    let mut cmd = sudo.execute(ctx, &oma)?;
-    cmd.arg("upgrade");
-
-    if ctx.config().yes(Step::System) {
-        cmd.arg("-y");
-    }
-
-    cmd.status_checked()
+    sudo.execute(ctx, &oma)?
+        .arg("upgrade")
+        .arg_if(ctx.config().yes(Step::System), "-y")
+        .status_checked()
 }
 
 fn upgrade_alpine_linux(ctx: &ExecutionContext) -> Result<()> {
@@ -252,30 +248,18 @@ fn upgrade_redhat(ctx: &ExecutionContext) -> Result<()> {
     if let Some(ostree) = which("rpm-ostree")
         && ctx.config().rpm_ostree()
     {
-        let mut command = ctx.execute(ostree);
-        command.arg("upgrade");
-        return command.status_checked();
+        return ctx.execute(ostree).arg("upgrade").status_checked();
     };
 
     let dnf = require_one(["dnf", "yum"])?;
     let sudo = ctx.require_sudo()?;
 
-    let mut command = sudo.execute(ctx, &dnf)?;
-    command.arg(if ctx.config().redhat_distro_sync() {
-        "distro-sync"
-    } else {
-        "upgrade"
-    });
+    sudo.execute(ctx, &dnf)?
+        .arg_if_else(ctx.config().redhat_distro_sync(), "distro-sync", "upgrade")
+        .args_if_some(ctx.config().dnf_arguments(), |args| args.split_whitespace())
+        .arg_if(ctx.config().yes(Step::System), "-y")
+        .status_checked()?;
 
-    if let Some(args) = ctx.config().dnf_arguments() {
-        command.args(args.split_whitespace());
-    }
-
-    if ctx.config().yes(Step::System) {
-        command.arg("-y");
-    }
-
-    command.status_checked()?;
     Ok(())
 }
 
@@ -283,31 +267,24 @@ fn upgrade_nobara(ctx: &ExecutionContext) -> Result<()> {
     let dnf = require("dnf")?;
     let sudo = ctx.require_sudo()?;
 
-    let mut update_command = sudo.execute(ctx, &dnf)?;
+    sudo.execute(ctx, &dnf)?
+        .arg_if(ctx.config().yes(Step::System), "-y")
+        .arg("update")
+        // See https://nobaraproject.org/docs/upgrade-troubleshooting/how-do-i-update-the-system/
+        .args([
+            "rpmfusion-nonfree-release",
+            "rpmfusion-free-release",
+            "fedora-repos",
+            "nobara-repos",
+        ])
+        .arg("--refresh")
+        .status_checked()?;
 
-    if ctx.config().yes(Step::System) {
-        update_command.arg("-y");
-    }
+    sudo.execute(ctx, &dnf)?
+        .arg_if(ctx.config().yes(Step::System), "-y")
+        .arg("distro-sync")
+        .status_checked()?;
 
-    update_command.arg("update");
-    // See https://nobaraproject.org/docs/upgrade-troubleshooting/how-do-i-update-the-system/
-    update_command.args([
-        "rpmfusion-nonfree-release",
-        "rpmfusion-free-release",
-        "fedora-repos",
-        "nobara-repos",
-    ]);
-    update_command.arg("--refresh").status_checked()?;
-
-    let mut upgrade_command = sudo.execute(ctx, &dnf)?;
-
-    if ctx.config().yes(Step::System) {
-        upgrade_command.arg("-y");
-    }
-
-    upgrade_command.arg("distro-sync");
-
-    upgrade_command.status_checked()?;
     Ok(())
 }
 
@@ -328,9 +305,8 @@ fn upgrade_fedora_immutable(ctx: &ExecutionContext) -> Result<()> {
     }
 
     let ostree = require("rpm-ostree")?;
-    let mut command = ctx.execute(ostree);
-    command.arg("upgrade");
-    command.status_checked()?;
+    ctx.execute(ostree).arg("upgrade").status_checked()?;
+
     Ok(())
 }
 
@@ -349,17 +325,10 @@ fn upgrade_suse(ctx: &ExecutionContext) -> Result<()> {
 
     sudo.execute(ctx, &zypper)?.arg("refresh").status_checked()?;
 
-    let mut cmd = sudo.execute(ctx, &zypper)?;
-    cmd.arg(if ctx.config().suse_dup() {
-        "dist-upgrade"
-    } else {
-        "update"
-    });
-    if ctx.config().yes(Step::System) {
-        cmd.arg("-y");
-    }
-
-    cmd.status_checked()?;
+    sudo.execute(ctx, &zypper)?
+        .arg_if_else(ctx.config().suse_dup(), "dist-upgrade", "update")
+        .arg_if(ctx.config().yes(Step::System), "-y")
+        .status_checked()?;
 
     Ok(())
 }
@@ -370,13 +339,10 @@ fn upgrade_opensuse_tumbleweed(ctx: &ExecutionContext) -> Result<()> {
 
     sudo.execute(ctx, &zypper)?.arg("refresh").status_checked()?;
 
-    let mut cmd = sudo.execute(ctx, &zypper)?;
-    cmd.arg("dist-upgrade");
-    if ctx.config().yes(Step::System) {
-        cmd.arg("-y");
-    }
-
-    cmd.status_checked()?;
+    sudo.execute(ctx, &zypper)?
+        .arg("dist-upgrade")
+        .arg_if(ctx.config().yes(Step::System), "-y")
+        .status_checked()?;
 
     Ok(())
 }
@@ -385,12 +351,10 @@ fn upgrade_suse_micro(ctx: &ExecutionContext) -> Result<()> {
     let upd = require("transactional-update")?;
     let sudo = ctx.require_sudo()?;
 
-    let mut cmd = sudo.execute(ctx, &upd)?;
-    if ctx.config().yes(Step::System) {
-        cmd.arg("-n");
-    }
-
-    cmd.arg("dup").status_checked()?;
+    sudo.execute(ctx, &upd)?
+        .arg_if(ctx.config().yes(Step::System), "-n")
+        .arg("dup")
+        .status_checked()?;
 
     Ok(())
 }
@@ -399,19 +363,11 @@ fn upgrade_openmandriva(ctx: &ExecutionContext) -> Result<()> {
     let dnf = require("dnf")?;
     let sudo = ctx.require_sudo()?;
 
-    let mut command = sudo.execute(ctx, &dnf)?;
-
-    command.arg("upgrade");
-
-    if let Some(args) = ctx.config().dnf_arguments() {
-        command.args(args.split_whitespace());
-    }
-
-    if ctx.config().yes(Step::System) {
-        command.arg("-y");
-    }
-
-    command.status_checked()?;
+    sudo.execute(ctx, &dnf)?
+        .arg("upgrade")
+        .args_if_some(ctx.config().dnf_arguments(), |args| args.split_whitespace())
+        .arg_if(ctx.config().yes(Step::System), "-y")
+        .status_checked()?;
 
     Ok(())
 }
@@ -420,26 +376,16 @@ fn upgrade_pclinuxos(ctx: &ExecutionContext) -> Result<()> {
     let apt_get = require("apt-get")?;
     let sudo = ctx.require_sudo()?;
 
-    let mut command_update = sudo.execute(ctx, &apt_get)?;
+    sudo.execute(ctx, &apt_get)?
+        .arg("update")
+        .args_if_some(ctx.config().dnf_arguments(), |args| args.split_whitespace())
+        .arg_if(ctx.config().yes(Step::System), "-y")
+        .status_checked()?;
 
-    command_update.arg("update");
-
-    if let Some(args) = ctx.config().dnf_arguments() {
-        command_update.args(args.split_whitespace());
-    }
-
-    if ctx.config().yes(Step::System) {
-        command_update.arg("-y");
-    }
-
-    command_update.status_checked()?;
-
-    let mut cmd = sudo.execute(ctx, &apt_get)?;
-    cmd.arg("dist-upgrade");
-    if ctx.config().yes(Step::System) {
-        cmd.arg("-y");
-    }
-    cmd.status_checked()?;
+    sudo.execute(ctx, &apt_get)?
+        .arg("dist-upgrade")
+        .arg_if(ctx.config().yes(Step::System), "-y")
+        .status_checked()?;
 
     Ok(())
 }
@@ -447,19 +393,15 @@ fn upgrade_pclinuxos(ctx: &ExecutionContext) -> Result<()> {
 fn upgrade_vanilla(ctx: &ExecutionContext) -> Result<()> {
     let apx = require("apx")?;
 
-    let mut update = ctx.execute(&apx);
-    update.args(["update", "--all"]);
-    if ctx.config().yes(Step::System) {
-        update.arg("-y");
-    }
-    update.status_checked()?;
+    ctx.execute(&apx)
+        .args(["update", "--all"])
+        .arg_if(ctx.config().yes(Step::System), "-y")
+        .status_checked()?;
 
-    let mut upgrade = ctx.execute(&apx);
-    update.args(["upgrade", "--all"]);
-    if ctx.config().yes(Step::System) {
-        upgrade.arg("-y");
-    }
-    upgrade.status_checked()?;
+    ctx.execute(&apx)
+        .args(["upgrade", "--all"])
+        .arg_if(ctx.config().yes(Step::System), "-y")
+        .status_checked()?;
 
     Ok(())
 }
@@ -468,19 +410,15 @@ fn upgrade_void(ctx: &ExecutionContext) -> Result<()> {
     let xbps = require("xbps-install")?;
     let sudo = ctx.require_sudo()?;
 
-    let mut command = sudo.execute(ctx, &xbps)?;
-    command.args(["-Su", "xbps"]);
-    if ctx.config().yes(Step::System) {
-        command.arg("-y");
-    }
-    command.status_checked()?;
+    sudo.execute(ctx, &xbps)?
+        .args(["-Su", "xbps"])
+        .arg_if(ctx.config().yes(Step::System), "-y")
+        .status_checked()?;
 
-    let mut command = sudo.execute(ctx, &xbps)?;
-    command.arg("-u");
-    if ctx.config().yes(Step::System) {
-        command.arg("-y");
-    }
-    command.status_checked()?;
+    sudo.execute(ctx, &xbps)?
+        .arg("-u")
+        .arg_if(ctx.config().yes(Step::System), "-y")
+        .status_checked()?;
 
     Ok(())
 }
@@ -525,6 +463,7 @@ fn upgrade_gentoo(ctx: &ExecutionContext) -> Result<()> {
     Ok(())
 }
 
+#[derive(PartialEq)]
 enum AptKind {
     AptFast,
     Mist,
@@ -571,29 +510,19 @@ fn upgrade_debian(ctx: &ExecutionContext) -> Result<()> {
             .status_checked_with_codes(&[0, 100])?;
     }
 
-    let mut command = sudo.execute(ctx, &apt)?;
-    if let Nala = kind {
-        command.arg("upgrade");
-    } else {
-        command.arg("dist-upgrade");
-    };
-    if ctx.config().yes(Step::System) {
-        command.arg("-y");
-    }
-    if let Some(args) = ctx.config().apt_arguments() {
-        command.args(args.split_whitespace());
-    }
-    command.status_checked()?;
+    sudo.execute(ctx, &apt)?
+        .arg_if_else(kind == Nala, "upgrade", "dist-upgrade")
+        .arg_if(ctx.config().yes(Step::System), "-y")
+        .args_if_some(ctx.config().apt_arguments(), |args| args.split_whitespace())
+        .status_checked()?;
 
     if ctx.config().cleanup() {
         sudo.execute(ctx, &apt)?.arg("clean").status_checked()?;
 
-        let mut command = sudo.execute(ctx, &apt)?;
-        command.arg("autoremove");
-        if ctx.config().yes(Step::System) {
-            command.arg("-y");
-        }
-        command.status_checked()?;
+        sudo.execute(ctx, &apt)?
+            .arg("autoremove")
+            .arg_if(ctx.config().yes(Step::System), "-y")
+            .status_checked()?;
     }
 
     Ok(())
@@ -636,11 +565,10 @@ fn upgrade_solus(ctx: &ExecutionContext) -> Result<()> {
     let eopkg = require("eopkg")?;
     let sudo = ctx.require_sudo()?;
 
-    let mut cmd = sudo.execute(ctx, &eopkg)?;
-    if ctx.config().yes(Step::System) {
-        cmd.arg("-y");
-    }
-    cmd.arg("upgrade").status_checked()?;
+    sudo.execute(ctx, &eopkg)?
+        .arg_if(ctx.config().yes(Step::System), "-y")
+        .arg("upgrade")
+        .status_checked()?;
 
     Ok(())
 }
@@ -650,15 +578,9 @@ pub fn run_am(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("AM");
 
-    let mut am = ctx.execute(am);
-
-    if ctx.config().yes(Step::AM) {
-        am.arg("-U");
-    } else {
-        am.arg("-u");
-    }
-
-    am.status_checked()
+    ctx.execute(am)
+        .arg_if_else(ctx.config().yes(Step::AM), "-U", "-u")
+        .status_checked()
 }
 
 pub fn run_appman(ctx: &ExecutionContext) -> Result<()> {
@@ -679,23 +601,18 @@ pub fn run_pacdef(ctx: &ExecutionContext) -> Result<()> {
     let new_version = string.contains("version: 1");
 
     if new_version {
-        let mut cmd = ctx.execute(&pacdef);
-        cmd.args(["package", "sync"]);
-        if ctx.config().yes(Step::System) {
-            cmd.arg("--noconfirm");
-        }
-        cmd.status_checked()?;
+        ctx.execute(&pacdef)
+            .args(["package", "sync"])
+            .arg_if(ctx.config().yes(Step::System), "--noconfirm")
+            .status_checked()?;
 
         println!();
         ctx.execute(&pacdef).args(["package", "review"]).status_checked()?;
     } else {
-        let mut cmd = ctx.execute(&pacdef);
-        cmd.arg("sync");
-        if ctx.config().yes(Step::System) {
-            cmd.arg("--noconfirm");
-        }
-
-        cmd.status_checked()?;
+        ctx.execute(&pacdef)
+            .arg("sync")
+            .arg_if(ctx.config().yes(Step::System), "--noconfirm")
+            .status_checked()?;
 
         println!();
         ctx.execute(&pacdef).arg("review").status_checked()?;
@@ -708,16 +625,15 @@ pub fn run_pacstall(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("Pacstall");
 
-    let mut update_cmd = ctx.execute(&pacstall);
-    let mut upgrade_cmd = ctx.execute(pacstall);
+    ctx.execute(&pacstall)
+        .arg_if(ctx.config().yes(Step::Pacstall), "-P")
+        .arg("-U")
+        .status_checked()?;
 
-    if ctx.config().yes(Step::Pacstall) {
-        update_cmd.arg("-P");
-        upgrade_cmd.arg("-P");
-    }
-
-    update_cmd.arg("-U").status_checked()?;
-    upgrade_cmd.arg("-Up").status_checked()
+    ctx.execute(pacstall)
+        .arg_if(ctx.config().yes(Step::Pacstall), "-P")
+        .arg("-Up")
+        .status_checked()
 }
 
 pub fn run_pkgfile(ctx: &ExecutionContext) -> Result<()> {
@@ -772,12 +688,10 @@ fn upgrade_clearlinux(ctx: &ExecutionContext) -> Result<()> {
     let swupd = require("swupd")?;
     let sudo = ctx.require_sudo()?;
 
-    let mut cmd = sudo.execute(ctx, &swupd)?;
-    cmd.arg("update");
-    if ctx.config().yes(Step::System) {
-        cmd.arg("--assume=yes");
-    }
-    cmd.status_checked()?;
+    sudo.execute(ctx, &swupd)?
+        .arg("update")
+        .arg_if(ctx.config().yes(Step::System), "--assume=yes")
+        .status_checked()?;
 
     Ok(())
 }
@@ -830,13 +744,11 @@ fn upgrade_nixos(ctx: &ExecutionContext) -> Result<()> {
         (NixHandler::Autodetect, Err(_))
         // We need vanilla
         | (NixHandler::Vanilla, _) => {
-            let mut command = sudo.execute(ctx, "/run/current-system/sw/bin/nixos-rebuild")?;
-            command.args(["switch", "--upgrade"]);
-
-            if let Some(args) = ctx.config().nix_arguments() {
-                command.args(args.split_whitespace());
-            }
-            command.status_checked()?;
+            sudo.execute(ctx, "/run/current-system/sw/bin/nixos-rebuild")?
+                .args(["switch", "--upgrade"])
+                .args_if_some(ctx.config().nix_arguments(), |args| {
+                    args.split_whitespace() })
+                .status_checked()?;
         }
     }
 
@@ -864,24 +776,18 @@ fn upgrade_neon(ctx: &ExecutionContext) -> Result<()> {
     sudo.execute(ctx, &pkcon)?.arg("refresh").status_checked()?;
 
     let mut exe = sudo.execute(ctx, &pkcon)?;
-    let cmd = exe.arg("update");
-    if ctx.config().yes(Step::System) {
-        cmd.arg("-y");
-    }
-    if ctx.config().cleanup() {
-        cmd.arg("--autoremove");
-    }
-    // from pkcon man, exit code 5 is 'Nothing useful was done.'
-    cmd.status_checked_with_codes(&[5])?;
+    exe.arg("update")
+        .arg_if(ctx.config().yes(Step::System), "-y")
+        .arg_if(ctx.config().cleanup(), "--autoremove")
+        // from pkcon man, exit code 5 is 'Nothing useful was done.'
+        .status_checked_with_codes(&[5])?;
 
     Ok(())
 }
 
 fn upgrade_kde_linux(ctx: &ExecutionContext) -> Result<()> {
     let updatectl = require("updatectl")?;
-    let mut command = ctx.execute(updatectl);
-    command.arg("update");
-    command.status_checked()?;
+    ctx.execute(updatectl).arg("update").status_checked()?;
 
     Ok(())
 }
@@ -1065,11 +971,9 @@ pub fn run_protonup_update(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("protonup");
 
-    let mut cmd = ctx.execute(protonup);
-    if ctx.config().yes(Step::Protonup) {
-        cmd.arg("--yes");
-    }
-    cmd.status_checked()?;
+    ctx.execute(protonup)
+        .arg_if(ctx.config().yes(Step::Protonup), "--yes")
+        .status_checked()?;
 
     Ok(())
 }
@@ -1145,15 +1049,10 @@ pub fn run_lure_update(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("LURE");
 
-    let mut exe = ctx.execute(lure);
-
-    if ctx.config().yes(Step::Lure) {
-        exe.args(["-i=false", "up"]);
-    } else {
-        exe.arg("up");
-    }
-
-    exe.status_checked()
+    ctx.execute(lure)
+        .arg_if(ctx.config().yes(Step::Lure), "-i=false")
+        .arg("up")
+        .status_checked()
 }
 
 pub fn run_waydroid(ctx: &ExecutionContext) -> Result<()> {
@@ -1255,13 +1154,9 @@ pub fn run_gearlever(ctx: &ExecutionContext) -> Result<()> {
         cmd.args(["run", "it.mijorus.gearlever"]);
         cmd
     };
-    cmd.args(["--update", "--all"]);
-
-    if ctx.config().yes(Step::Gearlever) {
-        cmd.arg("--yes");
-    }
-
-    cmd.status_checked()
+    cmd.args(["--update", "--all"])
+        .arg_if(ctx.config().yes(Step::Gearlever), "--yes")
+        .status_checked()
 }
 
 pub fn run_cinnamon_spices_updater(ctx: &ExecutionContext) -> Result<()> {

--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -255,7 +255,11 @@ fn upgrade_redhat(ctx: &ExecutionContext) -> Result<()> {
     let sudo = ctx.require_sudo()?;
 
     sudo.execute(ctx, &dnf)?
-        .arg_if_else(ctx.config().redhat_distro_sync(), "distro-sync", "upgrade")
+        .arg(if ctx.config().redhat_distro_sync() {
+            "distro-sync"
+        } else {
+            "upgrade"
+        })
         .args_if_some(ctx.config().dnf_arguments(), |args| args.split_whitespace())
         .arg_if(ctx.config().yes(Step::System), "-y")
         .status_checked()?;
@@ -326,7 +330,11 @@ fn upgrade_suse(ctx: &ExecutionContext) -> Result<()> {
     sudo.execute(ctx, &zypper)?.arg("refresh").status_checked()?;
 
     sudo.execute(ctx, &zypper)?
-        .arg_if_else(ctx.config().suse_dup(), "dist-upgrade", "update")
+        .arg(if ctx.config().suse_dup() {
+            "dist-upgrade"
+        } else {
+            "update"
+        })
         .arg_if(ctx.config().yes(Step::System), "-y")
         .status_checked()?;
 
@@ -511,7 +519,7 @@ fn upgrade_debian(ctx: &ExecutionContext) -> Result<()> {
     }
 
     sudo.execute(ctx, &apt)?
-        .arg_if_else(kind == Nala, "upgrade", "dist-upgrade")
+        .arg(if kind == Nala { "upgrade" } else { "dist-upgrade" })
         .arg_if(ctx.config().yes(Step::System), "-y")
         .args_if_some(ctx.config().apt_arguments(), |args| args.split_whitespace())
         .status_checked()?;
@@ -541,9 +549,7 @@ pub fn run_deb_get(ctx: &ExecutionContext) -> Result<()> {
 
     let base_cmd = || {
         let mut cmd = ctx.execute(&deb_get);
-        if disable_apt {
-            cmd.env("DISABLE_APT", "y");
-        }
+        cmd.env_if(disable_apt, "DISABLE_APT", "y");
         cmd
     };
 
@@ -579,7 +585,7 @@ pub fn run_am(ctx: &ExecutionContext) -> Result<()> {
     print_separator("AM");
 
     ctx.execute(am)
-        .arg_if_else(ctx.config().yes(Step::AM), "-U", "-u")
+        .arg(if ctx.config().yes(Step::AM) { "-U" } else { "-u" })
         .status_checked()
 }
 
@@ -844,31 +850,29 @@ pub fn run_fwupdmgr(ctx: &ExecutionContext) -> Result<()> {
 
     ctx.execute(&fwupdmgr).arg("refresh").status_checked_with_codes(&[2])?;
 
-    let mut updmgr = ctx.execute(&fwupdmgr);
-
     if ctx.config().firmware_upgrade() {
-        updmgr.arg("update");
-        if ctx.config().yes(Step::System) {
-            updmgr.arg("-y");
-        }
-        updmgr.status_checked_with_codes(&[2])
+        ctx.execute(&fwupdmgr)
+            .arg("update")
+            .arg_if(ctx.config().yes(Step::System), "-y")
+            .status_checked_with_codes(&[2])
     } else {
-        updmgr.arg("get-updates");
-
         // Exit 0 from `fwupdmgr get-updates` means firmware updates are available.
         // Exit 2 means no updates. When updates exist but `firmware_upgrade` is
         // disabled, hint to the user that they can apply them manually.
         let has_updates = std::cell::Cell::new(false);
-        updmgr.status_checked_with(|status| {
-            if status.success() {
-                has_updates.set(true);
-                Ok(())
-            } else if status.code() == Some(2) {
-                Ok(())
-            } else {
-                Err(())
-            }
-        })?;
+
+        ctx.execute(&fwupdmgr)
+            .arg("get-updates")
+            .status_checked_with(|status| {
+                if status.success() {
+                    has_updates.set(true);
+                    Ok(())
+                } else if status.code() == Some(2) {
+                    Ok(())
+                } else {
+                    Err(())
+                }
+            })?;
 
         if has_updates.get() {
             print_warning(t!(
@@ -1183,9 +1187,7 @@ pub fn run_protonplus_update(ctx: &ExecutionContext) -> Result<()> {
     };
     let cmd = || {
         let mut cmd = ctx.execute(&program);
-        if flatpak {
-            cmd.args(["run", "com.vysp3r.ProtonPlus"]);
-        }
+        cmd.args_if(flatpak, ["run", "com.vysp3r.ProtonPlus"]);
         cmd
     };
 

--- a/src/steps/os/macos.rs
+++ b/src/steps/os/macos.rs
@@ -105,14 +105,10 @@ pub fn upgrade_macos(ctx: &ExecutionContext) -> Result<()> {
         }
     }
 
-    let mut command = ctx.execute("softwareupdate");
-    command.args(["--install", "--all"]);
-
-    if should_ask {
-        command.arg("--no-scan");
-    }
-
-    command.status_checked()
+    ctx.execute("softwareupdate")
+        .args(["--install", "--all"])
+        .arg_if(should_ask, "--no-scan")
+        .status_checked()
 }
 
 fn system_update_available(ctx: &ExecutionContext) -> Result<bool> {
@@ -140,10 +136,10 @@ pub fn run_sparkle(ctx: &ExecutionContext) -> Result<()> {
             .args(["--probe", "--user-agent-name", "topgrade"])
             .output_checked_utf8();
         if probe.is_ok() {
-            let mut command = ctx.execute(&sparkle);
-            command.arg(application.path());
-            command.args(["--check-immediately", "--user-agent-name", "topgrade"]);
-            command.status_checked()?;
+            ctx.execute(&sparkle)
+                .arg(application.path())
+                .args(["--check-immediately", "--user-agent-name", "topgrade"])
+                .status_checked()?;
         }
     }
     Ok(())

--- a/src/steps/os/openbsd.rs
+++ b/src/steps/os/openbsd.rs
@@ -40,10 +40,8 @@ pub fn upgrade_packages(ctx: &ExecutionContext) -> Result<()> {
         sudo.execute(ctx, "/usr/sbin/pkg_delete")?.arg("-ac").status_checked()?;
     }
 
-    let mut command = sudo.execute(ctx, "/usr/sbin/pkg_add")?;
-    command.arg("-u");
-    if is_current {
-        command.arg("-Dsnap");
-    }
-    command.status_checked()
+    sudo.execute(ctx, "/usr/sbin/pkg_add")?
+        .arg("-u")
+        .arg_if(is_current, "-Dsnap")
+        .status_checked()
 }

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -295,19 +295,15 @@ pub fn run_pkgin(ctx: &ExecutionContext) -> Result<()> {
 
     let sudo = ctx.require_sudo()?;
 
-    let mut command = sudo.execute(ctx, &pkgin)?;
-    command.arg("update");
-    if ctx.config().yes(Step::Pkgin) {
-        command.arg("-y");
-    }
-    command.status_checked()?;
+    sudo.execute(ctx, &pkgin)?
+        .arg("update")
+        .arg_if(ctx.config().yes(Step::Pkgin), "-y")
+        .status_checked()?;
 
-    let mut command = sudo.execute(ctx, &pkgin)?;
-    command.arg("upgrade");
-    if ctx.config().yes(Step::Pkgin) {
-        command.arg("-y");
-    }
-    command.status_checked()
+    sudo.execute(ctx, &pkgin)?
+        .arg("upgrade")
+        .arg_if(ctx.config().yes(Step::Pkgin), "-y")
+        .status_checked()
 }
 
 pub fn run_fish_plug(ctx: &ExecutionContext) -> Result<()> {
@@ -398,18 +394,11 @@ pub fn run_brew_formula(ctx: &ExecutionContext, variant: BrewVariant) -> Result<
     //  `.current_dir("/tmp") // brew needs a writable current directory`
     //  but that only applied when sudo -Hu was used. Is it really needed?
 
-    let mut command = brew.execute(ctx)?;
-    command.args(["upgrade", "--formula"]);
-
-    if ctx.config().yes(Step::BrewFormula) {
-        command.arg("-y");
-    }
-
-    if ctx.config().brew_fetch_head() {
-        command.arg("--fetch-HEAD");
-    }
-
-    command.status_checked()?;
+    brew.execute(ctx)?
+        .args(["upgrade", "--formula"])
+        .arg_if(ctx.config().yes(Step::BrewFormula), "-y")
+        .arg_if(ctx.config().brew_fetch_head(), "--fetch-HEAD")
+        .status_checked()?;
 
     if ctx.config().cleanup() {
         brew.execute(ctx)?.arg("cleanup").status_checked()?;
@@ -734,7 +723,7 @@ pub fn run_nix(ctx: &ExecutionContext) -> Result<()> {
         let nix_env = require("nix-env")?;
         print_separator("Nix");
 
-        let mut command = match &get_symlink_sudo_user(profile_path) {
+        match &get_symlink_sudo_user(profile_path) {
             None => ctx.execute(nix_env),
             Some(user) => {
                 let sudo = ctx.require_sudo()?;
@@ -744,12 +733,10 @@ pub fn run_nix(ctx: &ExecutionContext) -> Result<()> {
                     SudoExecuteOpts::new().set_home().user(user).login_shell(),
                 )?
             }
-        };
-        command.arg("--upgrade");
-        if let Some(args) = ctx.config().nix_env_arguments() {
-            command.args(args.split_whitespace());
-        };
-        command.status_checked()
+        }
+        .arg("--upgrade")
+        .args_if_some(ctx.config().nix_env_arguments(), |args| args.split_whitespace())
+        .status_checked()
     }
 }
 
@@ -926,15 +913,13 @@ pub(super) fn nh_switch(ctx: &ExecutionContext, nh: &PathBuf, args: &NhSwitchArg
         print_separator(format!("nh {}", args.installable_type));
     }
 
-    let mut cmd = ctx.execute(nh);
-    cmd.arg(args.installable_type);
-    cmd.arg("switch");
-    cmd.arg("-u");
+    ctx.execute(nh)
+        .arg(args.installable_type)
+        .arg("switch")
+        .arg("-u")
+        .arg_if(!ctx.config().yes(Step::System), "--ask")
+        .status_checked()?;
 
-    if !ctx.config().yes(Step::System) {
-        cmd.arg("--ask");
-    }
-    cmd.status_checked()?;
     Ok(())
 }
 
@@ -1023,14 +1008,10 @@ pub fn run_home_manager(ctx: &ExecutionContext) -> Result<()> {
         | (Ok(home_manager), NixHandler::Vanilla, _) => {
             print_separator("home-manager");
 
-            let mut cmd = ctx.execute(home_manager);
-            cmd.arg("switch");
-
-            if let Some(extra_args) = ctx.config().home_manager() {
-                cmd.args(extra_args);
-            }
-
-            cmd.status_checked()
+            ctx.execute(home_manager)
+                .arg("switch")
+                .args_if_some(ctx.config().home_manager(), |args| { args })
+                .status_checked()
         }
         (Err(_), _, Err(_)) => unreachable!("require_one([\"home-manager\", \"nh\"])?; was called, so either tool must be available"),
     }
@@ -1202,18 +1183,15 @@ pub fn run_install_release(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("Install Release");
 
-    let mut command = ctx.execute(&ir);
-    command.args(["upgrade", "--pkg"]);
-    if ctx.config().yes(Step::InstallRelease) {
-        command.arg("-y");
-    }
-    command.status_checked()?;
+    ctx.execute(&ir)
+        .args(["upgrade", "--pkg"])
+        .arg_if(ctx.config().yes(Step::InstallRelease), "-y")
+        .status_checked()?;
 
-    let mut command = ctx.execute(&ir);
-    command.arg("upgrade");
-    if ctx.config().yes(Step::InstallRelease) {
-        command.arg("-y");
-    }
-    command.status_checked()?;
+    ctx.execute(&ir)
+        .arg("upgrade")
+        .arg_if(ctx.config().yes(Step::InstallRelease), "-y")
+        .status_checked()?;
+
     Ok(())
 }

--- a/src/steps/os/windows.rs
+++ b/src/steps/os/windows.rs
@@ -22,14 +22,10 @@ pub fn run_chocolatey(ctx: &ExecutionContext) -> Result<()> {
 
     let sudo = ctx.require_sudo()?;
 
-    let mut command = sudo.execute(ctx, &choco)?;
-    command.args(["upgrade", "all"]);
-
-    if yes {
-        command.arg("--yes");
-    }
-
-    command.status_checked()
+    sudo.execute(ctx, &choco)?
+        .args(["upgrade", "all"])
+        .arg_if(yes, "--yes")
+        .status_checked()
 }
 
 pub fn run_winget(ctx: &ExecutionContext) -> Result<()> {
@@ -143,13 +139,11 @@ fn upgrade_wsl_distribution(wsl: &Path, dist: &str, ctx: &ExecutionContext) -> R
         .trim_end()
         .to_owned();
 
-    let mut command = ctx.execute(wsl);
-
-    // Pass the distro name, discovered topgrade path, and forwarded flags as
-    // positional parameters so the inner `bash -lc` receives them as single argv
-    // elements instead of parsing their contents. `"${@:3}"` forwards the flags
-    // to `topgrade` (not `bash`) and expands to nothing when there are none.
-    command
+    ctx.execute(wsl)
+        // Pass the distro name, discovered topgrade path, and forwarded flags as
+        // positional parameters so the inner `bash -lc` receives them as single argv
+        // elements instead of parsing their contents. `"${@:3}"` forwards the flags
+        // to `topgrade` (not `bash`) and expands to nothing when there are none.
         .args([
             "-d",
             dist,
@@ -159,15 +153,10 @@ fn upgrade_wsl_distribution(wsl: &Path, dist: &str, ctx: &ExecutionContext) -> R
             "bash",
         ])
         .arg(dist)
-        .arg(&topgrade);
-    if ctx.config().verbose() {
-        command.arg("-v");
-    }
-    if ctx.config().yes(Step::Wsl) {
-        command.arg("-y");
-    }
-
-    command.status_checked()
+        .arg(&topgrade)
+        .arg_if(ctx.config().verbose(), "-v")
+        .arg_if(ctx.config().yes(Step::Wsl), "-y")
+        .status_checked()
 }
 
 pub fn run_wsl_topgrade(ctx: &ExecutionContext) -> Result<()> {

--- a/src/steps/os/windows.rs
+++ b/src/steps/os/windows.rs
@@ -76,17 +76,12 @@ pub fn update_wsl(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator(t!("Update WSL"));
 
-    let mut wsl_command = ctx.execute(wsl);
-    wsl_command.args(["--update"]);
+    ctx.execute(wsl)
+        .args(["--update"])
+        .arg_if(ctx.config().wsl_update_pre_release(), "--pre-release")
+        .arg_if(ctx.config().wsl_update_use_web_download(), "--web-download")
+        .status_checked()?;
 
-    if ctx.config().wsl_update_pre_release() {
-        wsl_command.args(["--pre-release"]);
-    }
-
-    if ctx.config().wsl_update_use_web_download() {
-        wsl_command.args(["--web-download"]);
-    }
-    wsl_command.status_checked()?;
     Ok(())
 }
 

--- a/src/steps/powershell.rs
+++ b/src/steps/powershell.rs
@@ -115,19 +115,17 @@ impl Powershell {
     where
         S: AsRef<OsStr>,
     {
-        let mut command = ctx.execute(&self.path).always();
+        let mut exec = ctx.execute(&self.path).always();
 
-        command.args(["-NoProfile", "-Command"]);
-        command.arg(cmd);
-        command.args(args);
+        exec.args(["-NoProfile", "-Command", cmd]).args(args);
 
         // If topgrade was run from pwsh, but we are trying to run powershell, then
         // the inherited PSModulePath breaks module imports
         if !self.is_pwsh {
-            command.env_remove("PSModulePath");
+            exec.env_remove("PSModulePath");
         }
 
-        command
+        exec
     }
 
     /// Builds a "primary" powershell command (uses dry-run if required):

--- a/src/steps/zsh.rs
+++ b/src/steps/zsh.rs
@@ -22,9 +22,9 @@ use etcetera::base_strategy::BaseStrategy;
 /// last command sidesteps that. Drop this helper and restore plain `execute` once zsh fixes it.
 fn execute_interactive_zsh(ctx: &ExecutionContext, zsh: &Path, command: &str) -> Executor {
     let script = format!("{command}; exit $?");
-    let mut exec = ctx.execute(zsh);
-    exec.args(["-i", "-c", &script]);
-    exec
+    let mut cmd = ctx.execute(zsh);
+    cmd.args(["-i", "-c", &script]);
+    cmd
 }
 
 pub fn run_zr(ctx: &ExecutionContext) -> Result<()> {

--- a/src/sudo.rs
+++ b/src/sudo.rs
@@ -281,64 +281,65 @@ impl Sudo {
         print_separator("Sudo");
 
         // self.path is only None for null sudo, which we've handled above
-        let mut cmd = ctx.execute(self.path.as_deref().unwrap());
-        match self.kind {
-            SudoKind::Doas => {
-                // `doas` doesn't have anything like `sudo -v` to cache credentials,
-                // so we just execute a no-op dummy command, `true`.
-                // See: https://man.openbsd.org/doas
-                cmd.arg("true");
-            }
-            SudoKind::Sudo => {
-                // From `man sudo` on macOS:
-                //   -v, --validate
-                //   Update the user's cached credentials, authenticating the user
-                //   if necessary.  For the sudoers plugin, this extends the sudo
-                //   timeout for another 5 minutes by default, but does not run a
-                //   command.  Not all security policies support cached credentials.
-                cmd.arg("-v");
-            }
-            SudoKind::WinSudo => {
-                // Windows `sudo` doesn't cache credentials, so we just execute a
-                // dummy command - the easiest on Windows is `rem` in cmd.
-                // See: https://learn.microsoft.com/en-us/windows/advanced-settings/sudo/
-                cmd.args(["cmd.exe", "/c", "rem"]);
-            }
-            SudoKind::Gsudo => {
-                // `gsudo` doesn't have anything like `sudo -v` to cache credentials,
-                // so we just execute a dummy command - the easiest on Windows is
-                // `rem` in cmd. `-d` tells it to run the command directly, without
-                // going through a shell (which could be powershell) first.
-                // See: https://gerardog.github.io/gsudo/docs/usage
-                cmd.args(["-d", "cmd.exe", "/c", "rem"]);
-                // TODO: `gsudo cache on` starts a session with cached credentials and could replace the dummy `rem` invocation here when sudo_loop is enabled...
-            }
-            SudoKind::Pkexec => {
-                // I don't think this does anything; `pkexec` usually asks for
-                // authentication every time, although it can be configured
-                // differently.
-                //
-                // See the note for `doas` above.
-                //
-                // See: https://linux.die.net/man/1/pkexec
-                cmd.arg("true");
-            }
-            SudoKind::Run0 => {
-                // `run0` uses polkit for authentication
-                // and thus has the same issues as `pkexec`.
-                //
-                // See: https://www.freedesktop.org/software/systemd/man/devel/run0.html
-                cmd.arg("true");
-            }
-            SudoKind::Please => {
-                // From `man please`
-                //   -w, --warm
-                //   Warm the access token and exit.
-                cmd.arg("-w");
-            }
-            SudoKind::Null => unreachable!(),
-        }
-        cmd.status_checked().wrap_err("Failed to elevate permissions")
+        ctx.execute(self.path.as_deref().unwrap())
+            .args(match self.kind {
+                SudoKind::Doas => {
+                    // `doas` doesn't have anything like `sudo -v` to cache credentials,
+                    // so we just execute a no-op dummy command, `true`.
+                    // See: https://man.openbsd.org/doas
+                    vec!["true"]
+                }
+                SudoKind::Sudo => {
+                    // From `man sudo` on macOS:
+                    //   -v, --validate
+                    //   Update the user's cached credentials, authenticating the user
+                    //   if necessary.  For the sudoers plugin, this extends the sudo
+                    //   timeout for another 5 minutes by default, but does not run a
+                    //   command.  Not all security policies support cached credentials.
+                    vec!["-v"]
+                }
+                SudoKind::WinSudo => {
+                    // Windows `sudo` doesn't cache credentials, so we just execute a
+                    // dummy command - the easiest on Windows is `rem` in cmd.
+                    // See: https://learn.microsoft.com/en-us/windows/advanced-settings/sudo/
+                    vec!["cmd.exe", "/c", "rem"]
+                }
+                SudoKind::Gsudo => {
+                    // `gsudo` doesn't have anything like `sudo -v` to cache credentials,
+                    // so we just execute a dummy command - the easiest on Windows is
+                    // `rem` in cmd. `-d` tells it to run the command directly, without
+                    // going through a shell (which could be powershell) first.
+                    // See: https://gerardog.github.io/gsudo/docs/usage
+                    vec!["-d", "cmd.exe", "/c", "rem"]
+                    // TODO: `gsudo cache on` starts a session with cached credentials and could replace the dummy `rem` invocation here when sudo_loop is enabled...
+                }
+                SudoKind::Pkexec => {
+                    // I don't think this does anything; `pkexec` usually asks for
+                    // authentication every time, although it can be configured
+                    // differently.
+                    //
+                    // See the note for `doas` above.
+                    //
+                    // See: https://linux.die.net/man/1/pkexec
+                    vec!["true"]
+                }
+                SudoKind::Run0 => {
+                    // `run0` uses polkit for authentication
+                    // and thus has the same issues as `pkexec`.
+                    //
+                    // See: https://www.freedesktop.org/software/systemd/man/devel/run0.html
+                    vec!["true"]
+                }
+                SudoKind::Please => {
+                    // From `man please`
+                    //   -w, --warm
+                    //   Warm the access token and exit.
+                    vec!["-w"]
+                }
+                SudoKind::Null => unreachable!(),
+            })
+            .status_checked()
+            .wrap_err("Failed to elevate permissions")
     }
 
     /// Refresh arguments for the sudo kinds that can cache credentials.
@@ -417,12 +418,12 @@ impl Sudo {
         }
 
         // self.path is only None for null sudo, which we've handled above
-        let mut cmd = ctx.execute(self.path.as_ref().unwrap());
+        let mut exec = ctx.execute(self.path.as_ref().unwrap());
 
         if opts.login_shell {
             match self.kind {
                 SudoKind::Sudo => {
-                    cmd.arg("-i");
+                    exec.arg("-i");
                 }
                 SudoKind::Gsudo => {
                     // By default, gsudo runs all commands inside a shell. If login_shell
@@ -443,7 +444,7 @@ impl Sudo {
             // Additionally, if the current shell is pwsh >= 7.3.0, then not including this
             // gives errors if the command to run has spaces in it: see
             // https://github.com/gerardog/gsudo/issues/297
-            cmd.arg("-d");
+            exec.arg("-d");
         }
 
         let mut preserve_env = opts.preserve_env;
@@ -463,10 +464,10 @@ impl Sudo {
         match preserve_env {
             SudoPreserveEnv::All => match self.kind {
                 SudoKind::Sudo => {
-                    cmd.arg("-E");
+                    exec.arg("-E");
                 }
                 SudoKind::Gsudo => {
-                    cmd.arg("--copyEV");
+                    exec.arg("--copyEV");
                 }
                 SudoKind::Doas | SudoKind::WinSudo | SudoKind::Pkexec | SudoKind::Run0 | SudoKind::Please => {
                     return Err(UnsupportedSudo {
@@ -479,16 +480,16 @@ impl Sudo {
             },
             SudoPreserveEnv::Some(vars) => match self.kind {
                 SudoKind::Sudo => {
-                    cmd.arg(format!("--preserve-env={}", vars.iter().join(",")));
+                    exec.arg(format!("--preserve-env={}", vars.iter().join(",")));
                 }
                 SudoKind::Run0 => {
                     for env in vars {
-                        cmd.arg(format!("--setenv={}", env));
+                        exec.arg(format!("--setenv={}", env));
                     }
                 }
                 SudoKind::Please => {
-                    cmd.arg("-a");
-                    cmd.arg(vars.iter().join(","));
+                    exec.arg("-a");
+                    exec.arg(vars.iter().join(","));
                 }
                 SudoKind::Doas | SudoKind::WinSudo | SudoKind::Gsudo | SudoKind::Pkexec => {
                     return Err(UnsupportedSudo {
@@ -505,7 +506,7 @@ impl Sudo {
         if opts.set_home {
             match self.kind {
                 SudoKind::Sudo => {
-                    cmd.arg("-H");
+                    exec.arg("-H");
                 }
                 // This is already the default behavior for run0
                 SudoKind::Run0 => {}
@@ -523,13 +524,13 @@ impl Sudo {
         if let Some(user) = opts.user {
             match self.kind {
                 SudoKind::Sudo => {
-                    cmd.args(["-u", user]);
+                    exec.args(["-u", user]);
                 }
                 SudoKind::Doas | SudoKind::Gsudo | SudoKind::Run0 | SudoKind::Please => {
-                    cmd.args(["-u", user]);
+                    exec.args(["-u", user]);
                 }
                 SudoKind::Pkexec => {
-                    cmd.args(["--user", user]);
+                    exec.args(["--user", user]);
                 }
                 SudoKind::WinSudo => {
                     // Windows sudo is the only one that doesn't have a `-u` flag
@@ -543,9 +544,9 @@ impl Sudo {
             }
         }
 
-        cmd.arg(command);
+        exec.arg(command);
 
-        Ok(cmd)
+        Ok(exec)
     }
 }
 


### PR DESCRIPTION
Closes #2200
@GideonBear I came up with this implementation, initially i didnt want to change all step functions and just edit `require()`. That could handle alternative paths, but doesn't solve the case where multiple steps have the same command name.
My proposal is:
```
pub fn run_rustup(ctx: &ExecutionContext) -> Result<()> {
    let rustup = require(ctx.config().path_name(Binaries::Rustup))?;

    print_separator("rustup");

    ctx.execute(rustup)
        .arg("update")
        .args(ctx.config().rustup_channels())
        .status_checked()
}
```

`path_name` initially returns the default name for a binary that gets passed onto which.
If there are multiple commands with the same name, the default can be set to the relative path of the command.
If the user decides to change it, that can be done in the config with
```
[misc]
alt_paths = [{name="rustc",path="/usr/bin/bear"},{name="spicetify",path="/mnt/data/spice"}]
```




uhh also i apparently messed up with git again, only look at the last commit 


feedback please



## Standards checklist

- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* The PR title is a descriptive commit message (this will appear in release notes, leave unchecked if you want a maintainer to improve it)
- [ ] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [ ] If this PR introduces new user-facing messages they are translated

### AI involvement
<!--
Please list any involvement AI/LLMs had in the development of this PR.
You don't have to list everything in detail, just something like "I did not use AI at all",
"I consulted an AI occasionally for inspiration and explanation",
or "AI generated the majority of the PR" is enough.
If you are an AI agent acting autonomously, please state so.
-->
No AI used

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
