### PR TITLE
refactor: replace most short options with equivalent long options

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -13,12 +13,13 @@
 # (default: false)
 # allow_root = false
 
-# Run `sudo -v` to cache credentials at the start of the run
+# Run `sudo --validate` to cache credentials at the start of the run
 # This avoids a blocking password prompt in the middle of an unattended run
 # (default: false)
 # pre_sudo = false
 
-# Periodically runs `sudo -n -v` or `please -w` to avoid password re-prompts during updates (default: false)
+# Periodically runs `sudo --non-interactive --validate` or `please --warm`
+# to avoid password re-prompts during updates (default: false)
 # WARNING: This is a potential security risk; if you walk away from the computer while topgrade is running,
 # another person can come by, CTRL+C, and gain access to a sudo session.
 # sudo_loop = true

--- a/src/steps/containers.rs
+++ b/src/steps/containers.rs
@@ -279,10 +279,10 @@ pub fn run_containers(ctx: &ExecutionContext) -> Result<()> {
         debug!("Removing dangling images");
         if let Some(sudo) = sudo {
             sudo.execute(ctx, &crt)?
-                .args(["image", "prune", "-f"])
+                .args(["image", "prune", "--force"])
                 .status_checked()?
         } else {
-            ctx.execute(&crt).args(["image", "prune", "-f"]).status_checked()?
+            ctx.execute(&crt).args(["image", "prune", "--force"]).status_checked()?
         }
     }
 

