### PR TITLE
feat(powershell): clean up old module versions

### DIFF
--- a/locales/app.yml
+++ b/locales/app.yml
@@ -136,6 +136,14 @@ _version: 2
   zh_CN: "正在更新模块..."
   zh_TW: "正在更新模組..."
   de: "Module werden aktualisiert..."
+"Cleaning up old PowerShell module versions...":
+  en: "Cleaning up old PowerShell module versions..."
+  lt: "Valomos senos „PowerShell“ modulių versijos..."
+  es: "Limpiando versiones antiguas de módulos de PowerShell..."
+  fr: "Nettoyage des anciennes versions des modules PowerShell..."
+  zh_CN: "正在清理旧版 PowerShell 模块..."
+  zh_TW: "正在清理舊版 PowerShell 模組..."
+  de: "Alte PowerShell-Modulversionen werden bereinigt..."
 "PowerShell Modules Update":
   en: "PowerShell Modules Update"
   lt: "PowerShell modulių atnaujinimas"

--- a/src/steps/cleanup_powershell_modules.ps1
+++ b/src/steps/cleanup_powershell_modules.ps1
@@ -1,0 +1,24 @@
+$ErrorActionPreference = 'Stop'
+
+if (
+    (Get-Command Get-InstalledPSResource -ErrorAction SilentlyContinue) -and
+    (Get-Command Uninstall-PSResource -ErrorAction SilentlyContinue)
+) {
+    Get-InstalledPSResource -Version '*' |
+        Where-Object Type -eq 'Module' |
+        Group-Object Name |
+        ForEach-Object {
+            $_.Group |
+                Sort-Object Version -Descending |
+                Select-Object -Skip 1 |
+                Uninstall-PSResource -Confirm:$false
+        }
+    return
+}
+
+Get-InstalledModule | ForEach-Object {
+    Get-InstalledModule -Name $_.Name -AllVersions |
+        Sort-Object Version -Descending |
+        Select-Object -Skip 1 |
+        Uninstall-Module -Confirm:$false
+}

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -1601,6 +1601,8 @@ pub fn run_dotnet_upgrade(ctx: &ExecutionContext) -> Result<()> {
     Ok(())
 }
 
