### PR TITLE
fix(android-studio): skip when `studio` is WordPress Studio CLI

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -2372,16 +2372,19 @@ fn run_jetbrains_ide(ctx: &ExecutionContext, bin: PathBuf, name: &str) -> Result
 pub fn run_android_studio(ctx: &ExecutionContext) -> Result<()> {
     // We don't use `run_jetbrains_ide` here because that would print "JetBrains Android Studio",
     //  which is incorrect as Android Studio is made by Google. Just "Android Studio" is fine.
-    run_jetbrains_ide_generic::<false>(
-        ctx,
-        require_one([
-            "studio",
-            "android-studio",
-            "android-studio-beta",
-            "android-studio-canary",
-        ])?,
-        "Android Studio",
-    )
+    let studio = require_one([
+        "studio",
+        "android-studio",
+        "android-studio-beta",
+        "android-studio-canary",
+    ])?;
+
+    let help = ctx.execute(&studio).always().arg("--help").output_checked()?;
+    if String::from_utf8(help.stdout)?.contains("WordPress Studio") {
+        return Err(SkipStep("Binary is WordPress Studio CLI, not Android Studio".to_string()).into());
+    }
+
+    run_jetbrains_ide_generic::<false>(ctx, studio, "Android Studio")
 }
 
 pub fn run_jetbrains_aqua(ctx: &ExecutionContext) -> Result<()> {

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -2379,9 +2379,9 @@ pub fn run_android_studio(ctx: &ExecutionContext) -> Result<()> {
         "android-studio-canary",
     ])?;
 
-    let help = ctx.execute(&studio).always().arg("--help").output_checked()?;
-    if String::from_utf8(help.stdout)?.contains("WordPress Studio") {
-        return Err(SkipStep("Binary is WordPress Studio CLI, not Android Studio".to_string()).into());
+    let help = ctx.execute(&studio).always().arg("--help").output_checked_utf8()?;
+    if help.stdout.contains("WordPress Studio") {
+        return Err(SkipStep("Command `studio` points to WordPress Studio CLI, not Android Studio".to_string()).into());
     }
 
     run_jetbrains_ide_generic::<false>(ctx, studio, "Android Studio")

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -2369,22 +2369,48 @@ fn run_jetbrains_ide(ctx: &ExecutionContext, bin: PathBuf, name: &str) -> Result
     run_jetbrains_ide_generic::<true>(ctx, bin, name)
 }
 
+enum Studio {
+    AndroidStudio(PathBuf),
+    WordPressStudio(PathBuf),
+}
+
+impl Studio {
+    fn android_studio(self) -> Result<PathBuf> {
+        match self {
+            Studio::AndroidStudio(studio) => Ok(studio),
+            Studio::WordPressStudio(studio) => Err(SkipStep(format!(
+                "Command `{}` points to WordPress Studio CLI, not Android Studio",
+                studio.display()
+            ))
+            .into()),
+        }
+    }
+
+    fn get(ctx: &ExecutionContext) -> Result<Self> {
+        let studio = require_one([
+            "studio",
+            "android-studio",
+            "android-studio-beta",
+            "android-studio-canary",
+        ])?;
+
+        // Check if `studio --help` mentions "WordPress Studio". Android Studio does not, WordPress Studio does.
+        let output = ctx.execute(&studio).always().arg("--help").output_checked_utf8()?;
+
+        if output.stdout.contains("WordPress Studio") {
+            debug!("Detected `studio` as WordPress Studio");
+            Ok(Self::WordPressStudio(studio))
+        } else {
+            debug!("Detected `studio` as Android Studio");
+            Ok(Self::AndroidStudio(studio))
+        }
+    }
+}
+
 pub fn run_android_studio(ctx: &ExecutionContext) -> Result<()> {
     // We don't use `run_jetbrains_ide` here because that would print "JetBrains Android Studio",
     //  which is incorrect as Android Studio is made by Google. Just "Android Studio" is fine.
-    let studio = require_one([
-        "studio",
-        "android-studio",
-        "android-studio-beta",
-        "android-studio-canary",
-    ])?;
-
-    let help = ctx.execute(&studio).always().arg("--help").output_checked_utf8()?;
-    if help.stdout.contains("WordPress Studio") {
-        return Err(SkipStep("Command `studio` points to WordPress Studio CLI, not Android Studio".to_string()).into());
-    }
-
-    run_jetbrains_ide_generic::<false>(ctx, studio, "Android Studio")
+    run_jetbrains_ide_generic::<false>(ctx, Studio::get(ctx)?.android_studio()?, "Android Studio")
 }
 
 pub fn run_jetbrains_aqua(ctx: &ExecutionContext) -> Result<()> {

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -2375,22 +2375,48 @@ fn run_jetbrains_ide(ctx: &ExecutionContext, bin: PathBuf, name: &str) -> Result
     run_jetbrains_ide_generic::<true>(ctx, bin, name)
 }
 
