### PR TITLE
feat(deno): add no_delta option to skip delta upgrades

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -375,6 +375,10 @@
 # Upgrade deno executable to the given version.
 # version = "stable"
 
+# Pass `--no-delta` to `deno upgrade` to skip delta patches and download the full
+# binary instead. Useful on low-memory machines where applying a delta fails.
+# no_delta = false
+
 
 [viteplus]
 # Use sudo if the Vite+ directory isn't owned by the current user

--- a/src/config.rs
+++ b/src/config.rs
@@ -177,6 +177,7 @@ pub struct Skills {
 #[serde(deny_unknown_fields)]
 pub struct Deno {
     version: Option<String>,
+    no_delta: Option<bool>,
 }
 
 #[derive(Deserialize, Default, Debug, Merge)]
@@ -2025,6 +2026,14 @@ impl Config {
         self.config_file.deno.as_ref().and_then(|deno| deno.version.as_deref())
     }
 
+    pub fn deno_no_delta(&self) -> bool {
+        self.config_file
+            .deno
+            .as_ref()
+            .and_then(|deno| deno.no_delta)
+            .unwrap_or(false)
+    }
+
     #[cfg(target_os = "linux")]
     pub fn firmware_upgrade(&self) -> bool {
         self.config_file
@@ -2321,6 +2330,18 @@ mod test {
             config_file: ConfigFile::default(),
             allowed_steps: Vec::new(),
         }
+    }
+
+    #[test]
+    fn deno_no_delta_defaults_off_and_reads_config() {
+        assert!(!config().deno_no_delta(), "default should leave delta upgrades enabled");
+
+        let config_file: ConfigFile = toml::from_str("[deno]\nno_delta = true\n").unwrap();
+        let cfg = Config {
+            config_file,
+            ..config()
+        };
+        assert!(cfg.deno_no_delta());
     }
 
     #[test]

--- a/src/steps/node.rs
+++ b/src/steps/node.rs
@@ -234,6 +234,13 @@ impl Deno {
             }
         }
 
+        // Delta upgrades download a small patch, but building the new binary from it needs
+        // enough memory to hold the whole thing. On low-RAM machines that allocation fails,
+        // so `--no-delta` lets those users fall back to a full download.
+        if ctx.config().deno_no_delta() {
+            args.push("--no-delta");
+        }
+
         ctx.execute(&self.command).arg("upgrade").args(args).status_checked()?;
         Ok(())
     }


### PR DESCRIPTION
Closes #2083.

On low-memory boxes `deno upgrade` can OOM while applying a delta patch. The linked issue has a 1 GB VPS where the delta step tries a 2 GB allocation and aborts. Deno already ships a `--no-delta` flag that skips the patch and just downloads the full binary, so this exposes it as a `no_delta` option under `[deno]` and passes it through when set. It defaults to false, so current behavior is unchanged unless you opt in.

To test it from a side branch, put

```toml
[deno]
no_delta = true
```

in your config and run the Deno step. The upgrade should pull the full binary instead of attempting a delta.