### PR TITLE
fix: ignore .DS_Store files when parsing configuration files

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -720,7 +720,10 @@ impl ConfigFile {
             let entry_path = entry?.path();
 
             if entry_path.is_file() {
-                let file_name = entry_path.file_name().expect("`fs::read_dir` does not return paths ending in `..`").to_string_lossy();
+                let file_name = entry_path
+                    .file_name()
+                    .expect("`fs::read_dir` does not return paths ending in `..`")
+                    .to_string_lossy();
                 if file_name.eq_ignore_ascii_case(".DS_Store") {
                     debug!("Skipping .DS_Store file at {}", entry_path.display());
                     continue;

--- a/src/config.rs
+++ b/src/config.rs
@@ -720,6 +720,11 @@ impl ConfigFile {
             let entry_path = entry?.path();
 
             if entry_path.is_file() {
+                let file_name = entry_path.file_name().unwrap_or_default().to_string_lossy();
+                if file_name.eq_ignore_ascii_case(".DS_Store") {
+                    debug!("Skipping .DS_Store file at {}", entry_path.display());
+                    continue;
+                }
                 debug!(
                     "Found additional (directory) configuration file at {}",
                     entry_path.display()

--- a/src/config.rs
+++ b/src/config.rs
@@ -720,7 +720,7 @@ impl ConfigFile {
             let entry_path = entry?.path();
 
             if entry_path.is_file() {
-                let file_name = entry_path.file_name().unwrap_or_default().to_string_lossy();
+                let file_name = entry_path.file_name().expect("`fs::read_dir` does not return paths ending in `..`").to_string_lossy();
                 if file_name.eq_ignore_ascii_case(".DS_Store") {
                     debug!("Skipping .DS_Store file at {}", entry_path.display());
                     continue;


### PR DESCRIPTION
## What does this PR do
If there's a `DS_Store` file in any of the config dirs, ignore them. Closes #2325 

```
❱ target/debug/topgrade -v
DEBUG Current system locale is en-CA
DEBUG Configuration at /Users/markjarjour/.config/topgrade.toml
DEBUG Skipping .DS_Store file at /Users/markjarjour/.config/topgrade.d/.DS_Store
```

## Standards checklist

- [x] I have read `CONTRIBUTING.md`
- [x] *Optional:* The PR title is a descriptive commit message (this will appear in release notes, leave unchecked if you want a maintainer to improve it)
- [x] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [ ] If this PR introduces new user-facing messages they are translated

### AI involvement
AI generated the majority of the PR. Code was run manually to check that it works.

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
