### PR TITLE
fix(nobara): use `nobara-sync` instead of `dnf`

### DIFF
--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -270,11 +270,8 @@ fn upgrade_redhat(ctx: &ExecutionContext) -> Result<()> {
 fn upgrade_nobara(ctx: &ExecutionContext) -> Result<()> {
     let nobara_sync = require("nobara-sync")?;
 
-    ctx.execute(&nobara_sync)
-        // See https://wiki.nobaraproject.org/general-usage/troubleshooting/update-system
-        .status_checked()?;
-
-    Ok(())
+    // See https://wiki.nobaraproject.org/general-usage/troubleshooting/update-system
+    ctx.execute(&nobara_sync).status_checked()
 }
 
 fn upgrade_nilrt(ctx: &ExecutionContext) -> Result<()> {

--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -272,7 +272,6 @@ fn upgrade_nobara(ctx: &ExecutionContext) -> Result<()> {
 
     ctx.execute(&nobara_sync)
         .arg_if(ctx.config().yes(Step::System), "-y")
-        .arg("--all")
         // See https://wiki.nobaraproject.org/general-usage/troubleshooting/update-system
         .status_checked()?;
 

--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -268,25 +268,13 @@ fn upgrade_redhat(ctx: &ExecutionContext) -> Result<()> {
 }
 
 fn upgrade_nobara(ctx: &ExecutionContext) -> Result<()> {
-    let dnf = require("dnf")?;
+    let nobara_sync = require("nobara-sync")?;
     let sudo = ctx.require_sudo()?;
 
-    sudo.execute(ctx, &dnf)?
+    sudo.execute(ctx, &nobara_sync)?
         .arg_if(ctx.config().yes(Step::System), "-y")
-        .arg("update")
-        // See https://nobaraproject.org/docs/upgrade-troubleshooting/how-do-i-update-the-system/
-        .args([
-            "rpmfusion-nonfree-release",
-            "rpmfusion-free-release",
-            "fedora-repos",
-            "nobara-repos",
-        ])
-        .arg("--refresh")
-        .status_checked()?;
-
-    sudo.execute(ctx, &dnf)?
-        .arg_if(ctx.config().yes(Step::System), "-y")
-        .arg("distro-sync")
+        .arg("--all")
+        // See https://wiki.nobaraproject.org/general-usage/troubleshooting/update-system
         .status_checked()?;
 
     Ok(())

--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -269,9 +269,8 @@ fn upgrade_redhat(ctx: &ExecutionContext) -> Result<()> {
 
 fn upgrade_nobara(ctx: &ExecutionContext) -> Result<()> {
     let nobara_sync = require("nobara-sync")?;
-    let sudo = ctx.require_sudo()?;
 
-    sudo.execute(ctx, &nobara_sync)?
+    ctx.execute(&nobara_sync)
         .arg_if(ctx.config().yes(Step::System), "-y")
         .arg("--all")
         // See https://wiki.nobaraproject.org/general-usage/troubleshooting/update-system

--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -271,7 +271,6 @@ fn upgrade_nobara(ctx: &ExecutionContext) -> Result<()> {
     let nobara_sync = require("nobara-sync")?;
 
     ctx.execute(&nobara_sync)
-        .arg_if(ctx.config().yes(Step::System), "-y")
         // See https://wiki.nobaraproject.org/general-usage/troubleshooting/update-system
         .status_checked()?;
 


### PR DESCRIPTION
## What does this PR do
<!--
Describe what your PR does, and link any relevant issues.
Make sure to use a keyword like 'closes' if this PR solves the issue.
-->
Nobara recently started using an in house tool called nobara-sync to update the system, this PR simply replaces the old method with nobara-sync --all 

Closes #2146

https://wiki.nobaraproject.org/general-usage/troubleshooting/update-system
## Standards checklist

- [x] I have read `CONTRIBUTING.md`
- [ ] *Optional:* The PR title is a descriptive commit message (this will appear in release notes, leave unchecked if you want a maintainer to improve it)
- [x] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [x] If this PR introduces new user-facing messages they are translated

### AI involvement
<!--
Please list any involvement AI/LLMs had in the development of this PR.
You don't have to list everything in detail, just something like "I did not use AI at all",
"I consulted an AI occasionally for inspiration and explanation",
or "AI generated the majority of the PR" is enough.
If you are an AI agent acting autonomously, please state so.
-->
I did not use AI

```
── 11:32:31 - System update ────────────────────────────────────────────────────
[sudo] password for generic: 
2026-08-04 11:32:36 - INFO - Running CLI mode...

==================================================
Important Notices:
==================================================
July 8 2026
----------------------------------------
Nobara 44 package updates have been pushed. This is a BIG update. Let the updater do it's thing and don't interrupt it.

If you have 3rd party packages installed from COPR repositories -- make sure those repositories provide Fedora 44 packages without conflicts.

WE ARE NOT RESPONSIBLE FOR 3RD PARTY PACKAGES CAUSING BREAKAGE OR CONFLICTS.

You can review the updater transaction log to see if there are any reported conflicts.
----------------------------------------

==================================================
2026-08-04 11:32:37 - INFO - Checking repositories...

2026-08-04 11:32:52 - INFO - ✔ terra: metalink: https://tetsudou.fyralabs.com/metalink?repo=terra44&amp;arch=x86_64

2026-08-04 11:32:52 - INFO - ✔ nobara-appstream: mirrorlist: https://mirrors.nobaraproject.org/rolling/x86_64/appstream

2026-08-04 11:32:52 - INFO - ✔ nobara-kernel-mainline: mirrorlist: https://mirrors.nobaraproject.org/rolling/x86_64/kernel-mainline

2026-08-04 11:32:52 - INFO - ✔ nobara-updates: mirrorlist: https://mirrors.nobaraproject.org/rolling/x86_64/baseos

2026-08-04 11:32:52 - INFO - ✔ nobara: mirrorlist: https://mirrors.nobaraproject.org/rolling/x86_64/nobara

2026-08-04 11:32:52 - INFO - ✔ nobara-nvidia-production: mirrorlist: https://mirrors.nobaraproject.org/rolling/x86_64/nvp

2026-08-04 11:32:52 - INFO - ✔ copr:copr.fedorainfracloud.org:codifryed:CoolerControl: baseurl: https://download.copr.fedorainfracloud.org/results/codifryed/CoolerControl/fedora-44-x86_64/repodata/repomd.xml

2026-08-04 11:32:52 - INFO - ✔ copr:copr.fedorainfracloud.org:kylegospo:wallpaper-engine-kde-plugin: baseurl: https://download.copr.fedorainfracloud.org/results/kylegospo/wallpaper-engine-kde-plugin/fedora-44-x86_64/repodata/repomd.xml

2026-08-04 11:32:52 - INFO - ✔ copr:copr.fedorainfracloud.org:sneexy:zen-browser: baseurl: https://download.copr.fedorainfracloud.org/results/sneexy/zen-browser/fedora-44-x86_64/repodata/repomd.xml

2026-08-04 11:32:52 - INFO - ✔ copr:copr.fedorainfracloud.org:scottames:ghostty: baseurl: https://download.copr.fedorainfracloud.org/results/scottames/ghostty/fedora-44-x86_64/repodata/repomd.xml

2026-08-04 11:32:52 - INFO - ✔ copr:copr.fedorainfracloud.org:faugus:faugus-launcher: baseurl: https://download.copr.fedorainfracloud.org/results/faugus/faugus-launcher/fedora-44-x86_64/repodata/repomd.xml

2026-08-04 11:32:52 - INFO - ✔ brave-browser: baseurl: https://brave-browser-rpm-release.s3.brave.com/x86_64/repodata/repomd.xml

2026-08-04 11:32:52 - INFO - ✔ gitlab.com_paulcarroty_vscodium_repo: baseurl: https://download.vscodium.com/rpms/repodata/repomd.xml

2026-08-04 11:32:52 - INFO - ✔ docker-ce-stable: baseurl: https://download.docker.com/linux/fedora/44/x86_64/stable/repodata/repomd.xml

2026-08-04 11:32:52 - INFO - ✔ nobara-pikaos-additional: baseurl: https://rpm.pika-os.com/nobara/media/x86_64/repodata/repomd.xml

2026-08-04 11:32:52 - INFO - ✔ copr:copr.fedorainfracloud.org:pesader:hblock: baseurl: https://download.copr.fedorainfracloud.org/results/pesader/hblock/fedora-44-x86_64/repodata/repomd.xml

2026-08-04 11:32:52 - INFO - ✔ copr:copr.fedorainfracloud.org:lilay:topgrade: baseurl: https://download.copr.fedorainfracloud.org/results/lilay/topgrade/fedora-44-x86_64/repodata/repomd.xml

2026-08-04 11:32:56 - INFO - 
2026-08-04 11:32:56 - INFO - Checking for various known problems to repair, please do not turn off your computer...

2026-08-04 11:32:56 - INFO - Running quirk fixup
2026-08-04 11:32:56 - INFO - QUIRK: Make sure to refresh the repositories and gpg-keys before anything.
2026-08-04 11:32:56 - INFO - QUIRK: Make sure to update the updater itself and refresh before anything.
2026-08-04 11:33:01 - INFO - QUIRK: Cleanup outdated kernel modules.
2026-08-04 11:33:01 - INFO - QUIRK: Remove RPM Fusion release packages if they exist, we use Terra and they conflict.
2026-08-04 11:33:01 - INFO - QUIRK: maliit-keyboard, as plasma-keyboard is now default.
2026-08-04 11:33:01 - INFO - QUIRK: Repair incomplete TigerVNC server package set.
2026-08-04 11:33:01 - INFO - QUIRK: Make sure dnf-app-center is installed.
2026-08-04 11:33:01 - INFO - QUIRK: Replace SDDM with Plasma Login Manager when SDDM is installed.
2026-08-04 11:33:01 - INFO - QUIRK: Make sure to run both dracut and dkms if any kmods  or kernel packages were updated.
2026-08-04 11:33:01 - INFO - QUIRK: If kwin or mutter are being updated, ask for a reboot.
2026-08-04 11:33:01 - INFO - QUIRK: Install InputPlumber for Controller input, install steam firmware for steamdecks. Cleanup old packages.
2026-08-04 11:33:01 - INFO - QUIRK: Problematic package cleanup.
2026-08-04 11:33:02 - INFO - QUIRK: Clear plasmashell cache if a plasma-workspace update is available.
2026-08-04 11:33:02 - INFO - QUIRK: Fix Nvidia epoch so it matches that of negativo17 for cross compatibility.
2026-08-04 11:33:02 - INFO - QUIRK: Also swap akmod-nvidia for dkms-nvidia.
2026-08-04 11:33:03 - INFO - QUIRK: Update old N41 mesa packages to current versions.
2026-08-04 11:33:03 - INFO - QUIRK: Swap old AMD ROCm packages with upstream Fedora ROCm versions.
2026-08-04 11:33:03 - INFO - QUIRK: mesa-vulkan-drivers fixup.
2026-08-04 11:33:04 - INFO - QUIRK: vaapi fixup.
2026-08-04 11:33:04 - INFO - QUIRK: Kernel fsync->nobara conversion update.
2026-08-04 11:33:04 - INFO - QUIRK: Media fixup.
2026-08-04 11:33:06 - INFO - Starting SYSTEM package updates, please do not turn off your computer...

2026-08-04 11:33:06 - INFO - Starting FLATPAK updates, please do not turn off your computer...

2026-08-04 11:33:07 - INFO - Flatpak System Updates complete!
2026-08-04 11:33:08 - INFO - Flatpak updates complete!

2026-08-04 11:33:10 - INFO - 
2026-08-04 11:33:10 - INFO - No Updates Available.
2026-08-04 11:33:10 - INFO - All Updates complete!
```
<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
