### PR TITLE
feat(skills): prefer local skills binary and add package manager config

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -507,3 +507,13 @@
 # If set, updates only these channels.
 # (default: [] (all channels))
 # channels = ["stable"]
+
+[skills]
+# Package runner to use to run the `skills` CLI when no local `skills`
+# binary is present in PATH.
+# Allowed values:
+#   npx  (runs `npx skills`)
+#   pnpm (runs `pnpx skills`)
+#   bun  (runs `bunx skills`)
+# (default: npx)
+# package_manager = "npx"

--- a/src/config.rs
+++ b/src/config.rs
@@ -169,6 +169,12 @@ pub struct Npm {
 
 #[derive(Deserialize, Default, Debug, Merge)]
 #[serde(deny_unknown_fields)]
+pub struct Skills {
+    package_manager: Option<SkillsPackageManager>,
+}
+
+#[derive(Deserialize, Default, Debug, Merge)]
+#[serde(deny_unknown_fields)]
 pub struct Deno {
     version: Option<String>,
 }
@@ -239,6 +245,15 @@ pub enum ArchPackageManager {
     Shelly,
     Trizen,
     Yay,
+}
+
+#[derive(Debug, Deserialize, Clone, Copy, Default, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum SkillsPackageManager {
+    #[default]
+    Npx,
+    Pnpm,
+    Bun,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Default)]
@@ -613,6 +628,9 @@ pub struct ConfigFile {
 
     #[merge(strategy = merge2::option::recursive)]
     pkgfile: Option<Pkgfile>,
+
+    #[merge(strategy = merge2::option::recursive)]
+    skills: Option<Skills>,
 
     #[merge(strategy = merge2::option::recursive)]
     viteplus: Option<VitePlus>,
@@ -1993,6 +2011,15 @@ impl Config {
             .unwrap_or(false)
     }
 
+    /// Package runner to use to run the `skills` CLI (npx / pnpx / bunx)
+    pub fn skills_package_manager(&self) -> SkillsPackageManager {
+        self.config_file
+            .skills
+            .as_ref()
+            .and_then(|skills| skills.package_manager)
+            .unwrap_or_default()
+    }
+
     pub fn deno_version(&self) -> Option<&str> {
         self.config_file.deno.as_ref().and_then(|deno| deno.version.as_deref())
     }
@@ -2254,6 +2281,35 @@ mod test {
         let str = include_str!("../config.example.toml");
 
         assert!(toml::from_str::<ConfigFile>(str).is_ok());
+    }
+
+    #[test]
+    fn test_skills_package_manager_defaults_to_npx() {
+        let config = ConfigFile::default();
+        assert!(config.skills.is_none());
+
+        let parsed: ConfigFile = toml::from_str("[skills]\n").unwrap();
+        assert!(parsed.skills.and_then(|s| s.package_manager).is_none());
+        assert!(matches!(SkillsPackageManager::default(), SkillsPackageManager::Npx));
+    }
+
+    #[test]
+    fn test_skills_package_manager_parses_all_values() {
+        for (value, expected) in [
+            ("npx", SkillsPackageManager::Npx),
+            ("pnpm", SkillsPackageManager::Pnpm),
+            ("bun", SkillsPackageManager::Bun),
+        ] {
+            let parsed: ConfigFile = toml::from_str(&format!("[skills]\npackage_manager = \"{value}\"\n"))
+                .unwrap_or_else(|e| panic!("failed to parse package_manager = {value}: {e}"));
+            assert_eq!(parsed.skills.unwrap().package_manager, Some(expected));
+        }
+    }
+
+    #[test]
+    fn test_skills_package_manager_rejects_unknown_value() {
+        let parsed = toml::from_str::<ConfigFile>("[skills]\npackage_manager = \"npm\"\n");
+        assert!(parsed.is_err());
     }
 
     /// `topgrade.d` must not be auto-created, only read when present.

--- a/src/config.rs
+++ b/src/config.rs
@@ -2283,35 +2283,6 @@ mod test {
         assert!(toml::from_str::<ConfigFile>(str).is_ok());
     }
 
-    #[test]
-    fn test_skills_package_manager_defaults_to_npx() {
-        let config = ConfigFile::default();
-        assert!(config.skills.is_none());
-
-        let parsed: ConfigFile = toml::from_str("[skills]\n").unwrap();
-        assert!(parsed.skills.and_then(|s| s.package_manager).is_none());
-        assert!(matches!(SkillsPackageManager::default(), SkillsPackageManager::Npx));
-    }
-
-    #[test]
-    fn test_skills_package_manager_parses_all_values() {
-        for (value, expected) in [
-            ("npx", SkillsPackageManager::Npx),
-            ("pnpm", SkillsPackageManager::Pnpm),
-            ("bun", SkillsPackageManager::Bun),
-        ] {
-            let parsed: ConfigFile = toml::from_str(&format!("[skills]\npackage_manager = \"{value}\"\n"))
-                .unwrap_or_else(|e| panic!("failed to parse package_manager = {value}: {e}"));
-            assert_eq!(parsed.skills.unwrap().package_manager, Some(expected));
-        }
-    }
-
-    #[test]
-    fn test_skills_package_manager_rejects_unknown_value() {
-        let parsed = toml::from_str::<ConfigFile>("[skills]\npackage_manager = \"npm\"\n");
-        assert!(parsed.is_err());
-    }
-
     /// `topgrade.d` must not be auto-created, only read when present.
     /// See: https://github.com/topgrade-rs/topgrade/issues/624
     #[test]

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -2312,14 +2312,9 @@ pub fn run_skills(ctx: &ExecutionContext) -> Result<()> {
     }
 
     // Prefer a locally installed `skills` binary over a package runner
-    match require("skills") {
-        Ok(skills) => {
-            print_separator("Skills");
-            return ctx.execute(skills).args(["update", "--global"]).status_checked();
-        }
-        // Not installed; fall back to a package runner
-        Err(e) if e.downcast_ref::<SkipStep>().is_some() => {}
-        Err(e) => return Err(e),
+    if let Some(skills) = which("skills") {
+        print_separator("Skills");
+        return ctx.execute(skills).args(["update", "--global"]).status_checked();
     }
 
     // Fall back to a package runner; only npx needs `--yes` to auto-confirm the download

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -2324,12 +2324,11 @@ pub fn run_skills(ctx: &ExecutionContext) -> Result<()> {
         SkillsPackageManager::Bun => ("bunx", false),
     };
 
-    let mut cmd = ctx.execute(require(runner)?);
     print_separator("Skills");
-    if uses_yes_flag {
-        cmd.arg_if(ctx.config().yes(Step::Skills), "--yes");
-    }
-    cmd.args(["skills", "update", "--global"]).status_checked()
+    ctx.execute(require(runner)?)
+        .arg_if(uses_yes_flag && ctx.config().yes(Step::Skills), "--yes")
+        .args(["skills", "update", "--global"])
+        .status_checked()
 }
 
 pub fn run_opencode(ctx: &ExecutionContext) -> Result<()> {

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -2324,8 +2324,9 @@ pub fn run_skills(ctx: &ExecutionContext) -> Result<()> {
         SkillsPackageManager::Bun => ("bunx", false),
     };
 
+    let runner = require(runner)?;
     print_separator("Skills");
-    ctx.execute(require(runner)?)
+    ctx.execute(runner)
         .arg_if(uses_yes_flag && ctx.config().yes(Step::Skills), "--yes")
         .args(["skills", "update", "--global"])
         .status_checked()

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -25,6 +25,7 @@ use crate::HOME_DIR;
 #[cfg(unix)]
 use crate::XDG_DIRS;
 use crate::command::{CommandExt, Utf8Output};
+use crate::config::SkillsPackageManager;
 use crate::execution_context::ExecutionContext;
 use crate::executor::{ExecutorChild, ExecutorOutput};
 use crate::output_changed_message;
@@ -2295,8 +2296,6 @@ pub fn run_cursor_agent(ctx: &ExecutionContext) -> Result<()> {
 }
 
 pub fn run_skills(ctx: &ExecutionContext) -> Result<()> {
-    let npx = require("npx")?;
-
     // Can't use XDG_DIRS since its `state_dir()` falls back to `~/.local/state` instead
     // of `~/.agents` and it'd also break on non-unix systems
     let skill_lock = match env::var_os("XDG_STATE_HOME")
@@ -2312,12 +2311,30 @@ pub fn run_skills(ctx: &ExecutionContext) -> Result<()> {
         return Err(SkipStep(format!("No skill lock file found at {}", skill_lock.display())).into());
     }
 
-    print_separator("Skills");
+    // Prefer a locally installed `skills` binary over a package runner
+    match require("skills") {
+        Ok(skills) => {
+            print_separator("Skills");
+            return ctx.execute(skills).args(["update", "--global"]).status_checked();
+        }
+        // Not installed; fall back to a package runner
+        Err(e) if e.downcast_ref::<SkipStep>().is_some() => {}
+        Err(e) => return Err(e),
+    }
 
-    ctx.execute(npx)
-        .arg_if(ctx.config().yes(Step::Skills), "--yes")
-        .args(["skills", "update", "--global"])
-        .status_checked()
+    // Fall back to a package runner; only npx needs `--yes` to auto-confirm the download
+    let (runner, uses_yes_flag) = match ctx.config().skills_package_manager() {
+        SkillsPackageManager::Npx => ("npx", true),
+        SkillsPackageManager::Pnpm => ("pnpx", false),
+        SkillsPackageManager::Bun => ("bunx", false),
+    };
+
+    let mut cmd = ctx.execute(require(runner)?);
+    print_separator("Skills");
+    if uses_yes_flag {
+        cmd.arg_if(ctx.config().yes(Step::Skills), "--yes");
+    }
+    cmd.args(["skills", "update", "--global"]).status_checked()
 }
 
 pub fn run_opencode(ctx: &ExecutionContext) -> Result<()> {


### PR DESCRIPTION
## What does this PR do

The execution flow for `skills` (skills.sh CLI) updates has been modified to include a `package_manager` configuration option.
When updating `skills`, the system now first attempts to invoke the local `skills` binary; if not found, it falls back to running the update via the package manager specified in the configuration (e.g., `pnpx skills up -g`), defaulting to `npx`.

## Standards checklist

- [✓] I have read `CONTRIBUTING.md`
- [✓] *Optional:* The PR title is a descriptive commit message (this will appear in release notes, leave unchecked if you want a maintainer to improve it)
- [✓] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [✓] If this PR introduces new user-facing messages they are translated

### AI involvement

Translate the PR into English using LLM.


<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