+enum Studio {
+    AndroidStudio(PathBuf),
+    WordPressStudio(PathBuf),
+}
+
+impl Studio {
+    fn android_studio(self) -> Result<PathBuf> {
+        match self {
+            Studio::AndroidStudio(studio) => Ok(studio),
+            Studio::WordPressStudio(studio) => Err(SkipStep(format!(
+                "Command `{}` points to WordPress Studio CLI, not Android Studio",
+                studio.display()
+            ))
+            .into()),
+        }
+    }
+
+    fn get(ctx: &ExecutionContext) -> Result<Self> {
+        let studio = require_one([
+            "studio",
+            "android-studio",
+            "android-studio-beta",
+            "android-studio-canary",
+        ])?;
+
+        // Check if `studio --help` mentions "WordPress Studio". Android Studio does not, WordPress Studio does.
+        let output = ctx.execute(&studio).always().arg("--help").output_checked_utf8()?;
+
+        if output.stdout.contains("WordPress Studio") {
+            debug!("Detected `studio` as WordPress Studio");
+            Ok(Self::WordPressStudio(studio))
+        } else {
+            debug!("Detected `studio` as Android Studio");
+            Ok(Self::AndroidStudio(studio))
+        }
+    }
+}
+
 pub fn run_android_studio(ctx: &ExecutionContext) -> Result<()> {
     // We don't use `run_jetbrains_ide` here because that would print "JetBrains Android Studio",
     //  which is incorrect as Android Studio is made by Google. Just "Android Studio" is fine.
-    let studio = require_one([
-        "studio",
-        "android-studio",
-        "android-studio-beta",
-        "android-studio-canary",
-    ])?;
-
-    let help = ctx.execute(&studio).always().arg("--help").output_checked_utf8()?;
-    if help.stdout.contains("WordPress Studio") {
-        return Err(SkipStep("Command `studio` points to WordPress Studio CLI, not Android Studio".to_string()).into());
-    }
-
-    run_jetbrains_ide_generic::<false>(ctx, studio, "Android Studio")
+    run_jetbrains_ide_generic::<false>(ctx, Studio::get(ctx)?.android_studio()?, "Android Studio")
 }
 
 pub fn run_jetbrains_aqua(ctx: &ExecutionContext) -> Result<()> {

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -2393,12 +2393,7 @@ impl Studio {
     }
 
     fn get(ctx: &ExecutionContext) -> Result<Self> {
-        let studio = require_one([
-            "studio",
-            "android-studio",
-            "android-studio-beta",
-            "android-studio-canary",
-        ])?;
+        let studio = require("studio")?;
 
         // Check if `studio --help` mentions "WordPress Studio". Android Studio does not, WordPress Studio does.
         let output = ctx.execute(&studio).always().arg("--help").output_checked_utf8()?;
@@ -2414,9 +2409,15 @@ impl Studio {
 }
 
 pub fn run_android_studio(ctx: &ExecutionContext) -> Result<()> {
+    let studio = Studio::get(ctx)
+        .or_else(|_| {
+            require_one(["android-studio", "android-studio-beta", "android-studio-canary"]).map(Studio::AndroidStudio)
+        })?
+        .android_studio()?;
+
     // We don't use `run_jetbrains_ide` here because that would print "JetBrains Android Studio",
     //  which is incorrect as Android Studio is made by Google. Just "Android Studio" is fine.
-    run_jetbrains_ide_generic::<false>(ctx, Studio::get(ctx)?.android_studio()?, "Android Studio")
+    run_jetbrains_ide_generic::<false>(ctx, studio, "Android Studio")
 }
 
 pub fn run_jetbrains_aqua(ctx: &ExecutionContext) -> Result<()> {

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -2378,16 +2378,19 @@ fn run_jetbrains_ide(ctx: &ExecutionContext, bin: PathBuf, name: &str) -> Result
 pub fn run_android_studio(ctx: &ExecutionContext) -> Result<()> {
     // We don't use `run_jetbrains_ide` here because that would print "JetBrains Android Studio",
     //  which is incorrect as Android Studio is made by Google. Just "Android Studio" is fine.
-    run_jetbrains_ide_generic::<false>(
-        ctx,
-        require_one([
-            "studio",
-            "android-studio",
-            "android-studio-beta",
-            "android-studio-canary",
-        ])?,
-        "Android Studio",
-    )
+    let studio = require_one([
+        "studio",
+        "android-studio",
+        "android-studio-beta",
+        "android-studio-canary",
+    ])?;
+
+    let help = ctx.execute(&studio).always().arg("--help").output_checked()?;
+    if String::from_utf8(help.stdout)?.contains("WordPress Studio") {
+        return Err(SkipStep("Binary is WordPress Studio CLI, not Android Studio".to_string()).into());
+    }
+
+    run_jetbrains_ide_generic::<false>(ctx, studio, "Android Studio")
 }
 
 pub fn run_jetbrains_aqua(ctx: &ExecutionContext) -> Result<()> {

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -2410,10 +2410,8 @@ impl Studio {
 
 pub fn run_android_studio(ctx: &ExecutionContext) -> Result<()> {
     let studio = Studio::get(ctx)
-        .or_else(|_| {
-            require_one(["android-studio", "android-studio-beta", "android-studio-canary"]).map(Studio::AndroidStudio)
-        })?
-        .android_studio()?;
+        .and_then(|x| x.android_studio())
+        .or_else(|_| require_one(["android-studio", "android-studio-beta", "android-studio-canary"]))?;
 
     // We don't use `run_jetbrains_ide` here because that would print "JetBrains Android Studio",
     //  which is incorrect as Android Studio is made by Google. Just "Android Studio" is fine.

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -2385,9 +2385,9 @@ pub fn run_android_studio(ctx: &ExecutionContext) -> Result<()> {
         "android-studio-canary",
     ])?;
 
-    let help = ctx.execute(&studio).always().arg("--help").output_checked()?;
-    if String::from_utf8(help.stdout)?.contains("WordPress Studio") {
-        return Err(SkipStep("Binary is WordPress Studio CLI, not Android Studio".to_string()).into());
+    let help = ctx.execute(&studio).always().arg("--help").output_checked_utf8()?;
+    if help.stdout.contains("WordPress Studio") {
+        return Err(SkipStep("Command `studio` points to WordPress Studio CLI, not Android Studio".to_string()).into());
     }
 
     run_jetbrains_ide_generic::<false>(ctx, studio, "Android Studio")


### PR DESCRIPTION
## What does this PR do
<!--
Describe what your PR does, and link any relevant issues.
Make sure to use a keyword like 'closes' if this PR solves the issue.
-->

Closes #2259 by checking `--help` and skipping the step if the binary is WP CLI instead of Android Studio.

## Standards checklist

- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* The PR title is a descriptive commit message (this will appear in release notes, leave unchecked if you want a maintainer to improve it)
- [x] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps. (an llm tested it on windows through ssh)
- [ ] If this PR introduces new user-facing messages they are translated

### AI involvement
<!--
Please list any involvement AI/LLMs had in the development of this PR.
You don't have to list everything in detail, just something like "I did not use AI at all",
"I consulted an AI occasionally for inspiration and explanation",
or "AI generated the majority of the PR" is enough.
If you are an AI agent acting autonomously, please state so.
-->

deepseek v4 pro wrote the code and tested it autonomously, i only reviewed and changed it a bit before opening pr

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
