### PR TITLE
feat(pkg): make non-interactive when `assume_yes`

### DIFF
--- a/src/steps/os/openbsd.rs
+++ b/src/steps/os/openbsd.rs
@@ -37,11 +37,13 @@ pub fn upgrade_packages(ctx: &ExecutionContext) -> Result<()> {
     let is_current = is_openbsd_current()?;
 
     if ctx.config().cleanup() {
-        sudo.execute(ctx, "/usr/sbin/pkg_delete")?.arg("-ac").status_checked()?;
+        sudo.execute(ctx, "/usr/sbin/pkg_delete")?
+            .arg("-acI")
+            .status_checked()?;
     }
 
     sudo.execute(ctx, "/usr/sbin/pkg_add")?
-        .arg("-u")
+        .arg("-uI")
         .arg_if(is_current, "-Dsnap")
         .status_checked()
 }

--- a/src/steps/os/openbsd.rs
+++ b/src/steps/os/openbsd.rs
@@ -1,5 +1,6 @@
 use crate::command::CommandExt;
 use crate::execution_context::ExecutionContext;
+use crate::step::Step;
 use crate::terminal::print_separator;
 use color_eyre::eyre::Result;
 use rust_i18n::t;
@@ -38,12 +39,14 @@ pub fn upgrade_packages(ctx: &ExecutionContext) -> Result<()> {
 
     if ctx.config().cleanup() {
         sudo.execute(ctx, "/usr/sbin/pkg_delete")?
-            .arg("-acI")
+            .arg("-ac")
+            .arg_if(ctx.config().yes(Step::Pkg), "-I")
             .status_checked()?;
     }
 
     sudo.execute(ctx, "/usr/sbin/pkg_add")?
-        .arg("-uI")
+        .arg("-u")
+        .arg_if(ctx.config().yes(Step::Pkg), "-I")
         .arg_if(is_current, "-Dsnap")
         .status_checked()
 }


### PR DESCRIPTION
## What does this PR do

Make OpenBSD step `pkg_add(1)`/`pkg_delete(1)` non-interactive

To do this, add `-I` to arguments when calling these commands as to not block execution.

### Reasoning:

This differs from an "assume yes" setting, as these are more for package merging issues that may come up with long `pkg_add -u` and `pkg_delete -ac` runs.

With the `-I` flag, conflicts won't block execution and will follow sane defaults as defined in the quirks package rules. This option is idiosyncratic to current best practices in mass upgrade utilities/scripts.

### Personal Motivation:

When I ran a recent topgrade on my OpenBSD fleet, and walked away expecting execution to continue, I came back to the package steps blocking execution.

## Standards checklist

- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* The PR title is a descriptive commit message (this will appear in release notes, leave unchecked if you want a maintainer to improve it)
- [x] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.

```
~ $ topgrade --only pkg      

── 14:14:09 - Sudo ─────────────────────────────────────────────────────────────

── 14:14:10 - OpenBSD Packages ─────────────────────────────────────────────────
quirks-7.218 signed on 2026-09-10T22:09:37Z
Couldn't find updates for msttcorefonts-2.0p5 oneko-sakura-1.2 openbsd-utils-1.3.1

── 14:14:40 - Summary ──────────────────────────────────────────────────────────
OpenBSD Packages: IGNORED
```

Note: those errors are due to ports not being packaged in binary packages for various reasons:
- Licensing
- WIP ports not contributed to the ports tree yet

The errors are not due to the changes in this PR.

- [ ] If this PR introduces new user-facing messages they are translated

### AI involvement

I did not use AI/LLM technology at all.

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
