### PR TITLE
fix(claude): skip plugins without a configured marketplace

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -2549,6 +2549,16 @@ pub fn run_claude_code_plugins(ctx: &ExecutionContext) -> Result<()> {
 
     let mut success = true;
     for plugin in &plugins {
+        // A plugin loaded straight from `~/.claude/skills/` has no marketplace behind it,
+        // so `claude plugin update` refuses it and nothing can be updated anyway.
+        if plugin.id.ends_with("@skills-dir") {
+            debug!(
+                "Skipping plugin {}: loaded from ~/.claude/skills, no marketplace",
+                plugin.id
+            );
+            continue;
+        }
+
         let mut cmd = ctx.execute(&claude);
         cmd.args(["plugin", "update", &plugin.id, "--scope", &plugin.scope]);
 

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -8,7 +8,7 @@ use regex::bytes::Regex;
 use rust_i18n::t;
 use semver::Version;
 use serde::Deserialize;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::env;
 use std::ffi::{OsStr, OsString};
 #[cfg(unix)]
@@ -2528,6 +2528,11 @@ pub fn run_claude_code_plugins(ctx: &ExecutionContext) -> Result<()> {
         project_path: Option<PathBuf>,
     }
 
+    #[derive(Deserialize)]
+    struct ClaudeMarketplace {
+        name: String,
+    }
+
     let claude = require("claude")?;
 
     print_separator("Claude Code Plugins");
@@ -2535,6 +2540,18 @@ pub fn run_claude_code_plugins(ctx: &ExecutionContext) -> Result<()> {
     ctx.execute(&claude)
         .args(["plugin", "marketplace", "update"])
         .status_checked()?;
+
+    let output = ctx
+        .execute(&claude)
+        .args(["plugin", "marketplace", "list", "--json"])
+        .output_checked_utf8()?;
+    let marketplaces: Vec<ClaudeMarketplace> = serde_json::from_str(&output.stdout).wrap_err_with(|| {
+        output_changed_message!(
+            "claude plugin marketplace list --json",
+            "json output is invalid or does not match expected structure"
+        )
+    })?;
+    let marketplaces: HashSet<&str> = marketplaces.iter().map(|m| m.name.as_str()).collect();
 
     let output = ctx
         .execute(&claude)
@@ -2549,13 +2566,12 @@ pub fn run_claude_code_plugins(ctx: &ExecutionContext) -> Result<()> {
 
     let mut success = true;
     for plugin in &plugins {
-        // A plugin loaded straight from `~/.claude/skills/` has no marketplace behind it,
-        // so `claude plugin update` refuses it and nothing can be updated anyway.
-        if plugin.id.ends_with("@skills-dir") {
-            debug!(
-                "Skipping plugin {}: loaded from ~/.claude/skills, no marketplace",
-                plugin.id
-            );
+        // Plugin ids are `<name>@<marketplace>`. A plugin whose marketplace is not configured
+        // (e.g. one loaded straight from `~/.claude/skills/`, reported as `@skills-dir`) has
+        // nothing to pull from, so `claude plugin update` refuses it.
+        let marketplace = plugin.id.rsplit_once('@').map(|(_, marketplace)| marketplace);
+        if !marketplace.is_some_and(|m| marketplaces.contains(m)) {
+            debug!("Skipping plugin {}: no configured marketplace behind it", plugin.id);
             continue;
         }
 

--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -2551,7 +2551,7 @@ pub fn run_claude_code_plugins(ctx: &ExecutionContext) -> Result<()> {
             "json output is invalid or does not match expected structure"
         )
     })?;
-    let marketplaces: HashSet<&str> = marketplaces.iter().map(|m| m.name.as_str()).collect();
+    let marketplaces: HashSet<String> = marketplaces.into_iter().map(|m| m.name).collect();
 
     let output = ctx
         .execute(&claude)


### PR DESCRIPTION
## What does this PR do
The current "Claude Code Plugins" step fails on any plugin loaded from `~/.claude/skills/` or `<cwd>/.claude/skills/`, which `claude plugin list --json` reports with the id suffix `@skills-dir`. This PR skips those plugins, since [Claude Code itself](https://code.claude.com/docs/en/plugins-reference#skills-directory-plugins) says they cannot be updated and edits there take effect after a reload.

## Standards checklist

- [X] I have read `CONTRIBUTING.md`
- [X] *Optional:* The PR title is a descriptive commit message (this will appear in release notes, leave unchecked if you want a maintainer to improve it)
- [X] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.

```
Before, with topgrade 17.9.0:

Checking for updates for plugin "tinymist-lsp@skills-dir" at user scope…
✘ Failed to update plugin "tinymist-lsp@skills-dir": This plugin is loaded from ~/.claude/skills/ with no marketplace backing — it cannot be updated. Delete the directory to remove it; `claude plugin disable` to turn it off; edits there take effect after /reload-plugins.
ERROR Updating plugin tinymist-lsp@skills-dir failed: Command failed: `/Users/johannes/.local/bin/claude plugin update tinymist-lsp@skills-dir --scope user`
―― 13:32:20 - Summary ――
Claude Code Plugins: FAILED

After, with this branch and -v:

DEBUG Skipping plugin tinymist-lsp@skills-dir: loaded from ~/.claude/skills, no marketplace
―― 14:24:52 - Summary ――
Claude Code Plugins: OK
```
- [ ] If this PR introduces new user-facing messages they are translated

### AI involvement
AI found the cause and drafted the patch. I reviewed and tested it, and wrote this description.

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