--- a/src/steps/emacs.rs
+++ b/src/steps/emacs.rs
@@ -90,7 +90,7 @@ impl Emacs {
         let emacs_upgrade_arg = EMACS_UPGRADE;
 
         ctx.execute(emacs)
-            .args(["--batch", "--debug-init", "-l"])
+            .args(["--batch", "--debug-init", "--load"])
             .arg(init_file)
             .arg("--eval")
             .arg(emacs_upgrade_arg)

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -91,7 +91,7 @@ pub fn run_cargo_update(ctx: &ExecutionContext) -> Result<()> {
             .ok()
             .or_else(|| cargo_dir.join("bin/cargo-cache").if_exists());
         if let Some(e) = cargo_cache {
-            ctx.execute(e).args(["-a"]).status_checked()?;
+            ctx.execute(e).args(["--autoclean"]).status_checked()?;
         } else {
             let message = String::from(
                 "cargo-cache isn't installed so Topgrade can't cleanup cargo packages.\nInstall cargo-cache by running `cargo install cargo-cache`",
@@ -1122,7 +1122,7 @@ pub fn run_conda_update(ctx: &ExecutionContext) -> Result<()> {
 
     for env_name in env_names {
         ctx.execute(&conda)
-            .args(["update", "--all", "-n", env_name])
+            .args(["update", "--all", "--name", env_name])
             .arg_if(ctx.config().yes(Step::Conda), "--yes")
             .status_checked()?;
     }
@@ -1131,7 +1131,7 @@ pub fn run_conda_update(ctx: &ExecutionContext) -> Result<()> {
     if let Some(env_paths) = ctx.config().conda_env_paths() {
         for env_path in env_paths.iter() {
             ctx.execute(&conda)
-                .args(["update", "--all", "-p", env_path])
+                .args(["update", "--all", "--prefix", env_path])
                 .arg_if(ctx.config().yes(Step::Conda), "--yes")
                 .status_checked()?;
         }
@@ -1815,7 +1815,7 @@ pub fn update_julia_packages(ctx: &ExecutionContext) -> Result<()> {
         } else {
             "--startup-file=no"
         })
-        .args(["-e", "using Pkg; Pkg.update()"])
+        .arg("--eval=using Pkg; Pkg.update()")
         .status_checked()
 }
 
@@ -2492,12 +2492,12 @@ pub fn run_typst(ctx: &ExecutionContext) -> Result<()> {
     let raw_info = ctx
         .execute(&typst)
         .always()
-        .args(["info", "-f", "json"])
+        .args(["info", "--format", "json"])
         .output_checked_utf8()?
         .stdout;
     let info: TypstInfo = serde_json::from_str(&raw_info).wrap_err_with(|| {
         output_changed_message!(
-            "typst info -f json",
+            "typst info --format json",
             "json output invalid or does not contain .build.settings.self-update"
         )
     })?;

--- a/src/steps/git.rs
+++ b/src/steps/git.rs
@@ -264,7 +264,7 @@ impl RepoStep {
             .always()
             .stdin(Stdio::null())
             .current_dir(repo.as_ref())
-            .args(["remote", "-v"])
+            .args(["remote", "--verbose"])
             .output_checked_utf8();
 
         res.map(|output| {

--- a/src/steps/node.rs
+++ b/src/steps/node.rs
@@ -61,9 +61,13 @@ impl Npm {
     /// of this NPM instance.
     ///
     /// If the "NPM" version is larger than 8.11.0, we use
-    /// `--location=global`; otherwise, use `-g`.
+    /// `--location=global`; otherwise, use `--global`.
     fn global_location_arg(&self, ctx: &ExecutionContext) -> &str {
-        if self.is_npm_8(ctx) { "--location=global" } else { "-g" }
+        if self.is_npm_8(ctx) {
+            "--location=global"
+        } else {
+            "--global"
+        }
     }
 
     #[cfg(target_os = "linux")]
@@ -213,7 +217,7 @@ impl Deno {
             } else if bin_version >= Version::new(1, 0, 0) {
                 match version {
                     "stable" | "rc" | "canary" => {
-                        // Prior to v1.6.0, `deno upgrade` is not able fetch the latest tag version.
+                        // Prior to v1.6.0, `deno upgrade` is not able to fetch the latest tag version.
                         return Err(
                             SkipStep("Deno (1.0.0-1.6.0) cannot be upgraded to a named channel".to_string()).into(),
                         );

--- a/src/steps/os/android.rs
+++ b/src/steps/os/android.rs
@@ -19,7 +19,7 @@ pub fn upgrade_packages(ctx: &ExecutionContext) -> Result<()> {
 
     ctx.execute(&pkg)
         .arg("upgrade")
-        .arg_if(ctx.config().yes(Step::System), "-y")
+        .arg_if(ctx.config().yes(Step::System), "--yes")
         .status_checked()?;
 
     if !is_nala && ctx.config().cleanup() {
@@ -29,7 +29,7 @@ pub fn upgrade_packages(ctx: &ExecutionContext) -> Result<()> {
 
         ctx.execute(apt)
             .arg("autoremove")
-            .arg_if(ctx.config().yes(Step::System), "-y")
+            .arg_if(ctx.config().yes(Step::System), "--yes")
             .status_checked()?;
     }
 

--- a/src/steps/os/archlinux.rs
+++ b/src/steps/os/archlinux.rs
@@ -25,14 +25,14 @@ impl ArchPackageManager for YayParu {
     fn upgrade(&self, ctx: &ExecutionContext) -> Result<()> {
         if ctx.config().show_arch_news() {
             ctx.execute(&self.executable)
-                .arg("-Pw")
+                .args(["--show", "--news"])
                 .status_checked_with_codes(&[1, 0])?;
         }
 
         ctx.execute(&self.executable)
             .arg("--pacman")
             .arg(&self.pacman)
-            .arg("-Syu")
+            .args(["--sync", "--refresh", "--sysupgrade"])
             .args(ctx.config().yay_arguments().split_whitespace())
             .arg_if(ctx.config().yes(Step::System), "--noconfirm")
             .status_checked()?;
@@ -41,7 +41,7 @@ impl ArchPackageManager for YayParu {
             ctx.execute(&self.executable)
                 .arg("--pacman")
                 .arg(&self.pacman)
-                .arg("-Scc")
+                .args(["--sync", "--clean", "--clean"])
                 .arg_if(ctx.config().yes(Step::System), "--noconfirm")
                 .status_checked()?;
         }
@@ -91,14 +91,14 @@ pub struct Trizen {
 impl ArchPackageManager for Trizen {
     fn upgrade(&self, ctx: &ExecutionContext) -> Result<()> {
         ctx.execute(&self.executable)
-            .arg("-Syu")
+            .args(["--sync", "--refresh", "--sysupgrade"])
             .args(ctx.config().trizen_arguments().split_whitespace())
             .arg_if(ctx.config().yes(Step::System), "--noconfirm")
             .status_checked()?;
 
         if ctx.config().cleanup() {
             ctx.execute(&self.executable)
-                .arg("-Sc")
+                .args(["--sync", "--clean"])
                 .arg_if(ctx.config().yes(Step::System), "--noconfirm")
                 .status_checked()?;
         }
@@ -123,13 +123,13 @@ impl ArchPackageManager for Pacman {
     fn upgrade(&self, ctx: &ExecutionContext) -> Result<()> {
         let sudo = ctx.require_sudo()?;
         sudo.execute(ctx, &self.executable)?
-            .arg("-Syu")
+            .args(["--sync", "--refresh", "--sysupgrade"])
             .arg_if(ctx.config().yes(Step::System), "--noconfirm")
             .status_checked()?;
 
         if ctx.config().cleanup() {
             sudo.execute(ctx, &self.executable)?
-                .arg("-Scc")
+                .args(["--sync", "--clean", "--clean"])
                 .arg_if(ctx.config().yes(Step::System), "--noconfirm")
                 .status_checked()?;
         }
@@ -161,14 +161,14 @@ impl Pikaur {
 impl ArchPackageManager for Pikaur {
     fn upgrade(&self, ctx: &ExecutionContext) -> Result<()> {
         ctx.execute(&self.executable)
-            .arg("-Syu")
+            .args(["--sync", "--refresh", "--sysupgrade"])
             .args(ctx.config().pikaur_arguments().split_whitespace())
             .arg_if(ctx.config().yes(Step::System), "--noconfirm")
             .status_checked()?;
 
         if ctx.config().cleanup() {
             ctx.execute(&self.executable)
-                .arg("-Sc")
+                .args(["--sync", "--clean"])
                 .arg_if(ctx.config().yes(Step::System), "--noconfirm")
                 .status_checked()?;
         }
@@ -241,13 +241,13 @@ impl ArchPackageManager for Aura {
 
         if version >= version_no_sudo {
             ctx.execute(&self.executable)
-                .arg("-Au")
+                .args(["--aursync", "--sysupgrade"])
                 .args(ctx.config().aura_aur_arguments().split_whitespace())
                 .arg_if(ctx.config().yes(Step::System), "--noconfirm")
                 .status_checked()?;
 
             ctx.execute(&self.executable)
-                .arg("-Syu")
+                .args(["--sync", "--refresh", "--sysupgrade"])
                 .args(ctx.config().aura_pacman_arguments().split_whitespace())
                 .arg_if(ctx.config().yes(Step::System), "--noconfirm")
                 .status_checked()?;
@@ -255,13 +255,13 @@ impl ArchPackageManager for Aura {
             let sudo = ctx.require_sudo()?;
 
             sudo.execute(ctx, &self.executable)?
-                .arg("-Au")
+                .args(["--aursync", "--sysupgrade"])
                 .args(ctx.config().aura_aur_arguments().split_whitespace())
                 .arg_if(ctx.config().yes(Step::System), "--noconfirm")
                 .status_checked()?;
 
             sudo.execute(ctx, &self.executable)?
-                .arg("-Syu")
+                .args(["--sync", "--refresh", "--sysupgrade"])
                 .args(ctx.config().aura_pacman_arguments().split_whitespace())
                 .arg_if(ctx.config().yes(Step::System), "--noconfirm")
                 .status_checked()?;

--- a/src/steps/os/dragonfly.rs
+++ b/src/steps/os/dragonfly.rs
@@ -11,7 +11,7 @@ pub fn upgrade_packages(ctx: &ExecutionContext) -> Result<()> {
     let sudo = ctx.require_sudo()?;
     sudo.execute(ctx, "/usr/local/sbin/pkg")?
         .arg("upgrade")
-        .arg_if(ctx.config().yes(Step::System), "-y")
+        .arg_if(ctx.config().yes(Step::System), "--yes")
         .status_checked()
 }
 
@@ -20,7 +20,7 @@ pub fn audit_packages(ctx: &ExecutionContext) -> Result<()> {
 
     let sudo = ctx.require_sudo()?;
     sudo.execute(ctx, "/usr/local/sbin/pkg")?
-        .args(["audit", "-Fr"])
+        .args(["audit", "--fetch", "--recursive"])
         .status_checked_with(|status| {
             if !status.success() {
                 println!(

--- a/src/steps/os/freebsd.rs
+++ b/src/steps/os/freebsd.rs
@@ -20,7 +20,7 @@ pub fn upgrade_packages(ctx: &ExecutionContext) -> Result<()> {
     let sudo = ctx.require_sudo()?;
     sudo.execute(ctx, "/usr/sbin/pkg")?
         .arg("upgrade")
-        .arg_if(ctx.config().yes(Step::System), "-y")
+        .arg_if(ctx.config().yes(Step::System), "--yes")
         .status_checked()
 }
 
@@ -29,6 +29,6 @@ pub fn audit_packages(ctx: &ExecutionContext) -> Result<()> {
 
     let sudo = ctx.require_sudo()?;
     sudo.execute(ctx, "/usr/sbin/pkg")?
-        .args(["audit", "-Fr"])
+        .args(["audit", "--fetch", "--recursive"])
         .status_checked()
 }

--- a/src/steps/os/linux.rs
+++ b/src/steps/os/linux.rs
@@ -317,7 +317,7 @@ fn upgrade_suse(ctx: &ExecutionContext) -> Result<()> {
         } else {
             "update"
         })
-        .arg_if(ctx.config().yes(Step::System), "-y")
+        .arg_if(ctx.config().yes(Step::System), "--no-confirm")
         .status_checked()?;
 
     Ok(())
@@ -331,7 +331,7 @@ fn upgrade_opensuse_tumbleweed(ctx: &ExecutionContext) -> Result<()> {
 
     sudo.execute(ctx, &zypper)?
         .arg("dist-upgrade")
-        .arg_if(ctx.config().yes(Step::System), "-y")
+        .arg_if(ctx.config().yes(Step::System), "--no-confirm")
         .status_checked()?;
 
     Ok(())
@@ -356,7 +356,7 @@ fn upgrade_openmandriva(ctx: &ExecutionContext) -> Result<()> {
     sudo.execute(ctx, &dnf)?
         .arg("upgrade")
         .args_if_some(ctx.config().dnf_arguments(), |args| args.split_whitespace())
-        .arg_if(ctx.config().yes(Step::System), "-y")
+        .arg_if(ctx.config().yes(Step::System), "--assumeyes")
         .status_checked()?;
 
     Ok(())
@@ -369,12 +369,12 @@ fn upgrade_pclinuxos(ctx: &ExecutionContext) -> Result<()> {
     sudo.execute(ctx, &apt_get)?
         .arg("update")
         .args_if_some(ctx.config().dnf_arguments(), |args| args.split_whitespace())
-        .arg_if(ctx.config().yes(Step::System), "-y")
+        .arg_if(ctx.config().yes(Step::System), "--yes")
         .status_checked()?;
 
     sudo.execute(ctx, &apt_get)?
         .arg("dist-upgrade")
-        .arg_if(ctx.config().yes(Step::System), "-y")
+        .arg_if(ctx.config().yes(Step::System), "--yes")
         .status_checked()?;
 
     Ok(())
@@ -385,12 +385,12 @@ fn upgrade_vanilla(ctx: &ExecutionContext) -> Result<()> {
 
     ctx.execute(&apx)
         .args(["update", "--all"])
-        .arg_if(ctx.config().yes(Step::System), "-y")
+        .arg_if(ctx.config().yes(Step::System), "--assume-yes")
         .status_checked()?;
 
     ctx.execute(&apx)
         .args(["upgrade", "--all"])
-        .arg_if(ctx.config().yes(Step::System), "-y")
+        .arg_if(ctx.config().yes(Step::System), "--assume-yes")
         .status_checked()?;
 
     Ok(())
@@ -401,13 +401,13 @@ fn upgrade_void(ctx: &ExecutionContext) -> Result<()> {
     let sudo = ctx.require_sudo()?;
 
     sudo.execute(ctx, &xbps)?
-        .args(["-Su", "xbps"])
-        .arg_if(ctx.config().yes(Step::System), "-y")
+        .args(["--sync", "--update", "xbps"])
+        .arg_if(ctx.config().yes(Step::System), "--yes")
         .status_checked()?;
 
     sudo.execute(ctx, &xbps)?
         .arg("-u")
-        .arg_if(ctx.config().yes(Step::System), "-y")
+        .arg_if(ctx.config().yes(Step::System), "--yes")
         .status_checked()?;
 
     Ok(())
@@ -489,7 +489,7 @@ fn upgrade_debian(ctx: &ExecutionContext) -> Result<()> {
         ctx.execute(&apt).arg("upgrade").status_checked()?;
 
         // Simply return as MIST does not have `clean` and `autoremove`
-        // subcommands, neither the `-y` option (for now maybe?).
+        // subcommands, neither a `yes` option (for now maybe?).
         return Ok(());
     }
 
@@ -502,7 +502,7 @@ fn upgrade_debian(ctx: &ExecutionContext) -> Result<()> {
 
     sudo.execute(ctx, &apt)?
         .arg(if kind == Nala { "upgrade" } else { "dist-upgrade" })
-        .arg_if(ctx.config().yes(Step::System), "-y")
+        .arg_if(ctx.config().yes(Step::System), "--yes")
         .args_if_some(ctx.config().apt_arguments(), |args| args.split_whitespace())
         .status_checked()?;
 
@@ -511,7 +511,7 @@ fn upgrade_debian(ctx: &ExecutionContext) -> Result<()> {
 
         sudo.execute(ctx, &apt)?
             .arg("autoremove")
-            .arg_if(ctx.config().yes(Step::System), "-y")
+            .arg_if(ctx.config().yes(Step::System), "--yes")
             .status_checked()?;
     }
 
@@ -554,7 +554,7 @@ fn upgrade_solus(ctx: &ExecutionContext) -> Result<()> {
     let sudo = ctx.require_sudo()?;
 
     sudo.execute(ctx, &eopkg)?
-        .arg_if(ctx.config().yes(Step::System), "-y")
+        .arg_if(ctx.config().yes(Step::System), "--yes-all")
         .arg("upgrade")
         .status_checked()?;
 
@@ -836,7 +836,7 @@ pub fn run_fwupdmgr(ctx: &ExecutionContext) -> Result<()> {
     if ctx.config().firmware_upgrade() {
         ctx.execute(&fwupdmgr)
             .arg("update")
-            .arg_if(ctx.config().yes(Step::System), "-y")
+            .arg_if(ctx.config().yes(Step::System), "--assume-yes")
             .status_checked_with_codes(&[2])
     } else {
         // Exit 0 from `fwupdmgr get-updates` means firmware updates are available.
@@ -876,14 +876,14 @@ pub fn run_flatpak(ctx: &ExecutionContext) -> Result<()> {
 
     let mut update_args = vec!["update", "--user"];
     if yes {
-        update_args.push("-y");
+        update_args.push("--assumeyes");
     }
     ctx.execute(&flatpak).args(&update_args).status_checked()?;
 
     if cleanup {
         let mut cleanup_args = vec!["uninstall", "--user", "--unused"];
         if yes {
-            cleanup_args.push("-y");
+            cleanup_args.push("--assumeyes");
         }
         ctx.execute(&flatpak).args(&cleanup_args).status_checked()?;
     }
@@ -893,26 +893,26 @@ pub fn run_flatpak(ctx: &ExecutionContext) -> Result<()> {
         let sudo = ctx.require_sudo()?;
         let mut update_args = vec!["update", "--system"];
         if yes {
-            update_args.push("-y");
+            update_args.push("--assumeyes");
         }
         sudo.execute(ctx, &flatpak)?.args(&update_args).status_checked()?;
         if cleanup {
             let mut cleanup_args = vec!["uninstall", "--system", "--unused"];
             if yes {
-                cleanup_args.push("-y");
+                cleanup_args.push("--assumeyes");
             }
             sudo.execute(ctx, &flatpak)?.args(&cleanup_args).status_checked()?;
         }
     } else {
         let mut update_args = vec!["update", "--system"];
         if yes {
-            update_args.push("-y");
+            update_args.push("--assumeyes");
         }
         ctx.execute(&flatpak).args(&update_args).status_checked()?;
         if cleanup {
             let mut cleanup_args = vec!["uninstall", "--system", "--unused"];
             if yes {
-                cleanup_args.push("-y");
+                cleanup_args.push("--assumeyes");
             }
             ctx.execute(flatpak).args(&cleanup_args).status_checked()?;
         }

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -204,21 +204,21 @@ pub fn run_fisher(ctx: &ExecutionContext) -> Result<()> {
 
     ctx.execute(&fish)
         .always()
-        .args(["-c", "type -t fisher"])
+        .arg("--command=type --type fisher")
         .output_checked_utf8()
         .map(|_| ())
         .map_err(|_| SkipStep(t!("`fisher` is not defined in `fish`").to_string()))?;
 
     ctx.execute(&fish)
         .always()
-        .args(["-c", "echo \"$__fish_config_dir/fish_plugins\""])
+        .arg("--command=echo \"$__fish_config_dir/fish_plugins\"")
         .output_checked_utf8()
         .and_then(|output| Path::new(&output.stdout.trim()).require().map(|_| ()))
         .map_err(|err| SkipStep(t!("`fish_plugins` path doesn't exist: {err}", err = err).to_string()))?;
 
     ctx.execute(&fish)
         .always()
-        .args(["-c", "fish_update_completions"])
+        .arg("--command=fish_update_completions")
         .output_checked_utf8()
         .map(|_| ())
         .map_err(|_| SkipStep(t!("`fish_update_completions` is not available").to_string()))?;
@@ -228,17 +228,17 @@ pub fn run_fisher(ctx: &ExecutionContext) -> Result<()> {
     let version_str = ctx
         .execute(&fish)
         .always()
-        .args(["-c", "fisher --version"])
+        .arg("--command=fisher --version")
         .output_checked_utf8()?
         .stdout;
     debug!("Fisher version: {}", version_str);
 
     if version_str.starts_with("fisher version 3.") {
         // v3 - see https://github.com/topgrade-rs/topgrade/pull/37#issuecomment-1283844506
-        ctx.execute(&fish).args(["-c", "fisher"]).status_checked()
+        ctx.execute(&fish).arg("--command=fisher").status_checked()
     } else {
         // v4
-        ctx.execute(&fish).args(["-c", "fisher update"]).status_checked()
+        ctx.execute(&fish).arg("--command=fisher update").status_checked()
     }
 }
 
@@ -284,7 +284,7 @@ pub fn run_oh_my_fish(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("oh-my-fish");
 
-    ctx.execute(fish).args(["-c", "omf update"]).status_checked()
+    ctx.execute(fish).arg("--command=omf update").status_checked()
 }
 
 pub fn run_pkgin(ctx: &ExecutionContext) -> Result<()> {
@@ -313,7 +313,7 @@ pub fn run_fish_plug(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("fish-plug");
 
-    ctx.execute(fish).args(["-c", "plug update"]).status_checked()
+    ctx.execute(fish).arg("--command=plug update").status_checked()
 }
 
 /// Upgrades `fundle` and `fundle` plugins.
@@ -328,7 +328,7 @@ pub fn run_fundle(ctx: &ExecutionContext) -> Result<()> {
     print_separator("fundle");
 
     ctx.execute(fish)
-        .args(["-c", "fundle self-update && fundle update"])
+        .arg("--command=fundle self-update && fundle update")
         .status_checked()
 }
 
@@ -395,7 +395,7 @@ pub fn run_brew_formula(ctx: &ExecutionContext, variant: BrewVariant) -> Result<
 
     brew.execute(ctx)?
         .args(["upgrade", "--formula"])
-        .arg_if(ctx.config().yes(Step::BrewFormula), "-y")
+        .arg_if(ctx.config().yes(Step::BrewFormula), "--no-ask")
         .arg_if(ctx.config().brew_fetch_head(), "--fetch-HEAD")
         .status_checked()?;
 
@@ -464,14 +464,14 @@ pub fn run_brew_cask(ctx: &ExecutionContext, variant: BrewVariant) -> Result<()>
     let mut brew_args = vec![];
 
     if cask_upgrade_exists {
-        brew_args.extend(["cu", "-y"]);
+        brew_args.extend(["cu", "--yes"]);
         if ctx.config().brew_cask_greedy() {
-            brew_args.push("-a");
+            brew_args.push("--all");
         }
     } else {
         brew_args.extend(["upgrade", "--cask"]);
         if ctx.config().yes(Step::BrewCask) {
-            brew_args.push("-y");
+            brew_args.push("--no-ask");
         }
         if ctx.config().brew_cask_greedy() {
             brew_args.push("--greedy");
@@ -514,7 +514,7 @@ pub fn run_guix(ctx: &ExecutionContext) -> Result<()> {
     print_separator("Guix");
 
     ctx.execute(&guix).arg("pull").status_checked()?;
-    ctx.execute(&guix).args(["package", "-u"]).status_checked()?;
+    ctx.execute(&guix).args(["package", "--upgrade"]).status_checked()?;
 
     Ok(())
 }

--- a/src/steps/os/windows.rs
+++ b/src/steps/os/windows.rs
@@ -93,12 +93,12 @@ pub fn update_wsl(ctx: &ExecutionContext) -> Result<()> {
 ///
 /// If the command is installed and the user hasn't installed any Linux distros
 /// on it, command `wsl -l` would print a help message and exit with failure, we
-/// use this to check whether WSL is install or not.
+/// use this to check whether WSL is installed or not.
 fn is_wsl_installed() -> Result<bool> {
     if let Some(wsl) = which("wsl") {
         // Don't use `output_checked` as an execution failure log is not wanted
         #[expect(clippy::disallowed_methods)]
-        let output = Command::new(wsl).arg("-l").output()?;
+        let output = Command::new(wsl).arg("--list").output()?;
         let status = output.status;
 
         if status.success() {
@@ -113,7 +113,7 @@ fn get_wsl_distributions(ctx: &ExecutionContext, wsl: &Path) -> Result<Vec<Strin
     let output = ctx
         .execute(wsl)
         .always()
-        .args(["--list", "-q"])
+        .args(["--list", "--quiet"])
         .output_checked_utf8()?
         .stdout;
     Ok(output
@@ -127,7 +127,7 @@ fn upgrade_wsl_distribution(wsl: &Path, dist: &str, ctx: &ExecutionContext) -> R
     let topgrade = ctx
         .execute(wsl)
         .always()
-        .args(["-d", dist, "bash", "-lc", "which topgrade"])
+        .args(["--distribution", dist, "bash", "-lc", "which topgrade"])
         .output_checked_utf8()
         .map_err(|_| SkipStep(t!("Could not find Topgrade installed in WSL").to_string()))?
         .stdout // The normal output from `which topgrade` appends a newline, so we trim it here.
@@ -140,7 +140,7 @@ fn upgrade_wsl_distribution(wsl: &Path, dist: &str, ctx: &ExecutionContext) -> R
         // elements instead of parsing their contents. `"${@:3}"` forwards the flags
         // to `topgrade` (not `bash`) and expands to nothing when there are none.
         .args([
-            "-d",
+            "--distribution",
             dist,
             "bash",
             "-lc",

--- a/src/steps/toolbx.rs
+++ b/src/steps/toolbx.rs
@@ -47,7 +47,7 @@ pub fn run_toolbx(ctx: &ExecutionContext) -> Result<()> {
         let topgrade_prefix = format!("TOPGRADE_PREFIX='Toolbx {tb}'");
         let mut args = vec![
             "run",
-            "-c",
+            "--container",
             tb,
             "env",
             &topgrade_prefix,

--- a/src/steps/zsh.rs
+++ b/src/steps/zsh.rs
@@ -23,7 +23,7 @@ use etcetera::base_strategy::BaseStrategy;
 fn execute_interactive_zsh(ctx: &ExecutionContext, zsh: &Path, command: &str) -> Executor {
     let script = format!("{command}; exit $?");
     let mut exec = ctx.execute(zsh);
-    exec.args(["-i", "-c", &script]);
+    exec.args(["--interactive", "-c", &script]);
     exec
 }
 
@@ -66,7 +66,7 @@ pub fn run_antidote(ctx: &ExecutionContext) -> Result<()> {
         // Commands handed to an *interactive* zsh must end on a builtin (#2158).
         AntidoteUpdate::Shell => ctx
             .execute(zsh)
-            .args(["-i", "-c", "antidote update; exit $?"])
+            .args(["--interactive", "-c", "antidote update; exit $?"])
             .status_checked(),
         AntidoteUpdate::Source(antidote) => ctx
             .execute(zsh)
@@ -80,7 +80,7 @@ fn antidote_available_in_shell(ctx: &ExecutionContext, zsh: &Path) -> bool {
     // Commands handed to an *interactive* zsh must end on a builtin (#2158).
     ctx.execute(zsh)
         .always()
-        .args(["-i", "-c", "command -v antidote"])
+        .args(["--interactive", "-c", "command -v antidote"])
         .output_checked()
         .is_ok()
 }
@@ -102,7 +102,7 @@ pub fn run_antigen(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("antigen");
 
-    execute_interactive_zsh(ctx, &zsh, "antigen selfupdate ; antigen update").status_checked()
+    execute_interactive_zsh(ctx, &zsh, "antigen selfupdate; antigen update").status_checked()
 }
 
 pub fn run_zgenom(ctx: &ExecutionContext) -> Result<()> {
@@ -125,7 +125,9 @@ pub fn run_zplug(ctx: &ExecutionContext) -> Result<()> {
 
     print_separator("zplug");
 
-    ctx.execute(zsh).args(["-i", "-c", "zplug update"]).status_checked()
+    ctx.execute(zsh)
+        .args(["--interactive", "-c", "zplug update"])
+        .status_checked()
 }
 
 pub fn run_zinit(ctx: &ExecutionContext) -> Result<()> {
@@ -167,7 +169,7 @@ pub fn run_zim(ctx: &ExecutionContext) -> Result<()> {
     print_separator("zim");
 
     ctx.execute(zsh)
-        .args(["-i", "-c", "zimfw upgrade && zimfw update"])
+        .args(["--interactive", "-c", "zimfw upgrade && zimfw update"])
         .status_checked()
 }
 
@@ -187,7 +189,7 @@ pub fn run_oh_my_zsh(ctx: &ExecutionContext) -> Result<()> {
         let res_env_zsh = ctx
             .execute("zsh")
             .always()
-            .args(["-ic", "print -rn -- ${ZSH:?}"])
+            .args(["--interactive", "-c", "print -rn -- ${ZSH:?}"])
             .output_checked_utf8();
 
         // this command will fail if `ZSH` is not set

--- a/src/sudo.rs
+++ b/src/sudo.rs
@@ -284,7 +284,7 @@ impl Sudo {
         ctx.execute(self.path.as_deref().unwrap())
             .args(match self.kind {
                 SudoKind::Doas => {
-                    // `doas` doesn't have anything like `sudo -v` to cache credentials,
+                    // `doas` doesn't have anything like `sudo --validate` to cache credentials,
                     // so we just execute a no-op dummy command, `true`.
                     // See: https://man.openbsd.org/doas
                     vec!["true"]
@@ -296,7 +296,7 @@ impl Sudo {
                     //   if necessary.  For the sudoers plugin, this extends the sudo
                     //   timeout for another 5 minutes by default, but does not run a
                     //   command.  Not all security policies support cached credentials.
-                    vec!["-v"]
+                    vec!["--validate"]
                 }
                 SudoKind::WinSudo => {
                     // Windows `sudo` doesn't cache credentials, so we just execute a
@@ -305,12 +305,12 @@ impl Sudo {
                     vec!["cmd.exe", "/c", "rem"]
                 }
                 SudoKind::Gsudo => {
-                    // `gsudo` doesn't have anything like `sudo -v` to cache credentials,
+                    // `gsudo` doesn't have anything like `sudo --validate` to cache credentials,
                     // so we just execute a dummy command - the easiest on Windows is
-                    // `rem` in cmd. `-d` tells it to run the command directly, without
+                    // `rem` in cmd. `--direct` tells it to run the command directly, without
                     // going through a shell (which could be powershell) first.
                     // See: https://gerardog.github.io/gsudo/docs/usage
-                    vec!["-d", "cmd.exe", "/c", "rem"]
+                    vec!["--direct", "cmd.exe", "/c", "rem"]
                     // TODO: `gsudo cache on` starts a session with cached credentials and could replace the dummy `rem` invocation here when sudo_loop is enabled...
                 }
                 SudoKind::Pkexec => {
@@ -334,7 +334,7 @@ impl Sudo {
                     // From `man please`
                     //   -w, --warm
                     //   Warm the access token and exit.
-                    vec!["-w"]
+                    vec!["--warm"]
                 }
                 SudoKind::Null => unreachable!(),
             })
@@ -345,12 +345,12 @@ impl Sudo {
     /// Refresh arguments for the sudo kinds that can cache credentials.
     fn refresh_args(&self) -> Option<&'static [&'static str]> {
         match self.kind {
-            // `-n`: refresh runs on a background thread, so a cold credential must fail fast rather than prompt.
-            // `-v`: on a still-valid timestamp extends it without touching PAM.
-            SudoKind::Sudo => Some(&["-n", "-v"]),
-            // `-w`: refreshes a still-valid token without prompting; it only prompts once the token has gone cold.
-            // `-n`: warm path skips the token update entirely, silently stopping the keep-alive.
-            SudoKind::Please => Some(&["-w"]),
+            // `--non-interactive`: refresh runs on a background thread, so a cold credential must fail fast rather than prompt.
+            // `--validate`: on a still-valid timestamp extends it without touching PAM.
+            SudoKind::Sudo => Some(&["--non-interactive", "--validate"]),
+            // `--warm`: refreshes a still-valid token without prompting; it only prompts once the token has gone cold.
+            // `--noprompt`: warm path skips the token update entirely, silently stopping the keep-alive.
+            SudoKind::Please => Some(&["--warm"]),
             _ => None,
         }
     }
@@ -422,11 +422,11 @@ impl Sudo {
         if opts.login_shell {
             match self.kind {
                 SudoKind::Sudo => {
-                    args.push("-i".into());
+                    args.push("--login".into());
                 }
                 SudoKind::Gsudo => {
                     // By default, gsudo runs all commands inside a shell. If login_shell
-                    // is *not* specified, we add `-d` to run outside of a shell - see below.
+                    // is *not* specified, we add `--direct` to run outside of a shell - see below.
                 }
                 SudoKind::Doas | SudoKind::WinSudo | SudoKind::Pkexec | SudoKind::Run0 | SudoKind::Please => {
                     return Err(UnsupportedSudo {
@@ -438,12 +438,12 @@ impl Sudo {
                 SudoKind::Null => unreachable!(),
             }
         } else if let SudoKind::Gsudo = self.kind {
-            // The `-d` (direct) flag disables shell detection, running the command directly
+            // The `--direct` flag disables shell detection, running the command directly
             // rather than through the current shell.
             // Additionally, if the current shell is pwsh >= 7.3.0, then not including this
             // gives errors if the command to run has spaces in it: see
             // https://github.com/gerardog/gsudo/issues/297
-            args.push("-d".into());
+            args.push("--direct".into());
         }
 
         let mut preserve_env = opts.preserve_env;
@@ -463,7 +463,7 @@ impl Sudo {
         match preserve_env {
             SudoPreserveEnv::All => match self.kind {
                 SudoKind::Sudo => {
-                    args.push("-E".into());
+                    args.push("--preserve-env".into());
                 }
                 SudoKind::Gsudo => {
                     args.push("--copyEV".into());
@@ -487,7 +487,7 @@ impl Sudo {
                     }
                 }
                 SudoKind::Please => {
-                    args.push("-a".into());
+                    args.push("--allowenv".into());
                     args.push(vars.iter().join(","));
                 }
                 SudoKind::Doas | SudoKind::WinSudo | SudoKind::Gsudo | SudoKind::Pkexec => {
@@ -505,7 +505,7 @@ impl Sudo {
         if opts.set_home {
             match self.kind {
                 SudoKind::Sudo => {
-                    args.push("-H".into());
+                    args.push("--set-home".into());
                 }
                 // This is already the default behavior for run0
                 SudoKind::Run0 => {}
@@ -523,7 +523,7 @@ impl Sudo {
         if let Some(user) = opts.user {
             match self.kind {
                 SudoKind::Sudo => {
-                    args.push("-u".into());
+                    args.push("--user".into());
                     args.push(user.into());
                 }
                 SudoKind::Doas | SudoKind::Gsudo | SudoKind::Run0 | SudoKind::Please => {


### PR DESCRIPTION
## What does this PR do
**Partial** fix of #2094. There should be no changes to the steps taken, only how they are invoked.

Subjects of some interest:

* `python`, `bash`, `rcup`, `kak`, `getnf`, `tmux`, `doas`, `port`, `ssh`, and all BSD commands do not have long options.
* `vim` and `nvim` mostly do not have long options.
* `git clean -d`, `zsh -c`, and `mamba -n` have no long equivalent.
* `command -v` in Zsh has no long equivalent.
* `deno -V` should not be changed to `deno --version`; its output is different (longer). Alternatively, `--version` could be used and the parsing changed (somewhat simple).
  <details><summary><code>-V</code> vs. <code>--verison</code></summary>

  ```
  $ deno -V
  deno 2.9.5
  $ deno --version
  deno 2.9.5 (stable, release, x86_64-unknown-linux-gnu)
  v8 15.0.245.2-rusty
  typescript 6.0.3
  ```

  </details>

* [A comment in `sudo.rs`](https://github.com/topgrade-rs/topgrade/blob/6145f7052f3ab0df08b96d34a148899b643f0738/src/sudo.rs#L352) mentions the `-n` (`--noprompt`) option for `please`, but the option appears unused in Topgrade.

## Standards checklist

- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* The PR title is a descriptive commit message (this will appear in release notes, leave unchecked if you want a maintainer to improve it)
- [ ] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps. (I have done some testing, but not formally.)
- [x] If this PR introduces new user-facing messages they are translated (n/a)

### AI involvement
I did not use AI at all.

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->