### PR TITLE
feat(generic): add PreCommit step running pre-commit gc

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -2407,6 +2407,14 @@ x = "cmd_x"
     }
 
     #[test]
+    fn test_precommit_in_default_steps() {
+        assert!(
+            crate::step::default_steps().contains(&crate::step::Step::PreCommit),
+            "PreCommit must be registered in default_steps()"
+        );
+    }
+
+    #[test]
     fn test_steps_first_and_last_reorder() {
         let config = config_from_toml(
             r#"

--- a/src/step.rs
+++ b/src/step.rs
@@ -145,6 +145,7 @@ pub enum Step {
     Pnpm,
     Poetry,
     Powershell,
+    PreCommit,
     Protonplus,
     Protonup,
     Pyenv,
@@ -553,6 +554,7 @@ impl Step {
             Pnpm => runner.execute(*self, "pnpm", || node::run_pnpm_upgrade(ctx))?,
             Poetry => runner.execute(*self, "Poetry", || generic::run_poetry(ctx))?,
             Powershell => runner.execute(*self, "PowerShell Modules Update", || generic::run_powershell(ctx))?,
+            PreCommit => runner.execute(*self, "pre-commit", || generic::run_pre_commit(ctx))?,
             Protonplus =>
             {
                 #[cfg(target_os = "linux")]
@@ -941,6 +943,7 @@ pub(crate) fn default_steps() -> Vec<Step> {
         Lensfun,
         Poetry,
         Uv,
+        PreCommit,
         Zvm,
         Aqua,
         Bun,

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -2227,6 +2227,18 @@ pub fn run_bun(ctx: &ExecutionContext) -> Result<()> {
     }
 }
 
+/// Run `pre-commit gc` to clean up unused hook repos / reflogs.
+/// Skips entirely (including the separator) when the global `cleanup` flag is off (issue #2167).
+pub fn run_pre_commit(ctx: &ExecutionContext) -> Result<()> {
+    if !ctx.config().cleanup() {
+        return Err(SkipStep("Cleanup disabled, skipping pre-commit gc".to_string()).into());
+    }
+
+    let pre_commit = require("pre-commit")?;
+    print_separator("pre-commit");
+    ctx.execute(&pre_commit).arg("gc").status_checked()
+}
+
 pub fn run_zigup(ctx: &ExecutionContext) -> Result<()> {
     let zigup = require("zigup")?;
     let config = ctx.config();


### PR DESCRIPTION
Closes #2167.

> **AI-involvement disclosure (per topgrade's PR template):** the code in this PR was written by an AI agent (GLM-5.2) under an automated contribution workflow, then reviewed, tested, and accepted by a human — the PR author. This PR body is human-written. No `Co-Authored-By` trailer is added because there is no human co-author of the code; the AI's involvement is disclosed here truthfully rather than hidden.

## What

Adds a new `pre_commit` step that runs `pre-commit gc` to clean up unused hook repos / reflogs — requested in #2167 (labeled `needs PR`).

## How

- New `Step::PreCommit` variant, registered in `default_steps()`, with a match arm wiring it to `generic::run_pre_commit`.
- `run_pre_commit` runs `pre-commit gc` but **skips entirely** (including the separator) when the global `cleanup` flag is off — matching the gating on the other cleanup steps. If `pre-commit` isn't installed, `require()` skips the step as usual, so users without `pre-commit` are unaffected.

## Test

`test_precommit_in_default_steps` guards that `PreCommit` stays registered in `default_steps()`. `cargo fmt --check`, `cargo clippy --all-features -D warnings`, and `cargo test --locked` are all green (32 passed).