+const POWERSHELL_CLEANUP_MODULES_COMMAND: &str = include_str!("cleanup_powershell_modules.ps1");
+
 pub fn run_powershell(ctx: &ExecutionContext) -> Result<()> {
     let powershell = ctx.require_powershell()?;
 
@@ -1623,7 +1625,17 @@ pub fn run_powershell(ctx: &ExecutionContext) -> Result<()> {
 
     println!("{}", t!("Updating modules..."));
 
-    powershell.build_command(ctx, &cmd, use_sudo)?.status_checked()
+    powershell.build_command(ctx, &cmd, use_sudo)?.status_checked()?;
+
+    if !ctx.config().cleanup() {
+        return Ok(());
+    }
+
+    println!("{}", t!("Cleaning up old PowerShell module versions..."));
+
+    powershell
+        .build_command(ctx, POWERSHELL_CLEANUP_MODULES_COMMAND, use_sudo)?
+        .status_checked()
 }
 
 fn powershell_update_modules_command(assume_yes: bool) -> String {
@@ -1645,7 +1657,10 @@ fn powershell_update_modules_command(assume_yes: bool) -> String {
 
 #[cfg(test)]
 mod powershell_tests {
-    use super::powershell_update_modules_command;
+    use std::process::Command;
+
+    use super::{POWERSHELL_CLEANUP_MODULES_COMMAND, powershell_update_modules_command};
+    use crate::utils::which;
 
     #[test]
     fn assume_yes_suppresses_confirmation_without_force() {
@@ -1659,6 +1674,171 @@ mod powershell_tests {
         assert!(!cmd.contains("-Force"));
         assert!(!cmd.contains("exit 0"));
         assert!(!cmd.contains("topgradeUpdateModule"));
+    }
+
+    #[test]
+    fn cleanup_prefers_psresourceget_for_outdated_modules() {
+        let Some(powershell) = which("pwsh").or_else(|| which("powershell")) else {
+            return;
+        };
+
+        let fixture = String::from(
+            r#"
+function Get-InstalledPSResource {
+    param([string] $Version)
+
+    if ($Version -ne '*') {
+        throw 'Cleanup did not request every installed PSResource version'
+    }
+
+    1, 3, 2 | ForEach-Object {
+        [pscustomobject] @{
+            Name = 'Demo'
+            Version = [version] "$($_).0"
+            Type = 'Module'
+        }
+    }
+
+    1, 2 | ForEach-Object {
+        [pscustomobject] @{
+            Name = 'DemoScript'
+            Version = [version] "$($_).0"
+            Type = 'Script'
+        }
+    }
+}
+
+function Uninstall-PSResource {
+    param(
+        [Parameter(ValueFromPipeline)] $InputObject,
+        [switch] $Confirm,
+        [switch] $SkipDependencyCheck
+    )
+
+    process {
+        if (-not $PSBoundParameters.ContainsKey('Confirm') -or $Confirm) {
+            throw 'Cleanup did not suppress PSResourceGet confirmation'
+        }
+
+        if ($SkipDependencyCheck) {
+            throw 'Cleanup bypassed PSResourceGet dependency checks'
+        }
+
+        "PSRESOURCE:$($InputObject.Name):$($InputObject.Version)"
+    }
+}
+
+function Get-InstalledModule {
+    throw 'Cleanup selected PowerShellGet instead of PSResourceGet'
+}
+
+function Uninstall-Module {
+    throw 'Cleanup selected PowerShellGet instead of PSResourceGet'
+}
+"#,
+        ) + POWERSHELL_CLEANUP_MODULES_COMMAND;
+
+        let output = Command::new(powershell)
+            .args(["-NoProfile", "-Command"])
+            .arg(fixture)
+            .output()
+            .expect("PowerShell cleanup fixture should run");
+
+        assert!(
+            output.status.success(),
+            "PowerShell cleanup fixture failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let uninstalled = stdout
+            .lines()
+            .filter(|line| line.starts_with("PSRESOURCE:"))
+            .collect::<Vec<_>>();
+
+        assert_eq!(uninstalled, ["PSRESOURCE:Demo:2.0", "PSRESOURCE:Demo:1.0"]);
+    }
+
+    #[test]
+    fn cleanup_falls_back_to_powershellget_without_complete_psresourceget_pair() {
+        let Some(powershell) = which("pwsh").or_else(|| which("powershell")) else {
+            return;
+        };
+
+        let fixture = String::from(
+            r#"
+function Get-Command {
+    [CmdletBinding()]
+    param([string] $Name)
+
+    if ($Name -eq 'Get-InstalledPSResource') {
+        return [pscustomobject] @{ Name = $Name }
+    }
+
+    if ($Name -eq 'Uninstall-PSResource') {
+        return
+    }
+
+    throw "Unexpected command discovery: $Name"
+}
+
+function Get-InstalledPSResource {
+    throw 'Cleanup selected an incomplete PSResourceGet provider'
+}
+
+function Get-InstalledModule {
+    param([string[]] $Name, [switch] $AllVersions)
+
+    $versions = if ($AllVersions) { 1, 3, 2 } else { 3 }
+    $versions | ForEach-Object {
+        [pscustomobject] @{
+            Name = 'Demo'
+            Version = [version] "$($_).0"
+        }
+    }
+}
+
+function Uninstall-Module {
+    param(
+        [Parameter(ValueFromPipeline)] $InputObject,
+        [switch] $Confirm,
+        [switch] $Force
+    )
+
+    process {
+        if (-not $PSBoundParameters.ContainsKey('Confirm') -or $Confirm) {
+            throw 'Cleanup did not suppress PowerShellGet confirmation'
+        }
+
+        if ($Force) {
+            throw 'Cleanup bypassed PowerShellGet dependency checks'
+        }
+
+        "POWERSHELLGET:$($InputObject.Name):$($InputObject.Version)"
+    }
+}
+"#,
+        ) + POWERSHELL_CLEANUP_MODULES_COMMAND;
+
+        let output = Command::new(powershell)
+            .args(["-NoProfile", "-Command"])
+            .arg(fixture)
+            .output()
+            .expect("PowerShell cleanup fixture should run");
+
+        assert!(
+            output.status.success(),
+            "PowerShell cleanup fixture failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let uninstalled = stdout
+            .lines()
+            .filter(|line| line.starts_with("POWERSHELLGET:"))
+            .collect::<Vec<_>>();
+
+        assert_eq!(uninstalled, ["POWERSHELLGET:Demo:2.0", "POWERSHELLGET:Demo:1.0"]);
     }
 }
 


### PR DESCRIPTION
## What does this PR do
<!--
Describe what your PR does, and link any relevant issues.
Make sure to use a keyword like 'closes' if this PR solves the issue.
-->

This adds optional cleanup of outdated PowerShell module versions to the existing PowerShell step. Closes #991 

PowerShell cleanup prefers PSResourceGet when both Get-InstalledPSResource and Uninstall-PSResource are available. It considers every installed module version, retains the newest version of each module, and removes older versions without bypassing dependency checks. If the complete PSResourceGet command pair is unavailable, cleanup falls back to PowerShellGet’s Get-InstalledModule and Uninstall-Module, preserving compatibility with Windows PowerShell 5.1. Provider selection is based on command availability rather than the PowerShell version.

The cleanup passes `-Confirm:$false` so it can run non-interactively. It intentionally does not use `-Force`, preserving PowerShellGet's dependency checks and avoiding forced reinstallation behavior.

The change also adds translations for the cleanup status message and a PowerShell behavioral test covering provider selection, semantic version sorting, newest-version retention, and the absence of `-Force`.

Verification performed:

- `cargo fmt --all -- --check`
- PowerShell parser check for `cleanup_powershell_modules.ps1`
- `cargo test --locked` — 33 passed, 0 failed
- `cargo clippy --locked --all-features -- --deny warnings`
- `git diff --check`
- Isolated macOS `pwsh` run with
  `--dry-run --cleanup --only powershell` — `PowerShell Modules Update: OK`

the change was not tested in a native Windows PowerShell environment.

## Standards checklist

- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* The PR title is a descriptive commit message (this will appear in release notes, leave unchecked if you want a maintainer to improve it)
- [ ] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [x] If this PR introduces new user-facing messages they are translated

### AI involvement
<!--
Please list any involvement AI/LLMs had in the development of this PR.
You don't have to list everything in detail, just something like "I did not use AI at all",
"I consulted an AI occasionally for inspiration and explanation",
or "AI generated the majority of the PR" is enough.
If you are an AI agent acting autonomously, please state so.
-->

An AI agent helped develop the implementation and pr. I independently reviewed and edited.

<!-- If you developed a feature or a bug fix for someone else and you do not have the means to test it, please tag this person here. -->

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
