### PR TITLE
fix(shelly): fix upgrade command

### DIFF
--- a/src/steps/os/archlinux.rs
+++ b/src/steps/os/archlinux.rs
@@ -298,7 +298,7 @@ impl ArchPackageManager for Shelly {
             .status_checked()?;
 
         ctx.execute(&self.executable)
-            .arg("upgrade-all")
+            .args(["upgrade", "all"])
             .args(ctx.config().shelly_arguments().split_whitespace())
             .arg_if(ctx.config().should_run(Step::Flatpak), "--no-flatpak")
             .arg_if(ctx.config().yes(Step::System), "--no-confirm")


### PR DESCRIPTION
## What does this PR do

Fixes the bug with Shelly as the package manager where “upgrade-all --no-flatpak” is used instead of “upgrade all --no-flatpak,” as reported in issue #2276


## Standards checklist

- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* The PR title is a descriptive commit message (this will appear in release notes, leave unchecked if you want a maintainer to improve it)
- [x] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.

<img width="1276" height="872" alt="grafik" src="https://github.com/user-attachments/assets/a67cc0a6-8115-4d3c-91c0-4a0e1788d965" />


- [ ] If this PR introduces new user-facing messages they are translated

### AI involvement

No AI is involved in this commit.

## Misc

Closes: #2276 



<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
