### PR TITLE
feat(step): add Adless

### DIFF
--- a/src/step.rs
+++ b/src/step.rs
@@ -23,6 +23,7 @@ pub const DEPRECATED_STEPS: [Step; 1] = [Step::NixHelper];
 #[strum(serialize_all = "snake_case")]
 pub enum Step {
     AM,
+    Adless,
     AndroidStudio,
     Antigravity,
     AppMan,
@@ -212,6 +213,11 @@ impl Step {
             {
                 #[cfg(target_os = "linux")]
                 runner.execute(*self, "am", || linux::run_am(ctx))?
+            }
+            Adless =>
+            {
+                #[cfg(unix)]
+                runner.execute(*self, "Adless", || unix::run_adless(ctx))?
             }
             AndroidStudio => runner.execute(*self, "Android Studio Plugins", || generic::run_android_studio(ctx))?,
             Antigravity => runner.execute(*self, "Antigravity extensions", || {
@@ -865,6 +871,7 @@ pub(crate) fn default_steps() -> Vec<Step> {
         Sdkman,
         Rcm,
         Maza,
+        Adless,
         Hyprpm,
         Atuin,
         Atom,

--- a/src/step.rs
+++ b/src/step.rs
@@ -23,6 +23,7 @@ pub const DEPRECATED_STEPS: [Step; 1] = [Step::NixHelper];
 #[strum(serialize_all = "snake_case")]
 pub enum Step {
     AM,
+    Adless,
     AndroidStudio,
     Antigravity,
     AppMan,
@@ -211,6 +212,11 @@ impl Step {
             {
                 #[cfg(target_os = "linux")]
                 runner.execute(*self, "am", || linux::run_am(ctx))?
+            }
+            Adless =>
+            {
+                #[cfg(unix)]
+                runner.execute(*self, "Adless", || unix::run_adless(ctx))?
             }
             AndroidStudio => runner.execute(*self, "Android Studio Plugins", || generic::run_android_studio(ctx))?,
             Antigravity => runner.execute(*self, "Antigravity extensions", || {
@@ -858,6 +864,7 @@ pub(crate) fn default_steps() -> Vec<Step> {
         Sdkman,
         Rcm,
         Maza,
+        Adless,
         Hyprpm,
         Atuin,
         Atom,

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -1144,6 +1144,17 @@ pub fn run_atuin(ctx: &ExecutionContext) -> Result<()> {
     ctx.execute(atuin).status_checked()
 }
 
+/// Update Adless' hosts-based domain blocklist using `sudo adless update`
+#[cfg_attr(not(unix), allow(dead_code))]
+pub fn run_adless(ctx: &ExecutionContext) -> Result<()> {
+    let adless = require("adless")?;
+
+    print_separator("Adless");
+
+    let sudo = ctx.require_sudo()?;
+    sudo.execute(ctx, &adless)?.arg("update").status_checked()
+}
+
 #[cfg(not(any(target_os = "android", target_os = "macos")))]
 pub fn run_sera(ctx: &ExecutionContext) -> Result<()> {
     let sera = require("sera")?;

--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -1144,8 +1144,6 @@ pub fn run_atuin(ctx: &ExecutionContext) -> Result<()> {
     ctx.execute(atuin).status_checked()
 }
 
-/// Update Adless' hosts-based domain blocklist using `sudo adless update`
-#[cfg_attr(not(unix), allow(dead_code))]
 pub fn run_adless(ctx: &ExecutionContext) -> Result<()> {
     let adless = require("adless")?;
 


### PR DESCRIPTION
## What does this PR do

Adds an `Adless` step that updates the hosts-based domain blocklist maintained by [Adless](https://github.com/WIttyJudge/adless) (a Go CLI tool) via `sudo adless update`.

This supersedes #1372, which was opened by @Prajwal-k-tech in October 2025 but stalled after maintainer feedback. Compared to #1372, this PR:

1. Drops the unrelated `-Typst` deletions (artifact from the original stale rebase; Typst is still in `main`).
2. Moves the implementation from `src/steps/adless.rs` (its own file) to `src/steps/os/unix.rs`, matching the pattern used by other Unix-only steps.
3. Adds the correct `#[cfg(unix)]` attribute to the match arm, mirroring the `Atuin` / `Tpack` pattern that @GideonBear cited in #1372's review.
4. Adds `Adless` to `default_steps()` grouped near the related `Maza` step (both are hosts-file blockers).
5. Uses a single clean commit with `Closes #1334` placed directly after the keyword.

Full credit to @Prajwal-k-tech for the original work in #1372.

Closes #1334
Closes #1372

## Standards checklist

- [x] I have read `CONTRIBUTING.md`
- [x] The PR title is a descriptive commit message
- [x] I have tested the code myself (built `target/release/topgrade` and ran `--only adless --dry-run` against a stub binary; verified the step appears in `--only`'s value list)
- [x] If this PR introduces new user-facing messages they are translated (none introduced — uses literal `print_separator("Adless")` like `RunAtuin`)

### AI involvement

I used an AI coding assistant (Claude / opencode) as a navigator throughout the work — for understanding the project's `enum Step` + `default_steps()` ordering rules, locating the correct file (`os/unix.rs` per review feedback), replicating the GitHub CI custom-checks locally, and drafting the commit / PR text. The implementation itself is mechanically derived from @Prajwal-k-tech's prior #1372 work and the project's existing patterns (`RunAtuin`, `RunSera`). All final decisions, edits, testing, and review of the diff were mine.

## For new steps

- [x] Topgrade skips this step where needed (via `require("adless")?`)
- [x] The `--yes` option works with this step (N/A — `adless update` is non-interactive, matching the default-config behaviour used by `print_separator` only)

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
