### PR TITLE
feat(step): add Hermes Agent

### DIFF
--- a/src/step.rs
+++ b/src/step.rs
@@ -391,12 +391,12 @@ impl Step {
             Helix => runner.execute(*self, "helix", || generic::run_helix_grammars(ctx))?,
             HelixDb => runner.execute(*self, "HelixDB", || generic::run_helix_db(ctx))?,
             Helm => runner.execute(*self, "helm", || generic::run_helm_repo_update(ctx))?,
+            HermesAgent => runner.execute(*self, "Hermes Agent", || generic::run_hermes_agent(ctx))?,
             HomeManager =>
             {
                 #[cfg(unix)]
                 runner.execute(*self, "home-manager", || unix::run_home_manager(ctx))?
             }
-            HermesAgent => runner.execute(*self, "Hermes Agent", || generic::run_hermes_agent(ctx))?,
             Hyprpm =>
             {
                 #[cfg(unix)]

--- a/src/step.rs
+++ b/src/step.rs
@@ -82,6 +82,7 @@ pub enum Step {
     Helix,
     HelixDb,
     Helm,
+    HermesAgent,
     HomeManager,
     Hyprpm,
     InstallRelease,
@@ -395,6 +396,7 @@ impl Step {
                 #[cfg(unix)]
                 runner.execute(*self, "home-manager", || unix::run_home_manager(ctx))?
             }
+            HermesAgent => runner.execute(*self, "Hermes Agent", || generic::run_hermes_agent(ctx))?,
             Hyprpm =>
             {
                 #[cfg(unix)]
@@ -975,6 +977,7 @@ pub(crate) fn default_steps() -> Vec<Step> {
         Typst,
         InstallRelease,
         Vagrant,
+        HermesAgent,
         // Steps that should run last
         // Last out of convention
         CustomCommands,

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -2862,3 +2862,11 @@ fn refresh_mise_env(ctx: &ExecutionContext, mise: &Path, neutral_cwd: &Path) -> 
     debug!("Refreshed process environment from mise");
     Ok(())
 }
+
+pub fn run_hermes_agent(ctx: &ExecutionContext) -> Result<()> {
+    let hermes = require("hermes")?;
+
+    print_separator("Hermes Agent");
+
+    ctx.execute(hermes).arg("update").arg("--yes").status_checked()
+}

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -2868,5 +2868,5 @@ pub fn run_hermes_agent(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("Hermes Agent");
 
-    ctx.execute(hermes).arg("update").arg("--yes").status_checked()
+    ctx.execute(hermes).arg("update").status_checked()
 }


### PR DESCRIPTION
## What does this PR do

Add a step for [Hermes Agent](https://github.com/NousResearch/hermes-agent).

## Standards checklist

- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* The PR title is a descriptive commit message (this will appear in release notes, leave unchecked if you want a maintainer to improve it)
- [x] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [ ] If this PR introduces new user-facing messages they are translated

`cargo run -- --only hermes_agent`

```shell
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.20s
     Running `target/debug/topgrade --only hermes_agent`

── 15:14:22 - Hermes Agent ─────────────────────────────────────────────────────
⚕ Updating Hermes Agent...

→ Fetching updates...
✓ Already up to date!

── 15:14:24 - Summary ──────────────────────────────────────────────────────────
Hermes Agent: OK
```

`cargo run -- --only hermes_agent --dry-run`
```shell
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.20s
     Running `target/debug/topgrade --only hermes_agent --dry-run`

── 15:19:43 - Hermes Agent ─────────────────────────────────────────────────────
Dry running: /home/worker/.local/bin/hermes update

── 15:19:43 - Summary ──────────────────────────────────────────────────────────
Hermes Agent: OK
```

`cargo run -- --only hermes_agent --yes`
```shell
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.20s
     Running `target/debug/topgrade --only hermes_agent --yes`

── 15:19:52 - Hermes Agent ─────────────────────────────────────────────────────
⚕ Updating Hermes Agent...

→ Fetching updates...
✓ Already up to date!

── 15:19:53 - Summary ──────────────────────────────────────────────────────────
Hermes Agent: OK
```

### AI involvement
None

## For new steps

<!-- This section can be deleted if you are not adding a new step. -->

- [x] *Optional:* Topgrade skips this step where needed
- [x] *Optional:* The `--yes` option works with this step if it is supported by
  the underlying command

<!-- If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here. -->

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
