### PR TITLE
feat(mise): add `assume_yes` support for `mise self-update`

### DIFF
--- a/src/steps/generic.rs
+++ b/src/steps/generic.rs
@@ -2820,6 +2820,7 @@ pub fn run_mise(ctx: &ExecutionContext) -> Result<()> {
         .execute(&mise)
         .current_dir(temp_dir.path())
         .args(["self-update"])
+        .arg_if(ctx.config().yes(Step::Mise), "--yes")
         .output_checked_with(|_| Ok(()))?;
     let status_code = output
         .status


### PR DESCRIPTION
## What does this PR do

mise's `self-update` will sometimes expect you to confirm:

```
▶ mise self-update -f
Checking target-arch... mise-v2026.9.3-macos-arm64.tar.gz
Checking current version... v2026.9.3
Looking for tag: v2026.9.3

mise release status:
  * Current exe: /Users/luiz/.local/bin/mise
  * New exe release: "mise-v2026.9.3-macos-arm64.tar.gz"
  * New exe download url: "https://api.github.com/repos/jdx/mise/releases/assets/550138907"

The new release will be downloaded/extracted and the existing binary will be replaced.
Do you want to continue? [Y/n]
```

when that happens, the step fails and it needs to be updated manually

This PR updates the mise step to pass `--yes` when assume_yes is set to true

## Standards checklist

- [X] I have read `CONTRIBUTING.md`
- [X] *Optional:* The PR title is a descriptive commit message (this will appear in release notes, leave unchecked if you want a maintainer to improve it)
- [ ] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [ ] If this PR introduces new user-facing messages, they are translated

### AI involvement

Searched for established repository patterns before changing the code

## For new steps

<!-- This section can be deleted if you are not adding a new step. -->

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--yes` option works with this step if it is supported by the underlying command

<!-- If you developed a feature or a bug fix for someone else and you do not have the means to test it, please tag this person here. -->

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
